### PR TITLE
feat(tls): make Mbed TLS dependency opt-in via -d vanilla_tls

### DIFF
--- a/http_server/tls/tls.v
+++ b/http_server/tls/tls.v
@@ -1,31 +1,19 @@
 module tls
 
-// V bindings over the vanilla_tls C shim (Mbed TLS 4, TLS 1.3). The gnarly
-// Mbed TLS macros/structs live in vanilla_tls.c; here we expose a small, clean
-// V API: a server-wide Config (cert + key + ssl conf) and per-connection
-// Sessions driven by the non-blocking epoll loop.
-
-#flag -I@VMODROOT/http_server/tls
-#flag -I/usr/local/include
-#flag -L/usr/local/lib -lmbedtls -lmbedx509 -lmbedcrypto
-#flag @VMODROOT/http_server/tls/vanilla_tls.c
-
-#include "vanilla_tls.h"
-
-fn C.vtls_global_init() int
-fn C.vtls_ctx_new() voidptr
-fn C.vtls_ctx_free(ctx voidptr)
-fn C.vtls_use_self_signed(ctx voidptr) int
-fn C.vtls_use_pem(ctx voidptr, cert &u8, clen usize, key &u8, klen usize) int
-fn C.vtls_setup(ctx voidptr) int
-fn C.vtls_set_alpn(ctx voidptr, list &char) int
-fn C.vtls_cert_pem(ctx voidptr) &char
-fn C.vtls_get_alpn(sess voidptr) &char
-fn C.vtls_session_new(ctx voidptr, fd int) voidptr
-fn C.vtls_session_free(sess voidptr)
-fn C.vtls_handshake(sess voidptr) int
-fn C.vtls_read(sess voidptr, buf &u8, len usize) int
-fn C.vtls_write(sess voidptr, buf &u8, len usize) int
+// Public TLS surface (types + status codes) shared by both builds.
+//
+// The Mbed TLS 4 implementation is heavy (links libmbedtls/x509/crypto and
+// compiles vanilla_tls.c), so it is opt-in: it only compiles when the program
+// is built with `-d vanilla_tls`. Without that flag a thin stub is compiled
+// instead, so a plain-HTTP server (and the benchmark entry) builds with no
+// Mbed TLS dependency at all.
+//
+//   real impl  -> tls_mbedtls_d_vanilla_tls.c.v   (built with `-d vanilla_tls`)
+//   stub       -> tls_stub_notd_vanilla_tls.c.v   (built by default)
+//
+// The types and constants below are identical in both builds, so the rest of
+// http_server (worker dispatch, the TLS connection state machine) type-checks
+// and compiles regardless; only the C-backed bodies differ.
 
 // Handshake/read/write status (mirrors the C shim). Negative so they never
 // collide with a byte count from read/write.
@@ -44,137 +32,7 @@ pub struct Config {
 	ctx voidptr
 }
 
