### PR TITLE
feat(limits): configurable max_request_bytes (lift fixed 8 MiB request cap)

### DIFF
--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -86,7 +86,8 @@ fn handle_readable_plain(request_handler fn ([]u8, int) ![]u8, epoll_fd int, fd 
 			return
 		}
 		unsafe { buf.len += n }
-		if buf.len > sm_max_request_bytes {
+		req_cap := if limits.max_request_bytes > 0 { limits.max_request_bytes } else { sm_max_request_bytes }
+		if buf.len > req_cap {
 			unsafe { buf.free() }
 			response.send_status_413_response(fd)
 			close_conn(epoll_fd, fd, active_conns, mut conns)

--- a/http_server/backend_epoll/tls_conn_linux.c.v
+++ b/http_server/backend_epoll/tls_conn_linux.c.v
@@ -140,7 +140,8 @@ fn handle_readable_fd_tls(request_handler fn ([]u8, int) ![]u8, epoll_fd int, fd
 			return
 		}
 		unsafe { buf.len += n }
-		if buf.len > tls_max_request_bytes {
+		req_cap := if limits.max_request_bytes > 0 { limits.max_request_bytes } else { tls_max_request_bytes }
+		if buf.len > req_cap {
 			unsafe { buf.free() }
 			close_tls(epoll_fd, fd, active_conns, mut sessions)
 			return

--- a/http_server/core/core.v
+++ b/http_server/core/core.v
@@ -26,9 +26,10 @@ pub mut:
 // `http_server.Limits` for the ergonomic config API.
 pub struct Limits {
 pub:
-	max_header_bytes int // > 0 ⇒ 431 Request Header Fields Too Large
-	max_body_bytes   int // > 0 ⇒ 413 Payload Too Large (rejected from Content-Length, before buffering)
-	max_connections  int // > 0 ⇒ refuse new connections past this many concurrent (checked at accept)
-	read_timeout_ms  int // > 0 ⇒ close a connection that can't finish its request in this long (408)
-	write_timeout_ms int // > 0 ⇒ close a connection whose parked response can't drain in this long
+	max_header_bytes  int // > 0 ⇒ 431 Request Header Fields Too Large
+	max_body_bytes    int // > 0 ⇒ 413 Payload Too Large (rejected from Content-Length, before buffering)
+	max_request_bytes int // > 0 ⇒ ceiling on a single buffered request (headers+body); 0 ⇒ built-in default (8 MiB)
+	max_connections   int // > 0 ⇒ refuse new connections past this many concurrent (checked at accept)
+	read_timeout_ms   int // > 0 ⇒ close a connection that can't finish its request in this long (408)
+	write_timeout_ms  int // > 0 ⇒ close a connection whose parked response can't drain in this long
 }


### PR DESCRIPTION
## Problem

The buffered-request ceiling was a hardcoded **8 MiB** (`sm_max_request_bytes` in `conn_state_linux.c.v`, `tls_max_request_bytes` in `tls_conn_linux.c.v`). Any request whose accumulated bytes crossed 8 MiB was dropped (413 / close), regardless of `ServerConfig.limits` — so e.g. a 20 MiB upload could never succeed.

## Change

Add `Limits.max_request_bytes`:
- `> 0` overrides the ceiling on **both** the plaintext and TLS read paths.
- `0` keeps the built-in 8 MiB default → **existing behavior unchanged**.

```v
http_server.new_server(http_server.ServerConfig{
    port: 8080
    request_handler: handle
    limits: http_server.Limits{ max_request_bytes: 32 * 1024 * 1024 } // accept up to 32 MiB
})!
```

## Why

Needed for the HttpArena `upload` benchmark (20 MiB bodies). More generally, the request-size ceiling should be a policy knob, not a hardcoded constant.

Backward compatible (default unchanged). Compiles clean; the conditional is a single comparison on the hot path only when the cap would otherwise trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)