-// init performs process-wide crypto init (psa_crypto_init). Call once at startup.
-pub fn init() ! {
-	if C.vtls_global_init() != 0 {
-		return error('vtls: psa_crypto_init failed')
-	}
-}
-
-// new_self_signed builds a config with a freshly generated self-signed cert
-// (EC P-256, TLS 1.3) — handy for dev/testing without a real certificate.
-pub fn new_self_signed() !&Config {
-	init()! // psa_crypto_init is idempotent
-	ctx := C.vtls_ctx_new()
-	if ctx == unsafe { nil } {
-		return error('vtls: out of memory')
-	}
-	if C.vtls_use_self_signed(ctx) != 0 {
-		C.vtls_ctx_free(ctx)
-		return error('vtls: self-signed certificate generation failed')
-	}
-	if C.vtls_setup(ctx) != 0 {
-		C.vtls_ctx_free(ctx)
-		return error('vtls: ssl config setup failed')
-	}
-	if C.vtls_set_alpn(ctx, &char(default_alpn.str)) != 0 {
-		C.vtls_ctx_free(ctx)
-		return error('vtls: failed to set ALPN')
-	}
-	return &Config{
-		ctx: ctx
-	}
-}
-
-// new_from_pem builds a config from PEM-encoded certificate and private key.
-pub fn new_from_pem(cert []u8, key []u8) !&Config {
-	init()!
-	ctx := C.vtls_ctx_new()
-	if ctx == unsafe { nil } {
-		return error('vtls: out of memory')
-	}
-	// Mbed TLS detects PEM (vs DER) by a trailing NUL, and the length passed MUST
-	// include it. os.read_bytes() doesn't NUL-terminate, so ensure it here.
-	mut c := cert.clone()
-	if c.len == 0 || c[c.len - 1] != 0 {
-		c << 0
-	}
-	mut k := key.clone()
-	if k.len == 0 || k[k.len - 1] != 0 {
-		k << 0
-	}
-	if C.vtls_use_pem(ctx, c.data, usize(c.len), k.data, usize(k.len)) != 0 {
-		C.vtls_ctx_free(ctx)
-		return error('vtls: failed to parse PEM cert/key')
-	}
-	if C.vtls_setup(ctx) != 0 {
-		C.vtls_ctx_free(ctx)
-		return error('vtls: ssl config setup failed')
-	}
-	if C.vtls_set_alpn(ctx, &char(default_alpn.str)) != 0 {
-		C.vtls_ctx_free(ctx)
-		return error('vtls: failed to set ALPN')
-	}
-	return &Config{
-		ctx: ctx
-	}
-}
-
-// set_alpn overrides the advertised ALPN list (comma-separated, preference
-// order — e.g. 'h2,http/1.1'). Defaults to `http/1.1`. Only advertise protocols
-// the server can actually serve. Call before accepting connections.
-pub fn (c &Config) set_alpn(protos string) ! {
-	if C.vtls_set_alpn(c.ctx, &char(protos.str)) != 0 {
-		return error('vtls: failed to set ALPN to "${protos}"')
-	}
-}
-
-// cert_pem returns the certificate as PEM (e.g. to save so a client can trust a
-// self-signed cert: `curl --cacert server.pem`).
-pub fn (c &Config) cert_pem() string {
-	p := C.vtls_cert_pem(c.ctx)
-	if p == unsafe { nil } {
-		return ''
-	}
-	return unsafe { cstring_to_vstring(p) }
-}
-
-pub fn (c &Config) free() {
-	C.vtls_ctx_free(c.ctx)
-}
-
 // Session is a per-connection TLS session bound to an accepted, non-blocking fd.
 pub struct Session {
 	sess voidptr
-}
-
-pub fn (c &Config) new_session(fd int) ?Session {
-	s := C.vtls_session_new(c.ctx, fd)
-	if s == unsafe { nil } {
-		return none
-	}
-	return Session{
-		sess: s
-	}
-}
-
-// handshake drives the TLS handshake. Returns 0 (done), `want` (retry), or `closed`.
-pub fn (s &Session) handshake() int {
-	return C.vtls_handshake(s.sess)
-}
-
-// read_into decrypts up to `len` bytes into `ptr`. Returns >=0 bytes, `want`,
-// or `closed`. Raw pointer so the read loop can fill a buffer's spare capacity.
-pub fn (s &Session) read_into(ptr &u8, len int) int {
-	return C.vtls_read(s.sess, ptr, usize(len))
-}
-
-// write_from encrypts `len` bytes from `ptr`. Returns bytes written (>=0),
-// `want`, or `closed`.
-pub fn (s &Session) write_from(ptr &u8, len int) int {
-	return C.vtls_write(s.sess, ptr, usize(len))
-}
-
-// alpn returns the protocol negotiated via ALPN (e.g. 'http/1.1'), or '' if the
-// client offered none. Meaningful only after the handshake completes.
-pub fn (s &Session) alpn() string {
-	p := C.vtls_get_alpn(s.sess)
-	if p == unsafe { nil } {
-		return ''
-	}
-	return unsafe { cstring_to_vstring(p) }
-}
-
-pub fn (s &Session) free() {
-	C.vtls_session_free(s.sess)
 }

--- a/http_server/tls/tls_mbedtls_d_vanilla_tls.c.v
+++ b/http_server/tls/tls_mbedtls_d_vanilla_tls.c.v
@@ -1,0 +1,159 @@
+module tls
+
+// Real TLS implementation backed by the vanilla_tls C shim (Mbed TLS 4,
+// TLS 1.3). Compiled only with `-d vanilla_tls`; otherwise the stubs in
+// tls_stub_notd_vanilla_tls.c.v are used and Mbed TLS is not a dependency.
+// The gnarly Mbed TLS macros/structs live in vanilla_tls.c; here we expose the
+// small, clean V API declared (as types) in tls.v.
+
+#flag -I@VMODROOT/http_server/tls
+#flag -I/usr/local/include
+#flag -L/usr/local/lib -lmbedtls -lmbedx509 -lmbedcrypto
+#flag @VMODROOT/http_server/tls/vanilla_tls.c
+
+#include "vanilla_tls.h"
+
+fn C.vtls_global_init() int
+fn C.vtls_ctx_new() voidptr
+fn C.vtls_ctx_free(ctx voidptr)
+fn C.vtls_use_self_signed(ctx voidptr) int
+fn C.vtls_use_pem(ctx voidptr, cert &u8, clen usize, key &u8, klen usize) int
+fn C.vtls_setup(ctx voidptr) int
+fn C.vtls_set_alpn(ctx voidptr, list &char) int
+fn C.vtls_cert_pem(ctx voidptr) &char
+fn C.vtls_get_alpn(sess voidptr) &char
+fn C.vtls_session_new(ctx voidptr, fd int) voidptr
+fn C.vtls_session_free(sess voidptr)
+fn C.vtls_handshake(sess voidptr) int
+fn C.vtls_read(sess voidptr, buf &u8, len usize) int
+fn C.vtls_write(sess voidptr, buf &u8, len usize) int
+
+// init performs process-wide crypto init (psa_crypto_init). Call once at startup.
+pub fn init() ! {
+	if C.vtls_global_init() != 0 {
+		return error('vtls: psa_crypto_init failed')
+	}
+}
+
+// new_self_signed builds a config with a freshly generated self-signed cert
+// (EC P-256, TLS 1.3) — handy for dev/testing without a real certificate.
+pub fn new_self_signed() !&Config {
+	init()! // psa_crypto_init is idempotent
+	ctx := C.vtls_ctx_new()
+	if ctx == unsafe { nil } {
+		return error('vtls: out of memory')
+	}
+	if C.vtls_use_self_signed(ctx) != 0 {
+		C.vtls_ctx_free(ctx)
+		return error('vtls: self-signed certificate generation failed')
+	}
+	if C.vtls_setup(ctx) != 0 {
+		C.vtls_ctx_free(ctx)
+		return error('vtls: ssl config setup failed')
+	}
+	if C.vtls_set_alpn(ctx, &char(default_alpn.str)) != 0 {
+		C.vtls_ctx_free(ctx)
+		return error('vtls: failed to set ALPN')
+	}
+	return &Config{
+		ctx: ctx
+	}
+}
+
+// new_from_pem builds a config from PEM-encoded certificate and private key.
+pub fn new_from_pem(cert []u8, key []u8) !&Config {
+	init()!
+	ctx := C.vtls_ctx_new()
+	if ctx == unsafe { nil } {
+		return error('vtls: out of memory')
+	}
+	// Mbed TLS detects PEM (vs DER) by a trailing NUL, and the length passed MUST
+	// include it. os.read_bytes() doesn't NUL-terminate, so ensure it here.
+	mut c := cert.clone()
+	if c.len == 0 || c[c.len - 1] != 0 {
+		c << 0
+	}
+	mut k := key.clone()
+	if k.len == 0 || k[k.len - 1] != 0 {
+		k << 0
+	}
+	if C.vtls_use_pem(ctx, c.data, usize(c.len), k.data, usize(k.len)) != 0 {
+		C.vtls_ctx_free(ctx)
+		return error('vtls: failed to parse PEM cert/key')
+	}
+	if C.vtls_setup(ctx) != 0 {
+		C.vtls_ctx_free(ctx)
+		return error('vtls: ssl config setup failed')
+	}
+	if C.vtls_set_alpn(ctx, &char(default_alpn.str)) != 0 {
+		C.vtls_ctx_free(ctx)
+		return error('vtls: failed to set ALPN')
+	}
+	return &Config{
+		ctx: ctx
+	}
+}
+
+// set_alpn overrides the advertised ALPN list (comma-separated, preference
+// order — e.g. 'h2,http/1.1'). Defaults to `http/1.1`. Only advertise protocols
+// the server can actually serve. Call before accepting connections.
+pub fn (c &Config) set_alpn(protos string) ! {
+	if C.vtls_set_alpn(c.ctx, &char(protos.str)) != 0 {
+		return error('vtls: failed to set ALPN to "${protos}"')
+	}
+}
+
+// cert_pem returns the certificate as PEM (e.g. to save so a client can trust a
+// self-signed cert: `curl --cacert server.pem`).
+pub fn (c &Config) cert_pem() string {
+	p := C.vtls_cert_pem(c.ctx)
+	if p == unsafe { nil } {
+		return ''
+	}
+	return unsafe { cstring_to_vstring(p) }
+}
+
+pub fn (c &Config) free() {
+	C.vtls_ctx_free(c.ctx)
+}
+
+pub fn (c &Config) new_session(fd int) ?Session {
+	s := C.vtls_session_new(c.ctx, fd)
+	if s == unsafe { nil } {
+		return none
+	}
+	return Session{
+		sess: s
+	}
+}
+
+// handshake drives the TLS handshake. Returns 0 (done), `want` (retry), or `closed`.
+pub fn (s &Session) handshake() int {
+	return C.vtls_handshake(s.sess)
+}
+
+// read_into decrypts up to `len` bytes into `ptr`. Returns >=0 bytes, `want`,
+// or `closed`. Raw pointer so the read loop can fill a buffer's spare capacity.
+pub fn (s &Session) read_into(ptr &u8, len int) int {
+	return C.vtls_read(s.sess, ptr, usize(len))
+}
+
+// write_from encrypts `len` bytes from `ptr`. Returns bytes written (>=0),
+// `want`, or `closed`.
+pub fn (s &Session) write_from(ptr &u8, len int) int {
+	return C.vtls_write(s.sess, ptr, usize(len))
+}
+
+// alpn returns the protocol negotiated via ALPN (e.g. 'http/1.1'), or '' if the
+// client offered none. Meaningful only after the handshake completes.
+pub fn (s &Session) alpn() string {
+	p := C.vtls_get_alpn(s.sess)
+	if p == unsafe { nil } {
+		return ''
+	}
+	return unsafe { cstring_to_vstring(p) }
+}
+
+pub fn (s &Session) free() {
+	C.vtls_session_free(s.sess)
+}

--- a/http_server/tls/tls_stub_notd_vanilla_tls.c.v
+++ b/http_server/tls/tls_stub_notd_vanilla_tls.c.v
@@ -1,0 +1,53 @@
+module tls
+
+// TLS stubs compiled by default (i.e. without `-d vanilla_tls`). They keep the
+// public API present so the rest of http_server type-checks and links with no
+// Mbed TLS dependency, while making any attempt to actually use TLS fail
+// loudly. To get a working TLS server, rebuild with `-d vanilla_tls` (which
+// swaps in tls_mbedtls_d_vanilla_tls.c.v and links Mbed TLS).
+
+const not_built = 'vtls: built without TLS support — rebuild with `-d vanilla_tls` (and install Mbed TLS 4)'
+
+pub fn init() ! {
+	return error(not_built)
+}
+
+pub fn new_self_signed() !&Config {
+	return error(not_built)
+}
+
+pub fn new_from_pem(cert []u8, key []u8) !&Config {
+	return error(not_built)
+}
+
+pub fn (c &Config) set_alpn(protos string) ! {
+	return error(not_built)
+}
+
+pub fn (c &Config) cert_pem() string {
+	return ''
+}
+
+pub fn (c &Config) free() {}
+
+pub fn (c &Config) new_session(fd int) ?Session {
+	return none
+}
+
+pub fn (s &Session) handshake() int {
+	return closed
+}
+
+pub fn (s &Session) read_into(ptr &u8, len int) int {
+	return closed
+}
+
+pub fn (s &Session) write_from(ptr &u8, len int) int {
+	return closed
+}
+
+pub fn (s &Session) alpn() string {
+	return ''
+}
+
+pub fn (s &Session) free() {}

--- a/http_server/tls/tls_test.v
+++ b/http_server/tls/tls_test.v
@@ -1,22 +1,30 @@
 module tls
 
+// These exercise the real Mbed TLS-backed implementation, so they only do
+// anything under `-d vanilla_tls`. In the default (stub) build they compile and
+// pass trivially, keeping `v test` green without an Mbed TLS dependency.
+
 fn test_self_signed_generation() {
-	init() or { panic('init: ${err}') }
-	cfg := new_self_signed() or { panic('gen: ${err}') }
-	pem := cfg.cert_pem()
-	assert pem.starts_with('-----BEGIN CERTIFICATE-----')
-	assert pem.contains('-----END CERTIFICATE-----')
-	assert pem.len > 200
-	cfg.free()
+	$if vanilla_tls ? {
+		init() or { panic('init: ${err}') }
+		cfg := new_self_signed() or { panic('gen: ${err}') }
+		pem := cfg.cert_pem()
+		assert pem.starts_with('-----BEGIN CERTIFICATE-----')
+		assert pem.contains('-----END CERTIFICATE-----')
+		assert pem.len > 200
+		cfg.free()
+	}
 }
 
 // ALPN is configurable (default http/1.1) and overridable. Negotiation itself
 // happens during the handshake; this just exercises the config path doesn't err.
 fn test_alpn_config() {
-	init() or { panic('init: ${err}') }
-	cfg := new_self_signed() or { panic('gen: ${err}') }
-	// Default is applied by the constructor; an explicit override must also work.
-	cfg.set_alpn('h2,http/1.1') or { panic('set_alpn list: ${err}') }
-	cfg.set_alpn('http/1.1') or { panic('set_alpn single: ${err}') }
-	cfg.free()
+	$if vanilla_tls ? {
+		init() or { panic('init: ${err}') }
+		cfg := new_self_signed() or { panic('gen: ${err}') }
+		// Default is applied by the constructor; an explicit override must also work.
+		cfg.set_alpn('h2,http/1.1') or { panic('set_alpn list: ${err}') }
+		cfg.set_alpn('http/1.1') or { panic('set_alpn single: ${err}') }
+		cfg.free()
+	}
 }


### PR DESCRIPTION
## Problem

`http_server` unconditionally `import`s the `tls` module, and `tls` compiled `vanilla_tls.c` and linked `-lmbedtls -lmbedx509 -lmbedcrypto` from `/usr/local`. That forced an **Mbed TLS 4 dependency on every consumer** — even a plain-HTTP server that never touches TLS.

This broke builds on any host without Mbed TLS, including the [the-benchmarker/web-frameworks](https://github.com/the-benchmarker/web-frameworks) CI image:

```
cc: /root/.vmodules/vanilla/http_server/tls/vanilla_tls.c:7:10: fatal error: mbedtls/ssl.h: No such file or directory
```

## Change

Split the `tls` module so the heavy C glue is **opt-in** behind `-d vanilla_tls`, using V's conditional-file compilation:

| file | compiled when | contents |
|---|---|---|
| `tls.v` | always | public types + status codes (`Config`, `Session`, `want`/`want_write`/`closed`, `default_alpn`) |
| `tls_mbedtls_d_vanilla_tls.c.v` | `-d vanilla_tls` | real Mbed TLS impl + `#flag`/`#include`/`fn C.*` |
| `tls_stub_notd_vanilla_tls.c.v` | default | API-compatible stubs (no Mbed TLS): `init`/`new_*` → error, `handshake`/`read`/`write` → `closed` |

The rest of `http_server` (worker dispatch, the TLS connection state machine) only uses the V-level API, so it type-checks and links in both builds with no other files touched. `tls_test.v` guards its assertions behind `$if vanilla_tls ?` so `v test` stays green without Mbed TLS.

## Verification

- `v test http_server/tls/` — passes (stub) and with `-d vanilla_tls` (real).
- `v -prod` (default): built in a **clean Debian container with no `/usr/local` Mbed TLS** and ran the HTTP endpoints — links zero Mbed TLS.
- `v -prod -d vanilla_tls`: still builds the full TLS server.

## How to use TLS after this

Build with `-d vanilla_tls` (and Mbed TLS 4 installed), e.g.:

```sh
v -prod -d vanilla_tls examples/tls -o server
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)