### PR TITLE
Raw handler contract + epoll pipelining with persistent buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@
 ```v
 import http_server
 
-fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
-  // ...parse request and return response...
+fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
+  // ...parse the request and APPEND the complete raw HTTP response
+  // (status line + headers + body) to `out`. The server owns `out`,
+  // reuses it across requests and batches pipelined responses into a
+  // single send — never free or keep it.
+  out << 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok'.bytes()
 }
 
 fn main() {
@@ -50,7 +54,9 @@ fn main() {
 ```v
 fn test_simple_without_init_the_server() {
   request := 'GET / HTTP/1.1\r\n\r\n'.bytes()
-  assert handle_request(request, -1)! == http_ok_response
+  mut out := []u8{}
+  handle_request(request, -1, mut out)!
+  assert out == http_ok_response
 }
 ```
 
@@ -110,8 +116,9 @@ v -prod run examples/database
 **Example handler:**
 
 ```v
-fn handle_request(req_buffer []u8, client_conn_fd int, mut pool ConnectionPool) ![]u8 {
-  // Use pool.acquire() and pool.release() for DB access
+fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8, mut pool ConnectionPool) ! {
+  // Use pool.acquire() and pool.release() for DB access;
+  // append the raw HTTP response to `out`.
 }
 ```
 

--- a/bench/e2e.c
+++ b/bench/e2e.c
@@ -1,0 +1,241 @@
+// e2e.c — end-to-end loopback HTTP benchmark of 3 response/buffer models.
+// gcc -O3 -march=native -pthread -o e2e e2e.c
+// ./e2e <mode> <pipeline_depth> <seconds>
+//   mode 1: persistent conn buffers, response raw-written into write buf,
+//           parse ALL pipelined reqs, ONE send per batch        (proposed)
+//   mode 2: persistent recv buf, malloc response per request,
+//           memcpy into write buf + free, ONE send per batch    (compat API)
+//   mode 3: fresh 256B grow recv buf per event, malloc response,
+//           one send PER response, free both                    (current vanilla)
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+#include <unistd.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
+#define PORT 9099
+#define MAXC 64
+static int MODE = 1, DEPTH = 16, SECS = 5;
+static volatile int stop_flag = 0;
+
+static const char REQ[] = "GET /pipeline HTTP/1.1\r\nHost: x\r\n\r\n";
+#define REQ_LEN (sizeof(REQ) - 1)
+static const char PREFIX[] = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ";
+#define PREFIX_LEN (sizeof(PREFIX) - 1)
+static const char BODY[] = "Hello, World!";
+#define BODY_LEN (sizeof(BODY) - 1)
+
+static inline int itoa10(char *dst, int v) {
+    char tmp[12]; int n = 0;
+    do { tmp[n++] = '0' + v % 10; v /= 10; } while (v);
+    for (int i = 0; i < n; i++) dst[i] = tmp[n - 1 - i];
+    return n;
+}
+
+// "handler": builds the response. mode 1 writes straight into out; modes 2/3
+// malloc, build, return (caller copies/sends + frees) — mirrors the V contract.
+static inline int build_into(uint8_t *p0) {
+    uint8_t *p = p0;
+    memcpy(p, PREFIX, PREFIX_LEN); p += PREFIX_LEN;
+    p += itoa10((char *)p, BODY_LEN);
+    memcpy(p, "\r\n\r\n", 4); p += 4;
+    memcpy(p, BODY, BODY_LEN); p += BODY_LEN;
+    return p - p0;
+}
+static uint8_t *handler_alloc(int *len) {
+    uint8_t *b = malloc(PREFIX_LEN + 16 + BODY_LEN);
+    *len = build_into(b);
+    return b;
+}
+
+typedef struct {
+    uint8_t rbuf[16384]; int rlen;       // persistent recv buffer (modes 1,2)
+    uint8_t wbuf[65536];                  // persistent write buffer (modes 1,2)
+} conn_t;
+static conn_t *conns[MAXC * 4];
+
+static int find_req_end(const uint8_t *b, int len) { // returns consumed or -1
+    for (int i = 3; i < len; i++)
+        if (b[i-3]=='\r' && b[i-2]=='\n' && b[i-1]=='\r' && b[i]=='\n') return i + 1;
+    return -1;
+}
+
+static void send_all(int fd, const uint8_t *b, int len) {
+    int off = 0;
+    while (off < len) {
+        int n = send(fd, b + off, len - off, MSG_NOSIGNAL);
+        if (n > 0) { off += n; continue; }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) continue; // spin (bench)
+        return;
+    }
+}
+
+static void *server_main(void *arg) {
+    (void)arg;
+    int lfd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    int one = 1;
+    setsockopt(lfd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof one);
+    struct sockaddr_in a = { .sin_family = AF_INET, .sin_port = htons(PORT),
+                             .sin_addr.s_addr = htonl(INADDR_LOOPBACK) };
+    bind(lfd, (void *)&a, sizeof a);
+    listen(lfd, 1024);
+
+    int ep = epoll_create1(0);
+    struct epoll_event ev = { .events = EPOLLIN, .data.fd = lfd };
+    epoll_ctl(ep, EPOLL_CTL_ADD, lfd, &ev);
+    struct epoll_event evs[512];
+
+    while (!stop_flag) {
+        int n = epoll_wait(ep, evs, 512, 100);
+        for (int i = 0; i < n; i++) {
+            int fd = evs[i].data.fd;
+            if (fd == lfd) {
+                int c;
+                while ((c = accept4(lfd, NULL, NULL, SOCK_NONBLOCK)) >= 0) {
+                    setsockopt(c, IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
+                    conns[c] = calloc(1, sizeof(conn_t));
+                    struct epoll_event e2 = { .events = EPOLLIN | EPOLLET, .data.fd = c };
+                    epoll_ctl(ep, EPOLL_CTL_ADD, c, &e2);
+                }
+                continue;
+            }
+            if (MODE == 3) {
+                // current vanilla: fresh growing buffer per EPOLLIN event;
+                // partial leftover saved per-fd across edges (save_read)
+                conn_t *sv = conns[fd];
+                size_t cap = 256, len = 0;
+                uint8_t *buf = malloc(cap);
+                if (sv->rlen > 0) {                 // resume saved partial
+                    while ((size_t)sv->rlen > cap) { cap *= 2; }
+                    buf = realloc(buf, cap);
+                    memcpy(buf, sv->rbuf, sv->rlen);
+                    len = sv->rlen; sv->rlen = 0;
+                }
+                int dead = 0;
+                for (;;) {
+                    if (len == cap) { cap *= 2; buf = realloc(buf, cap); }
+                    int r = recv(fd, buf + len, cap - len, 0);
+                    if (r > 0) { len += r; continue; }
+                    if (r == 0) dead = 1;
+                    break;             // EAGAIN or closed
+                }
+                // handler + ONE SEND per request found (vanilla's per-request
+                // model; pipelined requests are answered here so the client
+                // doesn't hang — vanilla itself would drop them):
+                int pos = 0;
+                while (!dead) {
+                    int used = find_req_end(buf + pos, len - pos);
+                    if (used < 0) break;
+                    int rl; uint8_t *resp = handler_alloc(&rl);
+                    send_all(fd, resp, rl);          // one send per response
+                    free(resp);
+                    pos += used;
+                }
+                if (!dead && (int)len > pos) {      // save partial for next edge
+                    sv->rlen = len - pos;
+                    memcpy(sv->rbuf, buf + pos, sv->rlen);
+                }
+                free(buf);
+                if (dead) { close(fd); free(conns[fd]); conns[fd] = NULL; }
+                continue;
+            }
+            // modes 1 & 2: persistent buffers + batched send
+            conn_t *cs = conns[fd];
+            int dead = 0;
+            for (;;) {
+                int r = recv(fd, cs->rbuf + cs->rlen, sizeof cs->rbuf - cs->rlen, 0);
+                if (r > 0) { cs->rlen += r; continue; }
+                if (r == 0) dead = 1;
+                break;
+            }
+            int pos = 0, woff = 0;
+            for (;;) {
+                int used = find_req_end(cs->rbuf + pos, cs->rlen - pos);
+                if (used < 0) break;
+                if (MODE == 1) {
+                    woff += build_into(cs->wbuf + woff);          // raw write
+                } else {
+                    int rl; uint8_t *resp = handler_alloc(&rl);   // compat
+                    memcpy(cs->wbuf + woff, resp, rl);
+                    woff += rl;
+                    free(resp);
+                }
+                pos += used;
+            }
+            if (pos > 0) {
+                memmove(cs->rbuf, cs->rbuf + pos, cs->rlen - pos);
+                cs->rlen -= pos;
+            }
+            if (woff > 0) send_all(fd, cs->wbuf, woff);           // ONE send
+            if (dead) { close(fd); free(conns[fd]); conns[fd] = NULL; }
+        }
+    }
+    return NULL;
+}
+
+// client: C connections, each keeps DEPTH pipelined requests in flight
+typedef struct { long done; } cstats_t;
+static void *client_main(void *arg) {
+    cstats_t *st = arg;
+    enum { NC = 8 };
+    int fds[NC];
+    uint8_t reqbatch[REQ_LEN * 64];
+    for (int i = 0; i < DEPTH; i++) memcpy(reqbatch + i * REQ_LEN, REQ, REQ_LEN);
+    int batch_len = REQ_LEN * DEPTH;
+    const int resp_len = PREFIX_LEN + 2 + 4 + BODY_LEN; // CL "13" = 2 digits
+
+    for (int i = 0; i < NC; i++) {
+        fds[i] = socket(AF_INET, SOCK_STREAM, 0);
+        struct sockaddr_in a = { .sin_family = AF_INET, .sin_port = htons(PORT),
+                                 .sin_addr.s_addr = htonl(INADDR_LOOPBACK) };
+        while (connect(fds[i], (void *)&a, sizeof a) < 0) usleep(1000);
+        int one = 1; setsockopt(fds[i], IPPROTO_TCP, TCP_NODELAY, &one, sizeof one);
+        struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };  // safety net
+        setsockopt(fds[i], SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv);
+    }
+    uint8_t rbuf[1 << 16];
+    while (!stop_flag) {
+        for (int i = 0; i < NC && !stop_flag; i++) {
+            if (send(fds[i], reqbatch, batch_len, MSG_NOSIGNAL) != batch_len) continue;
+            int want = resp_len * DEPTH, got = 0;
+            while (got < want) {
+                int r = recv(fds[i], rbuf, sizeof rbuf, 0);
+                if (r <= 0) break;
+                got += r;
+            }
+            st->done += DEPTH;
+        }
+    }
+    for (int i = 0; i < NC; i++) close(fds[i]);
+    return NULL;
+}
+
+int main(int argc, char **argv) {
+    if (argc > 1) MODE = atoi(argv[1]);
+    if (argc > 2) DEPTH = atoi(argv[2]);
+    if (argc > 3) SECS = atoi(argv[3]);
+
+    pthread_t sv, cl1, cl2;
+    cstats_t s1 = {0}, s2 = {0};
+    pthread_create(&sv, NULL, server_main, NULL);
+    usleep(100 * 1000);
+    pthread_create(&cl1, NULL, client_main, &s1);
+    pthread_create(&cl2, NULL, client_main, &s2);
+
+    sleep(SECS);
+    stop_flag = 1;
+    pthread_join(cl1, NULL); pthread_join(cl2, NULL);
+    pthread_join(sv, NULL);
+
+    long total = s1.done + s2.done;
+    printf("mode=%d depth=%d  %.0f req/s\n", MODE, DEPTH, (double)total / SECS);
+    return 0;
+}

--- a/bench/micro.c
+++ b/bench/micro.c
@@ -1,0 +1,206 @@
+// micro.c — response-building strategy micro-benchmark
+// gcc -O3 -march=native -o micro micro.c
+//
+// Strategies, per "request":
+//   A static_memcpy : fully precomputed response -> persistent out buffer
+//   B raw_write     : prefix memcpy + itoa(Content-Length) + body memcpy,
+//                     written directly into persistent out buffer (no abstraction)
+//   C gutter_writer : body written at gutter offset, headers formatted in stack
+//                     buf, body memmoved to abut headers (zeemo-style finalize)
+//   D alloc_build   : malloc response, build inside it, free (current vanilla
+//                     handler contract, minus the send)
+//   E alloc_copy    : malloc, build, memcpy into persistent out buffer, free
+//                     (compat path: old handler API + batched-send server)
+//   F reqbuf_grow   : request-side: malloc(256) + realloc-doubling to fit a
+//                     512B request + memcpy chunks + free (current epoll read
+//                     path) vs nothing (persistent buffer baseline)
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+
+static inline uint64_t now_ns(void) {
+    struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ull + ts.tv_nsec;
+}
+
+static const char PREFIX[] = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ";
+#define PREFIX_LEN (sizeof(PREFIX) - 1)
+#define GUTTER 256
+
+static inline int itoa10(char *dst, int v) {
+    char tmp[12]; int n = 0;
+    do { tmp[n++] = '0' + v % 10; v /= 10; } while (v);
+    for (int i = 0; i < n; i++) dst[i] = tmp[n - 1 - i];
+    return n;
+}
+
+// volatile sink so the optimizer can't delete the work
+static volatile uint64_t sink;
+
+typedef struct { const char *body; int body_len; } req_t;
+
+// A
+static size_t bench_static(uint8_t *out, const uint8_t *resp, int resp_len, long iters) {
+    size_t off = 0;
+    for (long i = 0; i < iters; i++) {
+        if (off + resp_len > (1 << 20)) off = 0;          // wrap the "batch buffer"
+        memcpy(out + off, resp, resp_len);
+        off += resp_len;
+    }
+    return off;
+}
+
+// B
+static size_t bench_raw(uint8_t *out, const req_t *r, long iters) {
+    size_t off = 0;
+    for (long i = 0; i < iters; i++) {
+        if (off + GUTTER + r->body_len > (1 << 20)) off = 0;
+        uint8_t *p = out + off;
+        memcpy(p, PREFIX, PREFIX_LEN); p += PREFIX_LEN;
+        p += itoa10((char *)p, r->body_len);
+        memcpy(p, "\r\n\r\n", 4); p += 4;
+        memcpy(p, r->body, r->body_len); p += r->body_len;
+        off = p - out;
+    }
+    return off;
+}
+
+// C
+static size_t bench_gutter(uint8_t *out, const req_t *r, long iters) {
+    size_t off = 0;
+    for (long i = 0; i < iters; i++) {
+        if (off + GUTTER + r->body_len + 256 > (1 << 20)) off = 0;
+        uint8_t *base = out + off;
+        memcpy(base + GUTTER, r->body, r->body_len);       // handler writes body
+        char hdr[GUTTER]; int h = 0;                        // finalize:
+        memcpy(hdr, PREFIX, PREFIX_LEN); h = PREFIX_LEN;
+        h += itoa10(hdr + h, r->body_len);
+        memcpy(hdr + h, "\r\n\r\n", 4); h += 4;
+        memmove(base + h, base + GUTTER, r->body_len);      // slide body left
+        memcpy(base, hdr, h);
+        off += h + r->body_len;
+    }
+    return off;
+}
+
+// D
+static size_t bench_alloc(const req_t *r, long iters) {
+    size_t acc = 0;
+    for (long i = 0; i < iters; i++) {
+        uint8_t *p0 = malloc(PREFIX_LEN + 16 + r->body_len);
+        uint8_t *p = p0;
+        memcpy(p, PREFIX, PREFIX_LEN); p += PREFIX_LEN;
+        p += itoa10((char *)p, r->body_len);
+        memcpy(p, "\r\n\r\n", 4); p += 4;
+        memcpy(p, r->body, r->body_len); p += r->body_len;
+        acc += p0[4] + (p - p0);                            // touch + length
+        free(p0);
+    }
+    return acc;
+}
+
+// E
+static size_t bench_alloc_copy(uint8_t *out, const req_t *r, long iters) {
+    size_t off = 0;
+    for (long i = 0; i < iters; i++) {
+        uint8_t *p0 = malloc(PREFIX_LEN + 16 + r->body_len);
+        uint8_t *p = p0;
+        memcpy(p, PREFIX, PREFIX_LEN); p += PREFIX_LEN;
+        p += itoa10((char *)p, r->body_len);
+        memcpy(p, "\r\n\r\n", 4); p += 4;
+        memcpy(p, r->body, r->body_len); p += r->body_len;
+        int len = p - p0;
+        if (off + len > (1 << 20)) off = 0;
+        memcpy(out + off, p0, len);
+        off += len;
+        free(p0);
+    }
+    return off;
+}
+
+// F — request-side read buffer: current epoll path (fresh 256B buf, grow by
+// doubling while "recv"ing a 512-byte request in 256B chunks), vs persistent.
+static size_t bench_reqbuf_grow(const uint8_t *wire, int req_len, long iters) {
+    size_t acc = 0;
+    for (long i = 0; i < iters; i++) {
+        size_t cap = 256, len = 0;
+        uint8_t *buf = malloc(cap);
+        while ((int)len < req_len) {
+            if (len == cap) { cap *= 2; buf = realloc(buf, cap); }
+            size_t spare = cap - len, n = (size_t)req_len - len;
+            if (n > spare) n = spare;
+            memcpy(buf + len, wire + len, n);               // simulated recv
+            len += n;
+        }
+        acc += buf[len - 1];
+        free(buf);
+    }
+    return acc;
+}
+
+static size_t bench_reqbuf_persistent(uint8_t *conn_buf, const uint8_t *wire, int req_len, long iters) {
+    size_t acc = 0;
+    for (long i = 0; i < iters; i++) {
+        memcpy(conn_buf, wire, req_len);                    // single recv, big buffer
+        acc += conn_buf[req_len - 1];
+    }
+    return acc;
+}
+
+static void run(const char *name, size_t (*fn)(void), long iters) { (void)name; (void)fn; (void)iters; }
+
+#define BENCH(label, expr)                                                  \
+    do {                                                                    \
+        /* warmup */                                                        \
+        sink += (expr);                                                     \
+        uint64_t t0 = now_ns();                                             \
+        sink += (expr);                                                     \
+        uint64_t dt = now_ns() - t0;                                        \
+        printf("%-34s %8.2f ns/op  (%6.1f Mops/s)\n", label,                \
+               (double)dt / iters, iters * 1000.0 / dt);                    \
+    } while (0)
+
+int main(void) {
+    long iters = 20 * 1000 * 1000;
+    uint8_t *out = aligned_alloc(64, 1 << 20);
+    memset(out, 0, 1 << 20);
+
+    static char body13[13];  memset(body13, 'x', 13);
+    static char body1k[1024]; memset(body1k, 'y', 1024);
+    req_t small = { body13, 13 }, big = { body1k, 1024 };
+
+    // precomputed static response (small)
+    uint8_t resp_static[256]; req_t tmp = small;
+    uint8_t *p = resp_static;
+    memcpy(p, PREFIX, PREFIX_LEN); p += PREFIX_LEN;
+    p += itoa10((char *)p, tmp.body_len);
+    memcpy(p, "\r\n\r\n", 4); p += 4;
+    memcpy(p, body13, 13); p += 13;
+    int resp_static_len = p - resp_static;
+
+    uint8_t wire[512]; memset(wire, 'r', sizeof wire);
+    uint8_t *conn_buf = aligned_alloc(64, 8192);
+
+    printf("== response building, 13-byte body (%ld iters) ==\n", iters);
+    BENCH("A static_memcpy (precomputed)", bench_static(out, resp_static, resp_static_len, iters));
+    BENCH("B raw_write (persistent buf)", bench_raw(out, &small, iters));
+    BENCH("C gutter_writer (finalize+move)", bench_gutter(out, &small, iters));
+    BENCH("D alloc_build+free (current)", bench_alloc(&small, iters));
+    BENCH("E alloc+copy+free (compat)", bench_alloc_copy(out, &small, iters));
+
+    printf("\n== response building, 1 KiB body ==\n");
+    BENCH("B raw_write (persistent buf)", bench_raw(out, &big, iters));
+    BENCH("C gutter_writer (finalize+move)", bench_gutter(out, &big, iters));
+    BENCH("D alloc_build+free (current)", bench_alloc(&big, iters));
+    BENCH("E alloc+copy+free (compat)", bench_alloc_copy(out, &big, iters));
+
+    printf("\n== request read buffer, 512-byte request ==\n");
+    BENCH("F1 fresh 256B buf + grow (current)", bench_reqbuf_grow(wire, 512, iters));
+    BENCH("F2 persistent 8KiB buf", bench_reqbuf_persistent(conn_buf, wire, 512, iters));
+
+    printf("\nsink=%llu\n", (unsigned long long)sink);
+    return 0;
+}

--- a/bench/middleware/middleware_bench.v
+++ b/bench/middleware/middleware_bench.v
@@ -65,7 +65,7 @@ fn inject_headers_string(resp []u8, hdrs string) []u8 {
 
 // ── chain composition (mirrors examples/middleware) ───────────────────────────
 
-type Handler = fn ([]u8, int, mut []u8) !
+type Handler = fn (req []u8, fd int, mut out []u8) !
 
 type Middleware = fn (Handler) Handler
 

--- a/bench/middleware/middleware_bench.v
+++ b/bench/middleware/middleware_bench.v
@@ -65,7 +65,7 @@ fn inject_headers_string(resp []u8, hdrs string) []u8 {
 
 // ── chain composition (mirrors examples/middleware) ───────────────────────────
 
-type Handler = fn ([]u8, int) ![]u8
+type Handler = fn ([]u8, int, mut []u8) !
 
 type Middleware = fn (Handler) Handler
 
@@ -78,8 +78,8 @@ fn chain(app Handler, mw ...Middleware) Handler {
 }
 
 fn passthrough(next Handler) Handler {
-	return fn [next] (req []u8, fd int) ![]u8 {
-		return next(req, fd)
+	return fn [next] (req []u8, fd int, mut out []u8) ! {
+		next(req, fd, mut out)!
 	}
 }
 
@@ -147,20 +147,25 @@ fn main() {
 	bm.measure('inject_headers_string (3 allocs, naive)')
 
 	// 3) direct handler call — the baseline for the chain overhead.
-	base := fn (req []u8, fd int) ![]u8 {
-		return base_resp
+	base := fn (req []u8, fd int, mut out []u8) ! {
+		out << base_resp
 	}
+	// One persistent buffer, cleared per call — mirrors the server's reused
+	// per-connection write buffer, so the loop measures call overhead only.
+	mut out_buf := []u8{cap: base_resp.len}
 	for _ in 0 .. iterations {
-		out := base([]u8{}, -1) or { base_resp }
-		acc += out.len
+		out_buf.clear()
+		base([]u8{}, -1, mut out_buf) or {}
+		acc += out_buf.len
 	}
 	bm.measure('direct handler call   (no middleware)')
 
 	// 4) 3-deep chain — same call through three composed wrappers.
 	wrapped := chain(base, passthrough, passthrough, passthrough)
 	for _ in 0 .. iterations {
-		out := wrapped([]u8{}, -1) or { base_resp }
-		acc += out.len
+		out_buf.clear()
+		wrapped([]u8{}, -1, mut out_buf) or {}
+		acc += out_buf.len
 	}
 	bm.measure('3-deep chain call     (3 middlewares)')
 

--- a/docs/PERF_GAP_ANALYSIS.md
+++ b/docs/PERF_GAP_ANALYSIS.md
@@ -1,0 +1,300 @@
+# Performance Gap Analysis: vanilla vs. the fast HTTP servers
+
+Analysis of six reference implementations — HttpArena **tokio**, **minima-sync**
+(C#/NativeAOT, raw io_uring), **rust-epoll**, **zeemo** (Zig, io_uring),
+**libreactorng** (C, raw io_uring, TechEmpower plaintext leader), and the
+**liburing** library/examples (proxy.c, releases 2.9–2.14) — compared against
+vanilla's epoll and io_uring backends.
+
+## What ALL the fast servers have in common
+
+Every one of these servers, regardless of language or backend, shares the same
+five architectural decisions. None of them wins through exotic tricks; they win
+through syscall economy and shared-nothing dataflow.
+
+1. **Shared-nothing, one listener per worker (`SO_REUSEPORT`).** Each
+   worker thread/process creates its *own* listening socket with
+   `SO_REUSEPORT` and accepts its own connections. The kernel load-balances.
+   There is **no accept thread, no cross-thread handoff, no round-robin
+   distribution** anywhere. (tokio: one current-thread runtime + listener per
+   core; minima-sync & zeemo: pinned reactor per core, own listener;
+   rust-epoll: thread per core, own listener; libreactorng: thread-local
+   reactor, deployed one process per core.)
+
+2. **HTTP/1.1 pipelining with batched writes.** One `recv` may contain N
+   requests. They all parse every complete request in the buffer, append every
+   response into a single per-connection write buffer, and issue **one
+   `send` for the whole batch**. Leftover partial bytes are compacted to the
+   buffer start (`memmove`) and the next recv appends after them. This is
+   zeemo's self-described "50M-RPS difference vs the obvious
+   one-request-per-recv loop".
+
+3. **Persistent per-connection buffers, fd-indexed.** A connection owns a
+   reused recv buffer (8–16 KiB) and write buffer (16–64 KiB) for its whole
+   lifetime; state lookup is a flat array indexed by fd (`slots[MAX_FD]`),
+   never a hash map. Connection objects are pooled (vanilla's io_uring pool
+   already does this part right).
+
+4. **Roughly one syscall per event-loop iteration, not per request.**
+   - epoll flavor (rust-epoll): adaptive `epoll_wait` timeout — `0` (pure
+     poll) while the last wait returned events, `-1` (block) only after an
+     empty poll. Plus `accept4` drain loops.
+   - io_uring flavor (minima-sync, zeemo, libreactorng): a single
+     `io_uring_submit_and_wait(1)` per loop iteration submits *all* SQEs
+     queued during the previous CQE drain and waits, then the CQ ring is
+     drained in a batch directly from the mmap'd ring (zero syscalls) and
+     acknowledged with **one** `cq_advance(n)` — never `cqe_seen` + `submit`
+     per CQE.
+
+5. **Zero hot-path allocation and minimal parsing.** Responses are built from
+   precomputed static byte literals + an in-place itoa for `Content-Length`
+   (or a back-patched placeholder), written directly into the connection's
+   write buffer. Only the 3–4 headers that affect framing/lifetime are
+   parsed (`Content-Length`, `Transfer-Encoding: chunked`, `Connection:
+   close`); everything else is skipped or kept as raw slices. None of them
+   sends a `Date` header (libreactorng sends one cached per second).
+
+Secondary common traits: `TCP_NODELAY` set at accept, `accept4(SOCK_NONBLOCK)`,
+`MSG_NOSIGNAL` on sends, CPU pinning of each worker to one core
+(`sched_setaffinity`), large backlog, and aggressive inlining of tiny helpers.
+
+## Why they beat vanilla on epoll
+
+Vanilla epoll backend today (`backend_epoll/worker_linux.c.v`,
+`conn_state_linux.c.v`):
+
+| Aspect | vanilla | fast servers |
+|---|---|---|
+| Accept | dedicated accept loop thread, round-robin fd handoff to worker epolls | per-worker `SO_REUSEPORT` listener, kernel balances |
+| Pipelining | **dropped** — `buf.trim(total)` discards trailing pipelined bytes | parse all, one batched send |
+| Recv buffer | fresh `[]u8{cap: 256}` allocated *per EPOLLIN event*, grown by doubling | persistent 8–16 KiB per-conn buffer, reused |
+| State lookup | `map[int]&ConnState` | flat fd-indexed array |
+| Wait strategy | `epoll_wait(-1)` (or 250 ms sweep) | adaptive timeout 0/-1 busy-poll hybrid |
+| Response | handler allocates `[]u8`, one `send` per request, freed after | static prefix + itoa into reused write buffer |
+| Pinning | none | `sched_setaffinity` per worker |
+
+The handoff model is the structural cost: every connection crosses a thread
+boundary (cache-cold), the accept thread serializes all accepts, and the
+round-robin ignores load. The 256-byte starting buffer guarantees ≥2 recv
+calls + reallocs for any normal request. Dropping pipelined bytes makes
+pipelined benchmarks (and clients) outright fail/slow.
+
+## Why they beat vanilla on io_uring
+
+Vanilla io_uring backend today (`http_server_io_uring_linux.c.v`,
+`io_uring/io_uring_linux.c.v`):
+
+| Aspect | vanilla | fast servers / liburing guidance |
+|---|---|---|
+| Setup flags | `IORING_SETUP_SQPOLL`, sq thread pinned per worker | **no SQPOLL**: `SINGLE_ISSUER \| DEFER_TASKRUN` (minima-sync; liburing: "the preferred and recommended way"), `COOP_TASKRUN` fallback; libreactorng/zeemo use *no* flags and still win via batching |
+| Loop | `wait_cqe` → handle **one** CQE → `cqe_seen` → **`submit` per CQE** | `submit_and_wait(1)` once per loop, batch-drain CQ, one `cq_advance(n)` |
+| Accept | single-shot, re-armed each accept | multishot accept, re-arm only when `IORING_CQE_F_MORE` is unset |
+| Recv | single-shot into fixed 4 KiB; **partial requests broken** (`buf[..bytes_read]` passed to handler as-is) | single-shot recv appending at offset (minima-sync/zeemo) with framing across recvs; or multishot recv + provided buffer rings (proxy.c) |
+| Pipelining | none — one request per recv assumed | drain-all + one batched send |
+| Send flags | `0` | `MSG_NOSIGNAL` |
+| Response | handler `[]u8` alloc, freed per request | serialized into persistent per-conn write buffer |
+| CQ size | SQ=CQ=16384 | small SQ (covers one batch), big CQ (`IORING_SETUP_CQSIZE`, e.g. 4096) to avoid overflow |
+| Ring fd | normal | `io_uring_register_ring_fd()` removes fget/fput per enter |
+
+SQPOLL is actively harmful here: with one worker per core *plus* one kernel SQ
+poll thread per worker, the machine is 2× oversubscribed and the poll threads
+burn the cores the workers need. Every modern reference (liburing proxy.c,
+minima-sync) chose `DEFER_TASKRUN + SINGLE_ISSUER` instead. The
+submit-per-CQE loop is the second big cost: under load it makes vanilla pay
+~2 syscalls per request where the others pay ~1 per *batch* of requests.
+
+The partial-request bug is also a correctness gap: a request fragmented across
+TCP segments (or larger than 4096 bytes) reaches the handler truncated.
+
+---
+
+## Changes to make in vanilla
+
+Ordered by expected impact. All consistent with the three rules (no slowdown,
+minimal abstraction, keep it simple) and BEST_PRACTICES.md.
+
+### 1. epoll: kill the accept thread — per-worker `SO_REUSEPORT` listeners
+
+Each worker creates its own listening socket (`SO_REUSEADDR + SO_REUSEPORT +
+TCP_NODELAY`, nonblocking), registers it in its own epoll, and runs an
+`accept4(..., SOCK_NONBLOCK)` drain loop on listener EPOLLIN. Delete
+`handle_accept_loop` and the round-robin. The io_uring backend already creates
+per-worker listeners — reuse that path. Connections then live and die on one
+core: no cross-thread cache misses, no accept serialization.
+
+### 2. Both backends: pipelining with batched send
+
+In the request loop, after framing one request, do **not** trim trailing
+bytes. Loop: `frame → handle → append response to write buffer → advance
+offset` until the buffer has no complete request left; `memmove` the leftover
+to the front; then issue **one** `send` for all accumulated responses.
+Backpressure path (partial send → park remainder for EPOLLOUT / resubmit
+send from offset) already exists in both backends and stays as is.
+
+### 3. Both backends: persistent per-connection buffers + flat fd table
+
+- Replace `map[int]&ConnState` (epoll) with `[]&ConnState` (or a struct
+  array) of size `max_fd`, indexed by fd — O(1), no hashing. Same for any
+  per-fd lookup.
+- Give every connection a persistent recv buffer (start 8 KiB) and write
+  buffer (16 KiB), allocated once at accept (or taken from a pool, as the
+  io_uring `pool_init` already does) and reused across requests. Stop
+  allocating `[]u8{cap: 256}` per EPOLLIN; recv appends at `len` into the
+  spare capacity of the persistent buffer.
+- Keep the existing connection pool; on close, return the connection (with
+  its buffers) to the pool instead of freeing.
+
+### 4. io_uring: rewrite the event loop for batching
+
+```
+// per loop iteration — ONE syscall
+io_uring_submit_and_wait(&ring, 1)
+for io_uring_peek_cqe(&ring, &cqe) == 0 {   // or copy_cqes batch of 256
+    dispatch(cqe)                            // queues new SQEs, no submit
+    count++
+    advance to next cqe
+}
+io_uring_cq_advance(&ring, count)            // one ack for the whole batch
+```
+
+All `prepare_*` calls only write SQEs; the single `submit_and_wait` at the top
+of the loop flushes everything queued during the previous drain. Remove
+`io_uring_submit` from `handle_io_uring_read` and friends.
+
+### 5. io_uring: drop SQPOLL, use modern setup flags
+
+```
+params.flags = IORING_SETUP_SINGLE_ISSUER | IORING_SETUP_DEFER_TASKRUN
+             | IORING_SETUP_CLAMP | IORING_SETUP_CQSIZE
+params.cq_entries = 4096        // big CQ
+entries (SQ)     = 256..1024    // only needs to cover one submit batch
+```
+
+Fallback chain for older kernels: drop `DEFER_TASKRUN` → try
+`IORING_SETUP_COOP_TASKRUN` → plain `0` flags (libreactorng proves plain flags
++ batching is already fast). Also call `io_uring_register_ring_fd(&ring)`
+after init.
+
+### 6. io_uring: multishot accept + fix partial reads
+
+- Enable multishot accept (`io_uring_prep_multishot_accept`); re-arm only
+  when the CQE lacks `IORING_CQE_F_MORE`. The code exists
+  (`use_multishot`) — it's just never turned on.
+- Recv must append: post recv into `buf + bytes_read` with the remaining
+  capacity, run the framing parser, and only call the handler when a request
+  is complete (reuse `frame_request_length_lim` exactly as the epoll path
+  does). This fixes the fragmented/large-request bug and enables pipelining.
+- Set `MSG_NOSIGNAL` on `io_uring_prep_send` flags.
+- Set `TCP_NODELAY` on accepted fds (currently missing in this backend).
+
+### 7. epoll: adaptive wait timeout (busy-poll hybrid)
+
+```v
+mut timeout := -1
+for {
+    n := C.epoll_wait(epoll_fd, &events[0], max_events, timeout)
+    timeout = if n > 0 { 0 } else { -1 }   // poll while hot, block when idle
+    ...
+}
+```
+
+One line of state, measurable latency/throughput win under load, zero cost
+idle. (Compose with the existing 250 ms sweep: use `0` when hot, `250`/`-1`
+as today when idle.)
+
+### 8. Pin workers to cores
+
+After spawning each worker, `sched_setaffinity` it to CPU `i` (minima-sync,
+zeemo). Cheap, keeps caches warm, pairs with `SO_REUSEPORT` balancing.
+
+### 9. Response building: raw write buffer, NO writer abstraction
+
+**Benchmarked (see "Benchmark evidence" below): a ResponseWriter abstraction
+is not justified.** The zeemo-style header-gutter `finalize()` (memmove) is
+*slower* than writing raw bytes sequentially, and for 1 KiB bodies it is even
+slower than malloc-per-response. And end-to-end, the allocation itself is
+noise next to syscall structure: with batched sends, malloc-per-response vs
+zero-alloc measured within ±1%; without pipelining the three models are
+identical. The real win of this item is *enabling item 2's batched send* and
+removing GC churn — not the nanoseconds of the alloc.
+
+So the contract should be the rawest possible one: the handler appends the
+**complete raw HTTP response bytes (headers included)** to the connection's
+persistent write buffer. No struct, no methods, no finalize step:
+
+```v
+// handler appends a full raw response into `out` (the conn's write buffer)
+fn (req []u8, fd int, mut out []u8) !
+```
+
+Static routes append a precomputed `const ... .bytes()`; dynamic routes append
+a `const` prefix, the Content-Length digits (`write_decimal`-style helper, or
+back-patch), `\r\n\r\n`, and the body. Optional helpers stay plain functions;
+nothing is mandatory. The server batches everything in `out` into one send
+(item 2) and never frees anything.
+
+**Bug found while tracing this path:** `send_or_park` /
+`handle_io_uring_write` call `resp.free()` on whatever the handler returns —
+but the bundled examples return module-level consts
+(`response.tiny_bad_request_response`). Freeing a const's data once means
+every later request that returns it sends from freed memory. Verify with a
+running build; if confirmed, this is a correctness reason (not just perf) to
+change the ownership contract.
+
+#### Benchmark evidence (Linux x86-64, gcc -O3, 4 cores; C mirrors of each model)
+
+Micro (13-byte body, per response): precomputed-static memcpy 1.6 ns; raw
+write into persistent buffer 2.2 ns; gutter-writer finalize 4.6 ns;
+malloc+build+free (current contract) 6.6 ns; malloc+copy+free (compat) 8.9 ns.
+With a 1 KiB body the gutter writer (30.9 ns) loses to malloc (22.2 ns) — the
+memmove dominates. Request side: fresh 256 B grow-buffer per event 21.4 ns vs
+persistent 8 KiB buffer 12.4 ns.
+
+End-to-end (loopback epoll server, identical parsing, 16 conns):
+
+| model | depth=1 | depth=16 (pipelined) |
+|---|---|---|
+| persistent buffers + raw write + one send per batch | 60.4k req/s | **977k req/s** |
+| persistent buffers + malloc/copy/free + one send per batch | 61.3k | 961–979k |
+| fresh grow buffer + malloc + **send per response** (current) | 61.0k | **606k** |
+
+Reading: per-request allocation costs ~7–9 ns — invisible at depth 1 (syscalls
+dominate) and within noise even pipelined. What costs 38% is the send-per-
+response structure (items 1–4). Eliminate the allocation anyway — it's free to
+do once buffers are persistent, and in V it also removes GC/manualfree churn —
+but spend the effort on syscall structure, not on response-builder machinery.
+Caveat: C glibc malloc in a tight loop is the *best* case; V's default Boehm
+GC makes the gap larger, in vanilla's favor of the raw contract.
+
+### 10. Smaller items
+
+- Backlog: raise `listen()` backlog (rust-epoll uses 65536; at least make it
+  configurable — 1024 is fine until accept bursts).
+- Limit header parsing on the hot path to the framing trio (already the
+  case in `frame_request_length_lim` — keep it that way; never pre-parse all
+  headers).
+- Events array: 1024 (`socket.max_connection_size`) per `epoll_wait` is fine;
+  512 (rust-epoll) and 256 CQEs (zeemo) are in the same range.
+- Optional/later, from liburing proxy.c: multishot recv + provided buffer
+  rings (`io_uring_setup_buf_ring`, `IOSQE_BUFFER_SELECT`) to cut per-conn
+  recv buffer memory; registered files/direct descriptors; `send_zc` for
+  large responses; NAPI busy-poll (`io_uring_register_napi`). None of the
+  benchmark winners *need* these — zeemo and libreactorng win without them —
+  so do items 1–9 first and benchmark before adding this complexity.
+
+## Suggested order of work
+
+| Step | Change | Backend | Risk | Expected gain |
+|---|---|---|---|---|
+| 1 | Per-worker reuseport listeners | epoll | low | large |
+| 2 | Persistent buffers + flat fd table | both | low | large |
+| 3 | Pipelining + batched send | both | medium | very large (pipelined), moderate (plain) |
+| 4 | Batched submit/drain loop | io_uring | low | large |
+| 5 | Drop SQPOLL → DEFER_TASKRUN/SINGLE_ISSUER | io_uring | low | large |
+| 6 | Multishot accept + partial-read fix | io_uring | low | correctness + moderate |
+| 7 | Adaptive epoll timeout | epoll | trivial | moderate |
+| 8 | CPU pinning | both | trivial | small–moderate |
+| 9 | Raw write-buffer handler contract (no writer abstraction) | both | medium | small alone; enables 3 |
+
+Benchmark each step in isolation with `-prod` (wrk/rewrk, plain + pipelined
+profiles) and verify with helgrind, per CONTRIBUTING.md.

--- a/examples/auth/src/main.v
+++ b/examples/auth/src/main.v
@@ -90,7 +90,7 @@ fn bearer(req request_parser.HttpRequest) string {
 	return ''
 }
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	path := req.path.to_string(req.buffer)
 
@@ -99,13 +99,14 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 			// After verifying a password (verify_password above), issue a JWT.
 			token := jwt_sign('{"sub":"user-42","exp":9999999999}')
 			body := '{"token":"${token}"}'
-			return 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
+			out << 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
 		}
 		'/protected' {
 			if !jwt_verify(bearer(req)) {
-				return 'HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Bearer\r\nContent-Length: 0\r\n\r\n'.bytes()
+				out << 'HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: Bearer\r\nContent-Length: 0\r\n\r\n'.bytes()
+				return
 			}
-			return 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
 		}
 		'/service' {
 			key := if s := req.get_header_value_slice('X-API-Key') {
@@ -114,12 +115,13 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 				''
 			}
 			if !check_api_key(key) {
-				return 'HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n'.bytes()
+				out << 'HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n'.bytes()
+				return
 			}
-			return 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
 		}
 		else {
-			return 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n'.bytes()
 		}
 	}
 }

--- a/examples/auth/src/main_test.v
+++ b/examples/auth/src/main_test.v
@@ -36,9 +36,13 @@ fn test_api_key_constant_time_check() {
 
 fn test_protected_route_requires_valid_bearer() ! {
 	// no token -> 401
-	assert handle('GET /protected HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1)!.bytestr().contains('401')
+	mut out1 := []u8{}
+	handle('GET /protected HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1, mut out1)!
+	assert out1.bytestr().contains('401')
 	// valid token -> 200
 	token := jwt_sign('{"sub":"user-42","exp":9999999999}')
 	req := 'GET /protected HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer ${token}\r\n\r\n'.bytes()
-	assert handle(req, -1)!.bytestr().contains('200 OK')
+	mut out2 := []u8{}
+	handle(req, -1, mut out2)!
+	assert out2.bytestr().contains('200 OK')
 }

--- a/examples/chunked_streaming/src/main.v
+++ b/examples/chunked_streaming/src/main.v
@@ -63,7 +63,7 @@ fn chunk(data string) string {
 	return '${data.len:x}\r\n${data}\r\n'
 }
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 
 	// If the request arrived chunked (once the core reassembles it), the body
@@ -82,7 +82,7 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 	sb.write_string(chunk('second piece\n'))
 	sb.write_string(chunk('third piece\n'))
 	sb.write_string('0\r\n\r\n') // terminating chunk
-	return sb
+	out << sb
 }
 
 fn main() {

--- a/examples/chunked_streaming/src/main_test.v
+++ b/examples/chunked_streaming/src/main_test.v
@@ -24,10 +24,18 @@ fn test_decode_chunked_truncated_errors() {
 }
 
 fn test_response_uses_chunked_framing() ! {
-	out := handle('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1)!.bytestr()
+	out := serve('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes())!.bytestr()
 	assert out.contains('Transfer-Encoding: chunked')
 	assert !out.contains('Content-Length') // chunked => no Content-Length
 	assert out.ends_with('0\r\n\r\n') // terminating chunk present
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(req []u8) ![]u8 {
+	mut out := []u8{}
+	handle(req, -1, mut out)!
+	return out
 }
 
 /*

--- a/examples/compression/src/main.v
+++ b/examples/compression/src/main.v
@@ -84,7 +84,7 @@ fn build_response(content_type string, body []u8, encoding string) []u8 {
 	return sb
 }
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	accept := if s := req.get_header_value_slice('Accept-Encoding') {
 		s.to_string(req.buffer)
@@ -98,7 +98,7 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 		'"items":[1,2,3,4,5,6,7,8,9,10],"note":"repeated text compresses well ' +
 		'repeated text compresses well repeated text compresses well"}').bytes()
 
-	return build_response('application/json', body, encoding)
+	out << build_response('application/json', body, encoding)
 }
 
 fn main() {

--- a/examples/cookies_sessions/src/main.v
+++ b/examples/cookies_sessions/src/main.v
@@ -67,7 +67,7 @@ fn parse_cookies(header string) map[string]string {
 	return out
 }
 
-fn handle(req_buffer []u8, _ int, mut store Store) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8, mut store Store) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	path := req.path.to_string(req.buffer)
 
@@ -82,28 +82,30 @@ fn handle(req_buffer []u8, _ int, mut store Store) ![]u8 {
 			// (Authenticate first — see examples/auth.) Then mint a session.
 			sid := store.create('user-42')
 			// Note ALL the security attributes on the Set-Cookie.
-			return ('HTTP/1.1 200 OK\r\n' +
+			out << ('HTTP/1.1 200 OK\r\n' +
 				'Set-Cookie: sid=${sid}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=86400\r\n' +
 				'Content-Length: 0\r\n\r\n').bytes()
 		}
 		'/me' {
 			sid := cookies['sid'] or {
-				return 'HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n'.bytes()
+				out << 'HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n'.bytes()
+				return
 			}
 			sess := store.get(sid) or {
-				return 'HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n'.bytes()
+				out << 'HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n'.bytes()
+				return
 			}
 			body := '{"user":"${sess.user_id}"}'
-			return 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
+			out << 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
 		}
 		'/logout' {
 			// Expire the cookie (Max-Age=0) and drop the server-side session.
-			return ('HTTP/1.1 200 OK\r\n' +
+			out << ('HTTP/1.1 200 OK\r\n' +
 				'Set-Cookie: sid=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0\r\n' +
 				'Content-Length: 0\r\n\r\n').bytes()
 		}
 		else {
-			return 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n'.bytes()
 		}
 	}
 }
@@ -121,8 +123,8 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
 		io_multiplexing: backend
-		request_handler: fn [mut store] (req_buffer []u8, fd int) ![]u8 {
-			return handle(req_buffer, fd, mut store)
+		request_handler: fn [mut store] (req_buffer []u8, fd int, mut out []u8) ! {
+			handle(req_buffer, fd, mut out, mut store)!
 		}
 	})!
 	println('Cookies/sessions demo on http://localhost:3000/  (/login, /me, /logout)')

--- a/examples/cors/src/main.v
+++ b/examples/cors/src/main.v
@@ -27,7 +27,7 @@ fn origin_allowed(origin string) bool {
 	return origin in allowed_origins
 }
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	method := req.method.to_string(req.buffer)
 	origin := if o := req.get_header_value_slice('Origin') {
@@ -43,13 +43,15 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 	// PREFLIGHT: answer the browser's permission probe.
 	if method == 'OPTIONS' {
 		if allow_origin == '' {
-			return 'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n'.bytes()
+			return
 		}
-		return ('HTTP/1.1 204 No Content\r\n' + 'Access-Control-Allow-Origin: ${allow_origin}\r\n' +
+		out << ('HTTP/1.1 204 No Content\r\n' + 'Access-Control-Allow-Origin: ${allow_origin}\r\n' +
 			'Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n' +
 			'Access-Control-Allow-Headers: Content-Type, Authorization, X-CSRF-Token\r\n' +
 			'Access-Control-Allow-Credentials: true\r\n' + 'Access-Control-Max-Age: 86400\r\n' +
 			'Vary: Origin\r\n' + 'Content-Length: 0\r\n\r\n').bytes()
+		return
 	}
 
 	// Actual request: attach CORS headers to the real response.
@@ -59,7 +61,7 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 			'Access-Control-Allow-Credentials: true\r\nVary: Origin\r\n'
 	}
 	body := '{"ok":true}'
-	return 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n${cors}Content-Length: ${body.len}\r\n\r\n${body}'.bytes()
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n${cors}Content-Length: ${body.len}\r\n\r\n${body}'.bytes()
 }
 
 fn main() {

--- a/examples/cors/src/main_test.v
+++ b/examples/cors/src/main_test.v
@@ -12,7 +12,7 @@ fn test_allowlist() {
 fn test_preflight_allowed_origin() ! {
 	req :=
 		'OPTIONS /api HTTP/1.1\r\nOrigin: http://localhost:5173\r\nAccess-Control-Request-Method: POST\r\n\r\n'.bytes()
-	out := handle(req, -1)!.bytestr()
+	out := serve(req)!.bytestr()
 	assert out.contains('204 No Content')
 	assert out.contains('Access-Control-Allow-Origin: http://localhost:5173')
 	assert out.contains('Access-Control-Allow-Methods:')
@@ -21,13 +21,21 @@ fn test_preflight_allowed_origin() ! {
 
 fn test_preflight_forbidden_origin() ! {
 	req := 'OPTIONS /api HTTP/1.1\r\nOrigin: https://evil.com\r\n\r\n'.bytes()
-	assert handle(req, -1)!.bytestr().contains('403 Forbidden')
+	assert serve(req)!.bytestr().contains('403 Forbidden')
 }
 
 fn test_simple_request_echoes_allowed_origin() ! {
 	req := 'GET /api HTTP/1.1\r\nOrigin: https://app.example.com\r\n\r\n'.bytes()
-	out := handle(req, -1)!.bytestr()
+	out := serve(req)!.bytestr()
 	assert out.contains('Access-Control-Allow-Origin: https://app.example.com')
 	// SECURITY invariant: never the wildcard `*` when credentials are allowed.
 	assert !out.contains('Access-Control-Allow-Origin: *')
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(req []u8) ![]u8 {
+	mut out := []u8{}
+	handle(req, -1, mut out)!
+	return out
 }

--- a/examples/csrf/src/main.v
+++ b/examples/csrf/src/main.v
@@ -46,7 +46,7 @@ fn is_unsafe(method string) bool {
 	return method in ['POST', 'PUT', 'PATCH', 'DELETE']
 }
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	method := req.method.to_string(req.buffer)
 	path := req.path.to_string(req.buffer)
@@ -62,9 +62,10 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 	// variant; the synchronizer variant keeps it server-side instead).
 	if path == '/form' && method == 'GET' {
 		token := new_token()
-		return ('HTTP/1.1 200 OK\r\n' +
+		out << ('HTTP/1.1 200 OK\r\n' +
 			'Set-Cookie: csrf=${token}; Secure; SameSite=Strict; Path=/\r\n' +
 			'Content-Type: text/html\r\nContent-Length: 0\r\n\r\n').bytes()
+		return
 	}
 
 	// State-changing request: require the header token to match the cookie.
@@ -76,12 +77,14 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 			''
 		}
 		if cookie_token == '' || !hmac.equal(cookie_token.bytes(), header_token.bytes()) {
-			return 'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n'.bytes()
+			return
 		}
-		return 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
+		out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
+		return
 	}
 
-	return 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+	out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 }
 
 fn main() {

--- a/examples/csrf/src/main_test.v
+++ b/examples/csrf/src/main_test.v
@@ -24,18 +24,26 @@ fn test_unsafe_methods_gated() {
 
 fn test_post_without_token_forbidden() ! {
 	req := 'POST /save HTTP/1.1\r\nContent-Length: 0\r\n\r\n'.bytes()
-	assert handle(req, -1)!.bytestr().contains('403 Forbidden')
+	assert serve(req)!.bytestr().contains('403 Forbidden')
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(req []u8) ![]u8 {
+	mut out := []u8{}
+	handle(req, -1, mut out)!
+	return out
 }
 
 fn test_post_with_matching_token_ok() ! {
 	tok := 'deadbeefcafe'
 	req :=
 		'POST /save HTTP/1.1\r\nCookie: csrf=${tok}\r\nX-CSRF-Token: ${tok}\r\nContent-Length: 0\r\n\r\n'.bytes()
-	assert handle(req, -1)!.bytestr().contains('200 OK')
+	assert serve(req)!.bytestr().contains('200 OK')
 }
 
 fn test_post_with_mismatched_token_forbidden() ! {
 	req :=
 		'POST /save HTTP/1.1\r\nCookie: csrf=aaaa\r\nX-CSRF-Token: bbbb\r\nContent-Length: 0\r\n\r\n'.bytes()
-	assert handle(req, -1)!.bytestr().contains('403 Forbidden')
+	assert serve(req)!.bytestr().contains('403 Forbidden')
 }

--- a/examples/database/src/main.v
+++ b/examples/database/src/main.v
@@ -5,7 +5,7 @@ import http_server.http1_1.response
 import http_server.http1_1.request_parser
 import db.pg
 
-fn handle_request(req_buffer []u8, client_conn_fd int, mut pool ConnectionPool) ![]u8 {
+fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8, mut pool ConnectionPool) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 
 	method := unsafe { tos(&req.buffer[req.method.start], req.method.len) }
@@ -13,20 +13,24 @@ fn handle_request(req_buffer []u8, client_conn_fd int, mut pool ConnectionPool) 
 
 	if method == 'GET' {
 		if path == '/' {
-			return home_controller([])
+			out << home_controller([])!
+			return
 		} else if path.starts_with('/user/') {
 			id := path[6..]
-			return get_user_controller([id], mut pool)
+			out << get_user_controller([id], mut pool)!
+			return
 		} else if path == '/user' {
-			return get_users_controller([], mut pool)
+			out << get_users_controller([], mut pool)!
+			return
 		}
 	} else if method == 'POST' {
 		if path == '/user' {
-			return create_user_controller([], mut pool)
+			out << create_user_controller([], mut pool)!
+			return
 		}
 	}
 
-	return response.tiny_bad_request_response
+	out << response.tiny_bad_request_response
 }
 
 fn main() {
@@ -49,8 +53,8 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
 		io_multiplexing: unsafe { http_server.IOBackend(0) }
-		request_handler: fn [mut pool] (req_buffer []u8, client_conn_fd int) ![]u8 {
-			return handle_request(req_buffer, client_conn_fd, mut pool)
+		request_handler: fn [mut pool] (req_buffer []u8, client_conn_fd int, mut out []u8) ! {
+			handle_request(req_buffer, client_conn_fd, mut out, mut pool)!
 		}
 	})!
 

--- a/examples/date_header/src/main.v
+++ b/examples/date_header/src/main.v
@@ -96,8 +96,8 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
 		io_multiplexing: backend
-		request_handler: fn [cache] (req_buffer []u8, fd int) ![]u8 {
-			return handle(req_buffer, fd, cache)
+		request_handler: fn [cache] (req_buffer []u8, fd int, mut out []u8) ! {
+			out << handle(req_buffer, fd, cache)!
 		}
 	})!
 	println('Date-header demo on http://localhost:3000/  (cached, refreshed 1x/s)')

--- a/examples/etag/src/main.v
+++ b/examples/etag/src/main.v
@@ -12,17 +12,17 @@ fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 
 	if method == 'GET' {
 		if path == '/' {
-			out << home_controller([])
+			out << home_controller([])!
 			return
 		} else if path.starts_with('/user/') {
 			id := path[6..]
 
-			out << get_user_controller([id], req)
+			out << get_user_controller([id], req)!
 			return
 		}
 	} else if method == 'POST' {
 		if path == '/user' {
-			out << create_user_controller([])
+			out << create_user_controller([])!
 			return
 		}
 	}

--- a/examples/etag/src/main.v
+++ b/examples/etag/src/main.v
@@ -4,7 +4,7 @@ import http_server
 import http_server.http1_1.response
 import http_server.http1_1.request_parser
 
-fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
+fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 
 	method := unsafe { tos(&req.buffer[req.method.start], req.method.len) }
@@ -12,19 +12,22 @@ fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
 
 	if method == 'GET' {
 		if path == '/' {
-			return home_controller([])
+			out << home_controller([])
+			return
 		} else if path.starts_with('/user/') {
 			id := path[6..]
 
-			return get_user_controller([id], req)
+			out << get_user_controller([id], req)
+			return
 		}
 	} else if method == 'POST' {
 		if path == '/user' {
-			return create_user_controller([])
+			out << create_user_controller([])
+			return
 		}
 	}
 
-	return response.tiny_bad_request_response
+	out << response.tiny_bad_request_response
 }
 
 fn main() {

--- a/examples/etag/src/main_test.v
+++ b/examples/etag/src/main_test.v
@@ -4,24 +4,32 @@ import http_server.http1_1.response
 
 fn test_handle_request_get_home() {
 	req_buffer := 'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n'.bytes()
-	res := handle_request(req_buffer, -1) or { panic(err) }
+	res := serve(req_buffer) or { panic(err) }
 	assert res == http_ok_response
 }
 
 fn test_handle_request_get_user() {
 	req_buffer := 'GET /user/123 HTTP/1.1\r\nHost: localhost\r\n\r\n'.bytes()
-	res := handle_request(req_buffer, -1) or { panic(err) }
+	res := serve(req_buffer) or { panic(err) }
 	assert res.bytestr() == 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nETag: 202cb962ac59075b964b07152d234b70\r\nContent-Length: 3\r\nAccess-Control-Allow-Origin: *\r\n\r\n123'
 }
 
 fn test_handle_request_post_user() {
 	req_buffer := 'POST /user HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n'.bytes()
-	res := handle_request(req_buffer, -1) or { panic(err) }
+	res := serve(req_buffer) or { panic(err) }
 	assert res == http_created_response
 }
 
 fn test_handle_request_bad_request() {
 	req_buffer := 'INVALID / HTTP/1.1\r\nHost: localhost\r\n\r\n'.bytes()
-	res := handle_request(req_buffer, -1) or { panic(err) }
+	res := serve(req_buffer) or { panic(err) }
 	assert res == response.tiny_bad_request_response
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(req []u8) ![]u8 {
+	mut out := []u8{}
+	handle_request(req, -1, mut out)!
+	return out
 }

--- a/examples/graceful_shutdown/src/main.v
+++ b/examples/graceful_shutdown/src/main.v
@@ -18,8 +18,8 @@ module main
 import http_server
 import os
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
-	return 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
+	out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 }
 
 fn main() {

--- a/examples/io_uring_demo/src/main.v
+++ b/examples/io_uring_demo/src/main.v
@@ -2,11 +2,11 @@ module main
 
 import http_server
 
-fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
+fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 	// Simple request handler that returns OK response
 	res :=
 		'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 13\r\nConnection: keep-alive\r\n\r\nHello, World!'.bytes()
-	return res
+	out << res
 }
 
 fn main() {

--- a/examples/ip_block/src/main.v
+++ b/examples/ip_block/src/main.v
@@ -4,8 +4,8 @@ module main
 //
 // Rejects requests from denied client IPs with 403 Forbidden, using the socket
 // peer address exposed by Phase 2 (`socket.peer_addr(fd)`). The handler keeps
-// the plain `fn ([]u8, int)` contract — it just reads the fd's peer when it
-// needs to decide.
+// the plain `fn ([]u8, int, mut []u8)` contract — it just reads the fd's peer
+// when it needs to decide.
 //
 // SECURITY / DESIGN notes:
 //   - Blocks by the SOCKET peer. Behind a proxy/CDN the peer IS the proxy, so
@@ -53,13 +53,14 @@ fn (mut b Blocklist) is_blocked(ip string) bool {
 const forbidden_response = 'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const ok_response = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 7\r\nConnection: keep-alive\r\n\r\nallowed'.bytes()
 
-fn handle(req_buffer []u8, fd int, mut blocklist Blocklist) ![]u8 {
+fn handle(req_buffer []u8, fd int, mut out []u8, mut blocklist Blocklist) ! {
 	ip := socket.peer_addr(fd)
 	if blocklist.is_blocked(ip) {
 		eprintln('[ip-block] denied ${ip}')
-		return forbidden_response
+		out << forbidden_response
+		return
 	}
-	return ok_response
+	out << ok_response
 }
 
 fn main() {
@@ -79,8 +80,8 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
 		io_multiplexing: backend
-		request_handler: fn [mut blocklist] (req_buffer []u8, fd int) ![]u8 {
-			return handle(req_buffer, fd, mut blocklist)
+		request_handler: fn [mut blocklist] (req_buffer []u8, fd int, mut out []u8) ! {
+			handle(req_buffer, fd, mut out, mut blocklist)!
 		}
 	})!
 	println('IP-block demo on http://localhost:3000/  (denied IPs get 403)')

--- a/examples/ip_block/src/main_test.v
+++ b/examples/ip_block/src/main_test.v
@@ -17,7 +17,9 @@ fn test_block_unblock_roundtrip() {
 fn test_allowed_ip_gets_200() ! {
 	mut b := Blocklist{}
 	// fd -1 => socket.peer_addr returns '' (not in the list) => allowed.
-	out := handle('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1, mut b)!.bytestr()
+	mut resp := []u8{}
+	handle('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1, mut resp, mut b)!
+	out := resp.bytestr()
 	assert out.contains('200 OK')
 	assert out.contains('allowed')
 }
@@ -26,6 +28,7 @@ fn test_blocked_ip_gets_403() ! {
 	mut b := Blocklist{}
 	// peer_addr('' for fd -1) — block that to drive the deny path through handle.
 	b.block('')
-	out := handle('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1, mut b)!.bytestr()
-	assert out.contains('403 Forbidden')
+	mut resp := []u8{}
+	handle('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1, mut resp, mut b)!
+	assert resp.bytestr().contains('403 Forbidden')
 }

--- a/examples/json_api/src/main.v
+++ b/examples/json_api/src/main.v
@@ -142,18 +142,20 @@ fn upload(req request_parser.HttpRequest) []u8 {
 
 // ----- routing -------------------------------------------------------------
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	method := req.method.to_string(req.buffer)
 	path := req.path.to_string(req.buffer)
 
 	if method == 'POST' && path == '/users' {
-		return create_user_json(req)
+		out << create_user_json(req)
+		return
 	}
 	if method == 'POST' && path == '/upload' {
-		return upload(req)
+		out << upload(req)
+		return
 	}
-	return bad_request('not found')
+	out << bad_request('not found')
 }
 
 fn main() {

--- a/examples/middleware/src/access_log.v
+++ b/examples/middleware/src/access_log.v
@@ -48,10 +48,10 @@ fn new_access_log(path string) !&AccessLog {
 // captured by pointer and shared across all workers.
 fn access_log_mw(log &AccessLog) Middleware {
 	return fn [log] (next Handler) Handler {
-		return fn [log, next] (req_buffer []u8, fd int) ![]u8 {
-			resp := next(req_buffer, fd)!
-			log.record(req_buffer, resp)
-			return resp
+		return fn [log, next] (req_buffer []u8, fd int, mut out []u8) ! {
+			start := out.len
+			next(req_buffer, fd, mut out)!
+			log.record(req_buffer, out[start..])
 		}
 	}
 }

--- a/examples/middleware/src/chain.v
+++ b/examples/middleware/src/chain.v
@@ -4,8 +4,9 @@ module main
 // chain() folds a list of them into one, ONCE at startup. No registry, no DI,
 // no per-request dispatch — Invariant 2 (zero abstraction).
 
-// Handler is the frozen core contract: bytes in (+ fd), bytes out.
-type Handler = fn ([]u8, int) ![]u8
+// Handler is the frozen core contract: bytes in (+ fd), response bytes
+// APPENDED to `out`.
+type Handler = fn ([]u8, int, mut []u8) !
 
 // Middleware takes the next handler and returns a wrapping handler.
 type Middleware = fn (Handler) Handler

--- a/examples/middleware/src/chain.v
+++ b/examples/middleware/src/chain.v
@@ -6,7 +6,7 @@ module main
 
 // Handler is the frozen core contract: bytes in (+ fd), response bytes
 // APPENDED to `out`.
-type Handler = fn ([]u8, int, mut []u8) !
+type Handler = fn (req []u8, fd int, mut out []u8) !
 
 // Middleware takes the next handler and returns a wrapping handler.
 type Middleware = fn (Handler) Handler

--- a/examples/middleware/src/controllers.v
+++ b/examples/middleware/src/controllers.v
@@ -19,9 +19,9 @@ const home_response = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nCont
 
 // route decodes the request and dispatches by path. This is the handler passed to
 // chain(); the global decorators wrap it.
-fn route(req_buffer []u8, _ int) ![]u8 {
+fn route(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
-	return match req.path.to_string(req.buffer) {
+	out << match req.path.to_string(req.buffer) {
 		'/' { handle_home(req) }
 		'/me' { handle_profile(req) }
 		'/admin' { handle_admin(req) }

--- a/examples/middleware/src/decorators.v
+++ b/examples/middleware/src/decorators.v
@@ -9,9 +9,15 @@ const security_headers = ('X-Content-Type-Options: nosniff\r\n' + 'X-Frame-Optio
 
 // with_security_headers injects the hardening headers into every response, once.
 fn with_security_headers(next Handler) Handler {
-	return fn [next] (req_buffer []u8, fd int) ![]u8 {
-		resp := next(req_buffer, fd)!
-		return inject_headers(resp, security_headers)
+	return fn [next] (req_buffer []u8, fd int, mut out []u8) ! {
+		start := out.len
+		next(req_buffer, fd, mut out)!
+		injected := inject_headers(out[start..], security_headers)
+		if injected.len == out.len - start {
+			return // nothing injected (malformed status line): out left untouched
+		}
+		out.trim(start)
+		out << injected
 	}
 }
 

--- a/examples/middleware/src/decorators.v
+++ b/examples/middleware/src/decorators.v
@@ -14,7 +14,7 @@ fn with_security_headers(next Handler) Handler {
 		next(req_buffer, fd, mut out)!
 		injected := inject_headers(out[start..], security_headers)
 		if injected.len == out.len - start {
-			return // nothing injected (malformed status line): out left untouched
+			return
 		}
 		out.trim(start)
 		out << injected

--- a/examples/middleware/src/main_test.v
+++ b/examples/middleware/src/main_test.v
@@ -40,23 +40,23 @@ fn test_inject_headers_noop_without_status_line() {
 // body's suffix order reveals the nesting (pure data flow, no shared state).
 fn tag_mw(tag string) Middleware {
 	return fn [tag] (next Handler) Handler {
-		return fn [tag, next] (req []u8, fd int) ![]u8 {
-			mut resp := next(req, fd)!
-			resp << tag.bytes()
-			return resp
+		return fn [tag, next] (req []u8, fd int, mut out []u8) ! {
+			next(req, fd, mut out)!
+			out << tag.bytes()
 		}
 	}
 }
 
 fn test_chain_runs_outermost_first() {
-	base := fn (req []u8, fd int) ![]u8 {
-		return 'app'.bytes()
+	base := fn (req []u8, fd int, mut out []u8) ! {
+		out << 'app'.bytes()
 	}
 	// A is OUTERMOST: it wraps B, which wraps app. On the way out the response
 	// unwinds app -> B -> A, so A's tag lands LAST.
 	h := chain(base, tag_mw('A'), tag_mw('B'))
-	out := h('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1)!.bytestr()
-	assert out == 'appBA'
+	mut out := []u8{}
+	h('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1, mut out)!
+	assert out.bytestr() == 'appBA'
 }
 
 // ── per-route auth policy through the composed handler ────────────────────────
@@ -68,7 +68,9 @@ fn serve(target string, auth string) string {
 		raw += 'Authorization: Bearer ${auth}\r\n'
 	}
 	raw += '\r\n'
-	return handler(raw.bytes(), -1) or { return 'ERR' }.bytestr()
+	mut out := []u8{}
+	handler(raw.bytes(), -1, mut out) or { return 'ERR' }
+	return out.bytestr()
 }
 
 fn test_public_route_needs_no_token() {

--- a/examples/observability/src/main.v
+++ b/examples/observability/src/main.v
@@ -63,7 +63,7 @@ fn status_of(resp []u8) int {
 }
 
 // observed wraps a handler: access log + metrics around every request.
-fn observed(next fn ([]u8, int, mut []u8) !, mut m Metrics) fn ([]u8, int, mut []u8) ! {
+fn observed(next fn (req []u8, fd int, mut out []u8) !, mut m Metrics) fn (req []u8, fd int, mut out []u8) ! {
 	return fn [next, mut m] (req_buffer []u8, fd int, mut out []u8) ! {
 		start := time.now()
 		req := request_parser.decode_http_request(req_buffer) or { return error('parse') }

--- a/examples/observability/src/main.v
+++ b/examples/observability/src/main.v
@@ -63,24 +63,24 @@ fn status_of(resp []u8) int {
 }
 
 // observed wraps a handler: access log + metrics around every request.
-fn observed(next fn ([]u8, int) ![]u8, mut m Metrics) fn ([]u8, int) ![]u8 {
-	return fn [next, mut m] (req_buffer []u8, fd int) ![]u8 {
+fn observed(next fn ([]u8, int, mut []u8) !, mut m Metrics) fn ([]u8, int, mut []u8) ! {
+	return fn [next, mut m] (req_buffer []u8, fd int, mut out []u8) ! {
 		start := time.now()
 		req := request_parser.decode_http_request(req_buffer) or { return error('parse') }
 		method := req.method.to_string(req.buffer)
 		path := req.path.to_string(req.buffer)
 
-		resp := next(req_buffer, fd) or {
+		start_len := out.len
+		next(req_buffer, fd, mut out) or {
 			m.record(500)
 			eprintln('level=error method=${method} path=${path} err=${err}')
 			return err
 		}
-		status := status_of(resp)
+		status := status_of(out[start_len..])
 		m.record(status)
 		dur_us := time.since(start).microseconds()
 		// One structured line per request.
 		println('level=info method=${method} path=${path} status=${status} dur_us=${dur_us}')
-		return resp
 	}
 }
 
@@ -111,8 +111,8 @@ fn app(req_buffer []u8, _ int, mut m Metrics) ![]u8 {
 
 fn main() {
 	mut m := &Metrics{}
-	handler := observed(fn [mut m] (req_buffer []u8, fd int) ![]u8 {
-		return app(req_buffer, fd, mut m)
+	handler := observed(fn [mut m] (req_buffer []u8, fd int, mut out []u8) ! {
+		out << app(req_buffer, fd, mut m)!
 	}, mut m)
 	// Explicit per-OS backend selection (other OSes keep the default = 0).
 	mut backend := unsafe { http_server.IOBackend(0) }

--- a/examples/proxy_aware/src/main.v
+++ b/examples/proxy_aware/src/main.v
@@ -73,7 +73,7 @@ fn real_client_ip(req request_parser.HttpRequest, fd int) string {
 	return hops.first()
 }
 
-fn handle(req_buffer []u8, fd int) ![]u8 {
+fn handle(req_buffer []u8, fd int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	client := real_client_ip(req, fd)
 	proto := if p := req.get_header_value_slice('X-Forwarded-Proto') {
@@ -82,7 +82,7 @@ fn handle(req_buffer []u8, fd int) ![]u8 {
 		'http'
 	}
 	body := '{"client_ip":"${client}","scheme":"${proto}"}'
-	return 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
 }
 
 fn main() {

--- a/examples/rate_limit/src/main.v
+++ b/examples/rate_limit/src/main.v
@@ -115,8 +115,8 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
 		io_multiplexing: backend
-		request_handler: fn [mut limiter] (req_buffer []u8, fd int) ![]u8 {
-			return handle(req_buffer, fd, mut limiter)
+		request_handler: fn [mut limiter] (req_buffer []u8, fd int, mut out []u8) ! {
+			out << handle(req_buffer, fd, mut limiter)!
 		}
 	})!
 	println('Rate-limit demo on http://localhost:3000/  (token bucket; needs real client IP from core)')

--- a/examples/redirects/src/main.v
+++ b/examples/redirects/src/main.v
@@ -35,7 +35,7 @@ fn safe_next(next string) string {
 	return '/' // reject absolute / protocol-relative targets
 }
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	method := req.method.to_string(req.buffer)
 	mut path := req.path.to_string(req.buffer)
@@ -46,7 +46,7 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 	match path {
 		'/old' {
 			// Canonical move: permanent, cacheable.
-			return redirect(301, 'Moved Permanently', '/new')
+			out << redirect(301, 'Moved Permanently', '/new')
 		}
 		'/login' {
 			if method == 'POST' {
@@ -56,16 +56,17 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 				} else {
 					'/dashboard'
 				}
-				return redirect(303, 'See Other', nxt)
+				out << redirect(303, 'See Other', nxt)
+				return
 			}
-			return 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n'.bytes()
 		}
 		'/api/v1/resource' {
 			// API redirect: preserve method + body.
-			return redirect(308, 'Permanent Redirect', '/api/v2/resource')
+			out << redirect(308, 'Permanent Redirect', '/api/v2/resource')
 		}
 		else {
-			return 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 		}
 	}
 }

--- a/examples/redirects/src/main_test.v
+++ b/examples/redirects/src/main_test.v
@@ -11,20 +11,28 @@ fn test_safe_next_rejects_offsite() {
 }
 
 fn test_permanent_move_301() ! {
-	out := handle('GET /old HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1)!.bytestr()
+	out := serve('GET /old HTTP/1.1\r\nHost: x\r\n\r\n'.bytes())!.bytestr()
 	assert out.contains('301 Moved Permanently')
 	assert out.contains('Location: /new')
 }
 
 fn test_api_redirect_preserves_method_308() ! {
 	out :=
-		handle('POST /api/v1/resource HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n'.bytes(), -1)!.bytestr()
+		serve('POST /api/v1/resource HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n'.bytes())!.bytestr()
 	assert out.contains('308 Permanent Redirect') // method+body preserving
 }
 
 fn test_post_redirect_get_303() ! {
 	out :=
-		handle('POST /login?next=/profile HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n'.bytes(), -1)!.bytestr()
+		serve('POST /login?next=/profile HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n'.bytes())!.bytestr()
 	assert out.contains('303 See Other')
 	assert out.contains('Location: /profile')
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(req []u8) ![]u8 {
+	mut out := []u8{}
+	handle(req, -1, mut out)!
+	return out
 }

--- a/examples/request_limits/src/main.v
+++ b/examples/request_limits/src/main.v
@@ -30,8 +30,8 @@ import http_server
 // handler ever runs — over-large bodies are rejected (413) from Content-Length
 // WITHOUT buffering them, and oversized header blocks get 431. That's the whole
 // point: limits belong in the read loop, not bolted onto each handler.
-fn handle(req_buffer []u8, _ int) ![]u8 {
-	return 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
+	out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 }
 
 fn main() {

--- a/examples/request_limits/src/main_test.v
+++ b/examples/request_limits/src/main_test.v
@@ -8,7 +8,15 @@ module main
 
 fn test_handler_is_trivial_200() ! {
 	req := 'POST /u HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\n0123456789'.bytes()
-	assert handle(req, -1)!.bytestr().contains('200 OK')
+	assert serve(req)!.bytestr().contains('200 OK')
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(req []u8) ![]u8 {
+	mut out := []u8{}
+	handle(req, -1, mut out)!
+	return out
 }
 
 /*

--- a/examples/security_headers/src/main.v
+++ b/examples/security_headers/src/main.v
@@ -30,22 +30,24 @@ const security_headers = 'Strict-Transport-Security: max-age=63072000; includeSu
 
 // with_security_headers wraps any handler and injects the headers into its
 // response, right after the status line. Composition, not inheritance.
-fn with_security_headers(next fn ([]u8, int) ![]u8) fn ([]u8, int) ![]u8 {
-	return fn [next] (req_buffer []u8, fd int) ![]u8 {
-		resp := next(req_buffer, fd)!
-		s := resp.bytestr()
+fn with_security_headers(next fn ([]u8, int, mut []u8) !) fn ([]u8, int, mut []u8) ! {
+	return fn [next] (req_buffer []u8, fd int, mut out []u8) ! {
+		start := out.len
+		next(req_buffer, fd, mut out)!
+		s := out[start..].bytestr()
 		// Insert headers after the first CRLF (the status line).
-		idx := s.index('\r\n') or { return resp }
+		idx := s.index('\r\n') or { return }
 		injected := s[..idx + 2] + security_headers + s[idx + 2..]
-		return injected.bytes()
+		out.trim(start)
+		out << injected.bytes()
 	}
 }
 
-fn app(req_buffer []u8, _ int) ![]u8 {
+fn app(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	_ := req
 	body := '<h1>secure</h1>'
-	return 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
 }
 
 fn main() {

--- a/examples/security_headers/src/main.v
+++ b/examples/security_headers/src/main.v
@@ -30,7 +30,7 @@ const security_headers = 'Strict-Transport-Security: max-age=63072000; includeSu
 
 // with_security_headers wraps any handler and injects the headers into its
 // response, right after the status line. Composition, not inheritance.
-fn with_security_headers(next fn ([]u8, int, mut []u8) !) fn ([]u8, int, mut []u8) ! {
+fn with_security_headers(next fn (req []u8, fd int, mut out []u8) !) fn (req []u8, fd int, mut out []u8) ! {
 	return fn [next] (req_buffer []u8, fd int, mut out []u8) ! {
 		start := out.len
 		next(req_buffer, fd, mut out)!

--- a/examples/security_headers/src/main_test.v
+++ b/examples/security_headers/src/main_test.v
@@ -6,8 +6,7 @@ module main
 // place (after the status line, before the body).
 
 fn test_wrapper_injects_all_headers() ! {
-	wrapped := with_security_headers(app)
-	out := wrapped('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1)!.bytestr()
+	out := serve('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes())!.bytestr()
 
 	assert out.contains('Strict-Transport-Security: max-age=')
 	assert out.contains("Content-Security-Policy: default-src 'self'")
@@ -18,12 +17,20 @@ fn test_wrapper_injects_all_headers() ! {
 }
 
 fn test_status_line_and_body_preserved() ! {
-	wrapped := with_security_headers(app)
-	out := wrapped('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), -1)!.bytestr()
+	out := serve('GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes())!.bytestr()
 	assert out.starts_with('HTTP/1.1 200 OK\r\n') // status line still first
 	assert out.contains('<h1>secure</h1>') // body intact
 	// headers go between status line and the body
 	hsts_at := out.index('Strict-Transport-Security') or { -1 }
 	body_at := out.index('<h1>') or { -1 }
 	assert hsts_at > 0 && body_at > hsts_at
+}
+
+// serve runs a request through the security-headers wrapper and returns the
+// response bytes, adapting the raw-handler contract for the assertions.
+fn serve(req []u8) ![]u8 {
+	wrapped := with_security_headers(app)
+	mut out := []u8{}
+	wrapped(req, -1, mut out)!
+	return out
 }

--- a/examples/simple/src/main.v
+++ b/examples/simple/src/main.v
@@ -12,16 +12,16 @@ fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 
 	if method == 'GET' {
 		if path == '/' {
-			out << home_controller([])
+			out << home_controller([])!
 			return
 		} else if path.starts_with('/user/') {
 			id := path[6..]
-			out << get_user_controller([id])
+			out << get_user_controller([id])!
 			return
 		}
 	} else if method == 'POST' {
 		if path == '/user' {
-			out << create_user_controller([])
+			out << create_user_controller([])!
 			return
 		}
 	}

--- a/examples/simple/src/main.v
+++ b/examples/simple/src/main.v
@@ -4,7 +4,7 @@ import http_server
 import http_server.http1_1.response
 import http_server.http1_1.request_parser
 
-fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
+fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 
 	method := unsafe { tos(&req.buffer[req.method.start], req.method.len) }
@@ -12,18 +12,21 @@ fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
 
 	if method == 'GET' {
 		if path == '/' {
-			return home_controller([])
+			out << home_controller([])
+			return
 		} else if path.starts_with('/user/') {
 			id := path[6..]
-			return get_user_controller([id])
+			out << get_user_controller([id])
+			return
 		}
 	} else if method == 'POST' {
 		if path == '/user' {
-			return create_user_controller([])
+			out << create_user_controller([])
+			return
 		}
 	}
 
-	return response.tiny_bad_request_response
+	out << response.tiny_bad_request_response
 }
 
 fn main() {

--- a/examples/simple/src/main_test.v
+++ b/examples/simple/src/main_test.v
@@ -11,8 +11,16 @@ fn test_simple_without_init_the_server() {
 	request2_response :=
 		'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 3\r\nConnection: keep-alive\r\n\r\n123'.bytes()
 
-	assert handle_request(request1, -1)! == http_ok_response
-	assert handle_request(request2, -1)! == request2_response
-	assert handle_request(request3, -1)! == http_created_response
-	assert handle_request(request4, -1)! == response.tiny_bad_request_response
+	assert serve(request1)! == http_ok_response
+	assert serve(request2)! == request2_response
+	assert serve(request3)! == http_created_response
+	assert serve(request4)! == response.tiny_bad_request_response
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(req []u8) ![]u8 {
+	mut out := []u8{}
+	handle_request(req, -1, mut out)!
+	return out
 }

--- a/examples/simple2/src/main.v
+++ b/examples/simple2/src/main.v
@@ -4,7 +4,7 @@ import http_server
 import http_server.http1_1.request_parser
 import http_server.http1_1.response
 
-fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
+fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	method := req.method.to_string(req.buffer)
 	path := req.path.to_string(req.buffer)
@@ -13,32 +13,37 @@ fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
 		'GET' {
 			match path {
 				'/' {
-					return home_controller([])
+					out << home_controller([])
+					return
 				}
 				'/users' {
-					return get_users_controller([])
+					out << get_users_controller([])
+					return
 				}
 				else {
 					if path.starts_with('/user/') {
 						id := path[6..]
-						return get_user_controller([id])
+						out << get_user_controller([id])
+						return
 					}
-					return response.tiny_bad_request_response
+					out << response.tiny_bad_request_response
+					return
 				}
 			}
 		}
 		'POST' {
 			if path == '/user' {
-				return create_user_controller([])
+				out << create_user_controller([])
+				return
 			}
-			return response.tiny_bad_request_response
+			out << response.tiny_bad_request_response
+			return
 		}
 		else {
-			return response.tiny_bad_request_response
+			out << response.tiny_bad_request_response
+			return
 		}
 	}
-
-	return response.tiny_bad_request_response
 }
 
 fn main() {

--- a/examples/simple2/src/main.v
+++ b/examples/simple2/src/main.v
@@ -13,17 +13,17 @@ fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 		'GET' {
 			match path {
 				'/' {
-					out << home_controller([])
+					out << home_controller([])!
 					return
 				}
 				'/users' {
-					out << get_users_controller([])
+					out << get_users_controller([])!
 					return
 				}
 				else {
 					if path.starts_with('/user/') {
 						id := path[6..]
-						out << get_user_controller([id])
+						out << get_user_controller([id])!
 						return
 					}
 					out << response.tiny_bad_request_response
@@ -33,7 +33,7 @@ fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 		}
 		'POST' {
 			if path == '/user' {
-				out << create_user_controller([])
+				out << create_user_controller([])!
 				return
 			}
 			out << response.tiny_bad_request_response

--- a/examples/simple2/src/main_test.v
+++ b/examples/simple2/src/main_test.v
@@ -4,24 +4,32 @@ import http_server.http1_1.response
 
 fn test_handle_request_get_home() {
 	req_buffer := 'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n'.bytes()
-	res := handle_request(req_buffer, -1) or { panic(err) }
+	res := serve(req_buffer) or { panic(err) }
 	assert res == http_ok_response
 }
 
 fn test_handle_request_get_user() {
 	req_buffer := 'GET /user/123 HTTP/1.1\r\nHost: localhost\r\n\r\n'.bytes()
-	res := handle_request(req_buffer, -1) or { panic(err) }
+	res := serve(req_buffer) or { panic(err) }
 	assert res == 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 3\r\nConnection: keep-alive\r\n\r\n123'.bytes()
 }
 
 fn test_handle_request_post_user() {
 	req_buffer := 'POST /user HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n'.bytes()
-	res := handle_request(req_buffer, -1) or { panic(err) }
+	res := serve(req_buffer) or { panic(err) }
 	assert res == http_created_response
 }
 
 fn test_handle_request_bad_request() {
 	req_buffer := 'INVALID / HTTP/1.1\r\nHost: localhost\r\n\r\n'.bytes()
-	res := handle_request(req_buffer, -1) or { panic(err) }
+	res := serve(req_buffer) or { panic(err) }
 	assert res == response.tiny_bad_request_response
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(req []u8) ![]u8 {
+	mut out := []u8{}
+	handle_request(req, -1, mut out)!
+	return out
 }

--- a/examples/simple3/src/main.v
+++ b/examples/simple3/src/main.v
@@ -12,7 +12,7 @@ pub mut:
 	db_pool ?pool.ConnectionPool
 }
 
-fn (app App) handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
+fn (app App) handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 
 	method := unsafe { tos(&req.buffer[req.method.start], req.method.len) }
@@ -20,17 +20,20 @@ fn (app App) handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
 
 	if method == 'GET' {
 		if path == '/' {
-			return app.home_controller(req)
+			out << app.home_controller(req)
+			return
 		} else if path.starts_with('/user/') {
-			return app.get_user_controller(req)
+			out << app.get_user_controller(req)
+			return
 		}
 	} else if method == 'POST' {
 		if path == '/user' {
-			return app.create_user_controller(req)
+			out << app.create_user_controller(req)
+			return
 		}
 	}
 
-	return response.tiny_bad_request_response
+	out << response.tiny_bad_request_response
 }
 
 fn main() {
@@ -53,8 +56,8 @@ fn main() {
 
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
-		request_handler: fn [app] (req_buffer []u8, client_conn_fd int) ![]u8 {
-			return app.handle_request(req_buffer, client_conn_fd)
+		request_handler: fn [app] (req_buffer []u8, client_conn_fd int, mut out []u8) ! {
+			app.handle_request(req_buffer, client_conn_fd, mut out)!
 		}
 		io_multiplexing: unsafe { http_server.IOBackend(0) }
 	})!

--- a/examples/simple3/src/main.v
+++ b/examples/simple3/src/main.v
@@ -20,15 +20,15 @@ fn (app App) handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) !
 
 	if method == 'GET' {
 		if path == '/' {
-			out << app.home_controller(req)
+			out << app.home_controller(req)!
 			return
 		} else if path.starts_with('/user/') {
-			out << app.get_user_controller(req)
+			out << app.get_user_controller(req)!
 			return
 		}
 	} else if method == 'POST' {
 		if path == '/user' {
-			out << app.create_user_controller(req)
+			out << app.create_user_controller(req)!
 			return
 		}
 	}

--- a/examples/simple3/src/main_test.v
+++ b/examples/simple3/src/main_test.v
@@ -13,8 +13,16 @@ fn test_simple_without_init_the_server() {
 
 	app := App{}
 
-	assert app.handle_request(request1, -1)! == http_ok_response
-	assert app.handle_request(request2, -1)! == request2_response
-	assert app.handle_request(request3, -1)! == http_created_response
-	assert app.handle_request(request4, -1)! == response.tiny_bad_request_response
+	assert serve(app, request1)! == http_ok_response
+	assert serve(app, request2)! == request2_response
+	assert serve(app, request3)! == http_created_response
+	assert serve(app, request4)! == response.tiny_bad_request_response
+}
+
+// serve adapts the raw-handler contract (writes into a caller-owned buffer) to
+// the return-a-buffer shape the assertions expect.
+fn serve(app App, req []u8) ![]u8 {
+	mut out := []u8{}
+	app.handle_request(req, -1, mut out)!
+	return out
 }

--- a/examples/sse/src/main.v
+++ b/examples/sse/src/main.v
@@ -86,7 +86,7 @@ const ok_response = ('HTTP/1.1 200 OK\r\n' + 'Content-Length: 0\r\n' +
 const bad_request = ('HTTP/1.1 400 Bad Request\r\n' + 'Content-Length: 0\r\n' +
 	'Connection: close\r\n' + '\r\n').bytes()
 
-fn handle(req_buffer []u8, fd int, mut clients Clients) ![]u8 {
+fn handle(req_buffer []u8, fd int, mut out []u8, mut clients Clients) ! {
 	// The kernel recycles fd numbers: a NEW request arriving on an fd that is
 	// still in the subscriber set means that subscription is stale — the old
 	// stream's connection was closed by the core and its number reused. Drop
@@ -102,17 +102,19 @@ fn handle(req_buffer []u8, fd int, mut clients Clients) ![]u8 {
 	//                and leaves the connection open. The broadcaster owns it now.
 	if method == 'GET' && path == '/events' {
 		clients.add(fd)
-		return sse_headers
+		out << sse_headers
+		return
 	}
 
 	// POST /broadcast — fan a message out to every subscriber, right now.
 	if method == 'POST' && path == '/broadcast' {
 		body := req.body.to_string(req.buffer)
 		clients.broadcast('data: ${body}\n\n'.bytes())
-		return ok_response
+		out << ok_response
+		return
 	}
 
-	return bad_request
+	out << bad_request
 }
 
 fn main() {
@@ -138,8 +140,8 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
 		io_multiplexing: backend
-		request_handler: fn [mut clients] (req_buffer []u8, fd int) ![]u8 {
-			return handle(req_buffer, fd, mut clients)
+		request_handler: fn [mut clients] (req_buffer []u8, fd int, mut out []u8) ! {
+			handle(req_buffer, fd, mut out, mut clients)!
 		}
 	})!
 	println('SSE server on http://localhost:3000/  (GET /events, POST /broadcast)')

--- a/examples/sse/src/main_test.v
+++ b/examples/sse/src/main_test.v
@@ -6,7 +6,9 @@ module main
 
 fn test_subscribe_returns_event_stream_and_registers_fd() ! {
 	mut clients := Clients{}
-	out := handle('GET /events HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), 7, mut clients)!.bytestr()
+	mut resp := []u8{}
+	handle('GET /events HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), 7, mut resp, mut clients)!
+	out := resp.bytestr()
 	assert out.contains('Content-Type: text/event-stream')
 	assert !out.contains('Content-Length:') // a stream stays open, no fixed length
 	assert clients.snapshot().len == 1 // fd registered; cost is one map entry
@@ -14,14 +16,17 @@ fn test_subscribe_returns_event_stream_and_registers_fd() ! {
 
 fn test_broadcast_endpoint_accepts() ! {
 	mut clients := Clients{} // empty set: no real fds to write to
-	out := handle('POST /broadcast HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello'.bytes(), 7, mut
-		clients)!.bytestr()
-	assert out.contains('200 OK')
+	mut resp := []u8{}
+	handle('POST /broadcast HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello'.bytes(), 7, mut resp, mut
+		clients)!
+	assert resp.bytestr().contains('200 OK')
 }
 
 fn test_unknown_route_is_bad_request() ! {
 	mut clients := Clients{}
-	assert handle('GET /nope HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), 7, mut clients)!.bytestr().contains('400')
+	mut resp := []u8{}
+	handle('GET /nope HTTP/1.1\r\nHost: x\r\n\r\n'.bytes(), 7, mut resp, mut clients)!
+	assert resp.bytestr().contains('400')
 }
 
 /*

--- a/examples/static_files/src/main.v
+++ b/examples/static_files/src/main.v
@@ -83,12 +83,13 @@ fn parse_range(range_header string, size i64) ?(i64, i64) {
 	return start, end
 }
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	method := req.method.to_string(req.buffer)
 	mut path := req.path.to_string(req.buffer)
 	if method != 'GET' && method != 'HEAD' {
-		return 'HTTP/1.1 405 Method Not Allowed\r\nAllow: GET, HEAD\r\nContent-Length: 0\r\n\r\n'.bytes()
+		out << 'HTTP/1.1 405 Method Not Allowed\r\nAllow: GET, HEAD\r\nContent-Length: 0\r\n\r\n'.bytes()
+		return
 	}
 	// Strip query string for file lookup.
 	if qi := path.index('?') {
@@ -98,19 +99,27 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 		path = '/index.html'
 	}
 
-	fs_path := safe_path(path) or { return not_found() }
+	fs_path := safe_path(path) or {
+		out << not_found()
+		return
+	}
 	if !os.is_file(fs_path) {
-		return not_found()
+		out << not_found()
+		return
 	}
 
-	content := os.read_bytes(fs_path) or { return not_found() }
+	content := os.read_bytes(fs_path) or {
+		out << not_found()
+		return
+	}
 	ctype := mime_type(fs_path)
 	etag := md5.sum(content).hex()
 
 	// Conditional GET: if the client's cached ETag matches, save the bytes.
 	if inm := req.get_header_value_slice('If-None-Match') {
 		if inm.to_string(req.buffer) == '"${etag}"' {
-			return 'HTTP/1.1 304 Not Modified\r\nETag: "${etag}"\r\n\r\n'.bytes()
+			out << 'HTTP/1.1 304 Not Modified\r\nETag: "${etag}"\r\n\r\n'.bytes()
+			return
 		}
 	}
 
@@ -128,7 +137,8 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 			if method == 'GET' {
 				sb.write(slice) or {}
 			}
-			return sb
+			out << sb
+			return
 		}
 	}
 
@@ -143,7 +153,7 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 	if method == 'GET' {
 		sb.write(content) or {}
 	}
-	return sb
+	out << sb
 }
 
 fn main() {

--- a/examples/tiny/src/main.v
+++ b/examples/tiny/src/main.v
@@ -5,8 +5,8 @@ import http_server
 
 const hello_world_response = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 13\r\nConnection: keep-alive\r\n\r\nHello, World!'.bytes()
 
-fn handle_request(req_buffer []u8, client_conn_fd int) ![]u8 {
-	return hello_world_response
+fn handle_request(req_buffer []u8, client_conn_fd int, mut out []u8) ! {
+	out << hello_world_response
 }
 
 fn main() {

--- a/examples/url_form/src/main.v
+++ b/examples/url_form/src/main.v
@@ -80,7 +80,7 @@ fn parse_form(s string) map[string]string {
 	return out
 }
 
-fn handle(req_buffer []u8, _ int) ![]u8 {
+fn handle(req_buffer []u8, _ int, mut out []u8) ! {
 	req := request_parser.decode_http_request(req_buffer)!
 	method := req.method.to_string(req.buffer)
 	path := req.path.to_string(req.buffer)
@@ -109,7 +109,7 @@ fn handle(req_buffer []u8, _ int) ![]u8 {
 		parts << '"${k}":"${v}"'
 	}
 	body := '{${parts.join(',')}}'
-	return 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
 }
 
 fn main() {

--- a/examples/veb_like/main.v
+++ b/examples/veb_like/main.v
@@ -132,8 +132,8 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
 		io_multiplexing: backend
-		request_handler: fn [app] (req_buffer []u8, client_conn_fd int) ![]u8 {
-			return router(req_buffer, client_conn_fd, app)
+		request_handler: fn [app] (req_buffer []u8, client_conn_fd int, mut out []u8) ! {
+			out << router(req_buffer, client_conn_fd, app)!
 		}
 		// Production limits: bound resource use so a single client can't exhaust
 		// the server. All default to 0 (unlimited) — set explicitly here.

--- a/examples/video_stream/src/main.v
+++ b/examples/video_stream/src/main.v
@@ -12,7 +12,7 @@ module main
 //                multipart/x-mixed-replace. One capture thread fans frames out to
 //                every viewer fd — no thread per viewer (see capture.v).
 //
-// Both keep the project's contract: the handler is still fn ([]u8, int) ![]u8.
+// Both keep the project's contract: the handler is still fn ([]u8, int, mut []u8) !.
 // /video returns the response bytes (the core streams large ones via EPOLLOUT
 // back-pressure); /webcam registers the fd and a single broadcaster owns it.
 import http_server
@@ -169,8 +169,8 @@ fn main() {
 	mut server := http_server.new_server(http_server.ServerConfig{
 		port:            3000
 		io_multiplexing: backend
-		request_handler: fn [mut viewers] (req_buffer []u8, fd int) ![]u8 {
-			return handle(req_buffer, fd, mut viewers)
+		request_handler: fn [mut viewers] (req_buffer []u8, fd int, mut out []u8) ! {
+			out << handle(req_buffer, fd, mut viewers)!
 		}
 		limits:          http_server.Limits{
 			max_header_bytes: 16 * 1024

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -13,7 +13,9 @@ module backend_epoll
 //     partial bytes are compacted to the front, and the whole batch goes out
 //     in ONE send;
 //   • backpressure — a batch that can't be sent in one go is parked and
-//     drained on EPOLLOUT (write_timeout guarded), never truncated.
+//     drained on EPOLLOUT (write_timeout guarded), never truncated; a peer
+//     that pipelines requests without reading responses is closed once its
+//     pending batch exceeds sm_max_pending_write.
 import http_server.core
 import http_server.epoll
 import http_server.http1_1.request_parser
@@ -33,6 +35,9 @@ fn C.send(__fd int, __buf voidptr, __n usize, __flags int) int
 fn C.memmove(__dest voidptr, __src voidptr, __n usize) voidptr
 
 const sm_max_request_bytes = 8 * 1024 * 1024
+// Write-side cap: close a connection whose peer pipelines requests but never
+// drains responses (otherwise write_buf would grow without bound).
+const sm_max_pending_write = 8 * 1024 * 1024
 const read_buf_cap = 8 * 1024
 const write_buf_cap = 16 * 1024
 const conn_table_min = 1024
@@ -76,7 +81,7 @@ fn state_for(mut st PlainState, fd int) &ConnState {
 			new_len *= 2
 		}
 		for st.conns.len < new_len {
-			st.conns << &ConnState(unsafe { nil })
+			st.conns << unsafe { nil }
 		}
 	}
 	if unsafe { st.conns[fd] == nil } {
@@ -89,23 +94,25 @@ fn state_for(mut st PlainState, fd int) &ConnState {
 }
 
 // handle_readable_plain drains the socket into the connection's persistent
-// read buffer, answers EVERY complete request in it (pipelining), compacts
-// the leftover, and flushes all responses in one batched send.
+// read buffer, answers EVERY complete request as it goes (pipelining), and
+// flushes all accumulated responses in one batched send at the end of the
+// burst. Returns early (connection closed) on any fatal condition.
 @[direct_array_access; manualfree]
-fn handle_readable_plain(request_handler fn ([]u8, int, mut []u8) !, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState) {
+fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState) {
 	stdatomic.add_i64(&counter.n, 1)
 	defer {
 		stdatomic.add_i64(&counter.n, -1)
 	}
 
 	mut cs := state_for(mut st, fd)
-
-	// Drain this edge into the persistent buffer (edge-triggered: read to EAGAIN).
 	req_cap := if limits.max_request_bytes > 0 {
 		limits.max_request_bytes
 	} else {
 		sm_max_request_bytes
 	}
+
+	// Edge-triggered: read to EAGAIN. Parse after every recv so the request
+	// cap applies to a single (partial) request, not to the whole burst.
 	for {
 		if cs.read_buf.len == cs.read_buf.cap {
 			unsafe { cs.read_buf.grow_cap(cs.read_buf.cap) }
@@ -127,56 +134,24 @@ fn handle_readable_plain(request_handler fn ([]u8, int, mut []u8) !, epoll_fd in
 		unsafe {
 			cs.read_buf.len += n
 		}
+		// Answer every complete request currently buffered; false ⇒ closed.
+		if !drain_requests(request_handler, epoll_fd, fd, limits, active_conns, mut st, mut
+			cs) {
+			return
+		}
+		// After draining, read_buf holds at most one partial request.
 		if cs.read_buf.len > req_cap {
-			response.send_status_413_response(fd)
-			close_conn(epoll_fd, fd, active_conns, mut st)
-			return
-		}
-	}
-
-	// Answer every complete pipelined request in the buffer.
-	mut pos := 0
-	for pos < cs.read_buf.len {
-		total := request_parser.frame_request_length_lim(cs.read_buf[pos..], limits.max_header_bytes,
-			limits.max_body_bytes) or {
-			flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) // drain what was answered
-			match err.code() {
-				413 { response.send_status_413_response(fd) }
-				431 { response.send_status_431_response(fd) }
-				else { response.send_bad_request_response(fd) }
+			cs.write_buf << response.status_413_response
+			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+				close_conn(epoll_fd, fd, active_conns, mut st)
 			}
-			close_conn(epoll_fd, fd, active_conns, mut st)
 			return
-		}
-		if total < 0 {
-			break // incomplete — wait for the next edge
-		}
-		req := cs.read_buf[pos..pos + total] // zero-copy view into the read buffer
-		request_handler(req, fd, mut cs.write_buf) or {
-			cs.write_buf << response.tiny_bad_request_response
-			flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
-			close_conn(epoll_fd, fd, active_conns, mut st)
-			return
-		}
-		pos += total
-	}
-
-	// Compact leftover partial bytes to the buffer start (keeps capacity).
-	leftover := cs.read_buf.len - pos
-	if pos > 0 {
-		if leftover > 0 {
-			unsafe {
-				C.memmove(cs.read_buf.data, &u8(cs.read_buf.data) + pos, usize(leftover))
-			}
-		}
-		unsafe {
-			cs.read_buf.len = leftover
 		}
 	}
 
 	// Read-timeout bookkeeping: armed once when a request is mid-read,
 	// cleared when the buffer holds no partial request.
-	if leftover > 0 {
+	if cs.read_buf.len > 0 {
 		if limits.read_timeout_ms > 0 && cs.read_deadline == 0 {
 			cs.read_deadline = time.sys_mono_now() + u64(limits.read_timeout_ms) * 1_000_000
 			st.parked++
@@ -192,10 +167,69 @@ fn handle_readable_plain(request_handler fn ([]u8, int, mut []u8) !, epoll_fd in
 	}
 }
 
+// drain_requests parses and answers every complete request in read_buf,
+// appending responses to write_buf, then compacts the leftover partial bytes
+// to the buffer front. Returns false if the connection was closed.
+@[direct_array_access; manualfree]
+fn drain_requests(request_handler core.RequestHandler, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) bool {
+	mut pos := 0
+	for pos < cs.read_buf.len {
+		total := request_parser.frame_request_length_lim(cs.read_buf[pos..], limits.max_header_bytes,
+			limits.max_body_bytes) or {
+			// Append the canned error so it lands AFTER the responses already
+			// batched for this burst, then flush and close.
+			match err.code() {
+				413 { cs.write_buf << response.status_413_response }
+				431 { cs.write_buf << response.status_431_response }
+				else { cs.write_buf << response.tiny_bad_request_response }
+			}
+			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+				close_conn(epoll_fd, fd, active_conns, mut st)
+			}
+			return false
+		}
+		if total < 0 {
+			break // incomplete — wait for more bytes
+		}
+		req := cs.read_buf[pos..pos + total] // zero-copy view into the read buffer
+		request_handler(req, fd, mut cs.write_buf) or {
+			cs.write_buf << response.tiny_bad_request_response
+			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+				close_conn(epoll_fd, fd, active_conns, mut st)
+			}
+			return false
+		}
+		pos += total
+		// Peer pipelines requests but never reads responses: bail out before
+		// the pending batch grows without bound.
+		if cs.write_buf.len - cs.write_off > sm_max_pending_write {
+			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+				close_conn(epoll_fd, fd, active_conns, mut st)
+			}
+			return false
+		}
+	}
+
+	// Compact leftover partial bytes to the buffer start (keeps capacity).
+	if pos > 0 {
+		leftover := cs.read_buf.len - pos
+		if leftover > 0 {
+			unsafe {
+				C.memmove(cs.read_buf.data, &u8(cs.read_buf.data) + pos, usize(leftover))
+			}
+		}
+		unsafe {
+			cs.read_buf.len = leftover
+		}
+	}
+	return true
+}
+
 // flush_batch writes all pending response bytes, or parks the remainder for
 // EPOLLOUT. The write buffer is reset (capacity kept) once fully sent.
+// Returns false if the connection was closed (callers must not touch it).
 @[manualfree]
-fn flush_batch(epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) {
+fn flush_batch(epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) bool {
 	for cs.write_off < cs.write_buf.len {
 		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off }, usize(cs.write_buf.len - cs.write_off),
 			C.MSG_NOSIGNAL)
@@ -210,10 +244,10 @@ fn flush_batch(epoll_fd int, fd int, limits core.Limits, active_conns &core.Coun
 				st.parked++
 			}
 			epoll.mod_fd_in_epoll(epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLOUT | C.EPOLLET))
-			return
+			return true // parked, still alive
 		}
 		close_conn(epoll_fd, fd, active_conns, mut st)
-		return
+		return false
 	}
 	cs.write_buf.clear() // len = 0, capacity kept for the next batch
 	cs.write_off = 0
@@ -221,22 +255,27 @@ fn flush_batch(epoll_fd int, fd int, limits core.Limits, active_conns &core.Coun
 		cs.write_deadline = 0
 		st.parked--
 	}
+	return true
 }
 
 // handle_writable_plain drains a parked batch when the socket is writable.
+// Returns false if the connection was closed (the worker must then skip any
+// further events for this fd in the current batch).
 @[direct_array_access; manualfree]
-fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut st PlainState) {
+fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut st PlainState) bool {
 	if fd >= st.conns.len {
-		return
+		return false
 	}
 	mut cs := st.conns[fd]
 	if unsafe { cs == nil } {
-		return
+		// EPOLLOUT is only armed after state exists; nil means a close raced
+		// this event in the same batch.
+		return false
 	}
 	if cs.write_off >= cs.write_buf.len {
 		// Spurious wake — nothing parked; stop watching writability.
 		epoll.mod_fd_in_epoll(epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLET))
-		return
+		return true
 	}
 	for cs.write_off < cs.write_buf.len {
 		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off }, usize(cs.write_buf.len - cs.write_off),
@@ -246,10 +285,10 @@ fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut s
 			continue
 		}
 		if n < 0 && (C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK) {
-			return
+			return true
 		}
 		close_conn(epoll_fd, fd, active_conns, mut st)
-		return
+		return false
 	}
 	cs.write_buf.clear()
 	cs.write_off = 0
@@ -258,6 +297,7 @@ fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut s
 		st.parked--
 	}
 	epoll.mod_fd_in_epoll(epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLET)) // stop watching writability
+	return true
 }
 
 // sweep_timeouts closes connections whose read/write deadline has passed.
@@ -282,7 +322,10 @@ fn sweep_timeouts(epoll_fd int, active_conns &core.Counter, mut st PlainState) {
 
 // close_conn frees the connection's buffers, clears its table slot and
 // releases the fd. The ConnState struct itself is reclaimed by the GC once
-// the slot no longer references it.
+// the slot no longer references it. NOT idempotent (release_conn always
+// runs): every close site must make sure it is the only one closing — the
+// bool returns of flush_batch / drain_requests / handle_writable_plain exist
+// exactly for that.
 @[direct_array_access; manualfree]
 fn close_conn(epoll_fd int, fd int, active_conns &core.Counter, mut st PlainState) {
 	if fd < st.conns.len {
@@ -298,7 +341,7 @@ fn close_conn(epoll_fd int, fd int, active_conns &core.Counter, mut st PlainStat
 				cs.read_buf.free()
 				cs.write_buf.free()
 			}
-			st.conns[fd] = &ConnState(unsafe { nil })
+			st.conns[fd] = unsafe { nil }
 		}
 	}
 	release_conn(epoll_fd, fd, active_conns)

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -118,8 +118,7 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 			unsafe { cs.read_buf.grow_cap(cs.read_buf.cap) }
 		}
 		spare := cs.read_buf.cap - cs.read_buf.len
-		n := C.recv(fd, unsafe { &u8(cs.read_buf.data) + cs.read_buf.len }, usize(spare),
-			0)
+		n := C.recv(fd, unsafe { &u8(cs.read_buf.data) + cs.read_buf.len }, usize(spare), 0)
 		if n < 0 {
 			if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
 				break // burst fully drained
@@ -135,8 +134,7 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 			cs.read_buf.len += n
 		}
 		// Answer every complete request currently buffered; false ⇒ closed.
-		if !drain_requests(request_handler, epoll_fd, fd, limits, active_conns, mut st, mut
-			cs) {
+		if !drain_requests(request_handler, epoll_fd, fd, limits, active_conns, mut st, mut cs) {
 			return
 		}
 		// After draining, read_buf holds at most one partial request.
@@ -174,8 +172,8 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 fn drain_requests(request_handler core.RequestHandler, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) bool {
 	mut pos := 0
 	for pos < cs.read_buf.len {
-		total := request_parser.frame_request_length_lim(cs.read_buf[pos..], limits.max_header_bytes,
-			limits.max_body_bytes) or {
+		total := request_parser.frame_request_length_lim(cs.read_buf[pos..],
+			limits.max_header_bytes, limits.max_body_bytes) or {
 			// Append the canned error so it lands AFTER the responses already
 			// batched for this burst, then flush and close.
 			match err.code() {
@@ -183,6 +181,7 @@ fn drain_requests(request_handler core.RequestHandler, epoll_fd int, fd int, lim
 				431 { cs.write_buf << response.status_431_response }
 				else { cs.write_buf << response.tiny_bad_request_response }
 			}
+
 			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
 				close_conn(epoll_fd, fd, active_conns, mut st)
 			}
@@ -231,16 +230,15 @@ fn drain_requests(request_handler core.RequestHandler, epoll_fd int, fd int, lim
 @[manualfree]
 fn flush_batch(epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) bool {
 	for cs.write_off < cs.write_buf.len {
-		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off }, usize(cs.write_buf.len - cs.write_off),
-			C.MSG_NOSIGNAL)
+		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off },
+			usize(cs.write_buf.len - cs.write_off), C.MSG_NOSIGNAL)
 		if n > 0 {
 			cs.write_off += n
 			continue
 		}
 		if n < 0 && (C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK) {
 			if limits.write_timeout_ms > 0 && cs.write_deadline == 0 {
-				cs.write_deadline = time.sys_mono_now() +
-					u64(limits.write_timeout_ms) * 1_000_000
+				cs.write_deadline = time.sys_mono_now() + u64(limits.write_timeout_ms) * 1_000_000
 				st.parked++
 			}
 			epoll.mod_fd_in_epoll(epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLOUT | C.EPOLLET))
@@ -278,8 +276,8 @@ fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut s
 		return true
 	}
 	for cs.write_off < cs.write_buf.len {
-		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off }, usize(cs.write_buf.len - cs.write_off),
-			C.MSG_NOSIGNAL)
+		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off },
+			usize(cs.write_buf.len - cs.write_off), C.MSG_NOSIGNAL)
 		if n > 0 {
 			cs.write_off += n
 			continue

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -2,16 +2,18 @@ module backend_epoll
 
 // Plain (non-TLS) connection state machine for the epoll worker.
 //
-// Resolves two Phase-1 blockers without slowing the common case:
-//   • cross-edge reads  — a request split across network round-trips is buffered
-//     per-fd and resumed on the next EPOLLIN (no premature close);
-//   • EPOLLOUT writes   — a response that can't be sent in one go is parked and
-//     drained on EPOLLOUT (backpressure), instead of being truncated/closed.
-//
-// Per-fd state lives in a per-worker `map[int]&ConnState` created ONLY for
-// connections that actually block mid-read or mid-write. The fast path (request
-// complete in one burst + response sent in one go) creates no entry and pays
-// only a `conns.len > 0` check — so the 510k baseline is preserved.
+// Shared-nothing hot path modeled on the fastest HTTP/1.1 servers
+// (see docs/PERF_GAP_ANALYSIS.md):
+//   • persistent per-connection buffers — every connection owns a reused read
+//     buffer (8 KiB) and write buffer (16 KiB) for its whole lifetime; no
+//     per-event allocation, no per-request free;
+//   • flat fd-indexed state table — O(1) lookup, no hashing;
+//   • HTTP/1.1 pipelining — one EPOLLIN burst may carry many requests; every
+//     complete request is parsed and answered into the write buffer, leftover
+//     partial bytes are compacted to the front, and the whole batch goes out
+//     in ONE send;
+//   • backpressure — a batch that can't be sent in one go is parked and
+//     drained on EPOLLOUT (write_timeout guarded), never truncated.
 import http_server.core
 import http_server.epoll
 import http_server.http1_1.request_parser
@@ -20,6 +22,7 @@ import sync.stdatomic
 import time
 
 #include <errno.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <sys/epoll.h>
 
@@ -27,146 +30,217 @@ import time
 // now in backend_epoll they must be declared here.
 fn C.recv(__fd int, __buf voidptr, __n usize, __flags int) int
 fn C.send(__fd int, __buf voidptr, __n usize, __flags int) int
+fn C.memmove(__dest voidptr, __src voidptr, __n usize) voidptr
 
 const sm_max_request_bytes = 8 * 1024 * 1024
+const read_buf_cap = 8 * 1024
+const write_buf_cap = 16 * 1024
+const conn_table_min = 1024
 
-// ConnState is only allocated for a connection that blocks mid-transfer.
+// ConnState is allocated once per connection (on its first event) and reused
+// until the connection closes. The buffers keep their capacity across
+// requests: read_buf accumulates request bytes across edges, write_buf
+// accumulates response bytes until they are flushed in one send.
 struct ConnState {
 mut:
-	read_buf       []u8 // partial request accumulated across epoll edges
-	write_buf      []u8 // response remaining to be sent
+	read_buf       []u8 // persistent request buffer; len = bytes buffered
+	write_buf      []u8 // persistent response buffer; [write_off..len) pending
 	write_off      int
 	read_deadline  u64 // monotonic ns; >0 while a request is mid-read (read_timeout)
-	write_deadline u64 // monotonic ns; >0 while a response is parked (write_timeout)
+	write_deadline u64 // monotonic ns; >0 while a batch is parked (write_timeout)
 }
 
+// PlainState is the per-worker connection table. `parked` counts connections
+// with an armed deadline, so the worker only pays for timeout sweeps when
+// something is actually mid-transfer.
+pub struct PlainState {
+mut:
+	conns  []&ConnState
+	parked int
+}
+
+pub fn new_plain_state() PlainState {
+	return PlainState{
+		conns: []&ConnState{len: conn_table_min, init: unsafe { nil }}
+	}
+}
+
+// state_for returns the connection state for fd, creating it (with its
+// persistent buffers) on first use. The table grows by doubling, so fd
+// indexing stays O(1) with no hashing.
+@[direct_array_access]
+fn state_for(mut st PlainState, fd int) &ConnState {
+	if fd >= st.conns.len {
+		mut new_len := st.conns.len
+		for new_len <= fd {
+			new_len *= 2
+		}
+		for st.conns.len < new_len {
+			st.conns << &ConnState(unsafe { nil })
+		}
+	}
+	if unsafe { st.conns[fd] == nil } {
+		st.conns[fd] = &ConnState{
+			read_buf:  []u8{len: 0, cap: read_buf_cap}
+			write_buf: []u8{len: 0, cap: write_buf_cap}
+		}
+	}
+	return st.conns[fd]
+}
+
+// handle_readable_plain drains the socket into the connection's persistent
+// read buffer, answers EVERY complete request in it (pipelining), compacts
+// the leftover, and flushes all responses in one batched send.
 @[direct_array_access; manualfree]
-fn handle_readable_plain(request_handler fn ([]u8, int) ![]u8, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut conns map[int]&ConnState) {
+fn handle_readable_plain(request_handler fn ([]u8, int, mut []u8) !, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState) {
 	stdatomic.add_i64(&counter.n, 1)
 	defer {
 		stdatomic.add_i64(&counter.n, -1)
 	}
 
-	// Resume a partial read from a previous edge (only if any state exists).
-	mut buf := []u8{len: 0, cap: 256}
-	if conns.len > 0 {
-		if mut cs := conns[fd] {
-			if cs.read_buf.len > 0 {
-				unsafe {
-					buf = cs.read_buf // take ownership (move, no copy)
-				}
-				cs.read_buf = []u8{}
-			}
-		}
-	}
+	mut cs := state_for(mut st, fd)
 
+	// Drain this edge into the persistent buffer (edge-triggered: read to EAGAIN).
+	req_cap := if limits.max_request_bytes > 0 {
+		limits.max_request_bytes
+	} else {
+		sm_max_request_bytes
+	}
 	for {
-		if buf.len == buf.cap {
-			unsafe { buf.grow_cap(buf.cap) }
+		if cs.read_buf.len == cs.read_buf.cap {
+			unsafe { cs.read_buf.grow_cap(cs.read_buf.cap) }
 		}
-		spare := buf.cap - buf.len
-		n := C.recv(fd, unsafe { &u8(buf.data) + buf.len }, usize(spare), 0)
+		spare := cs.read_buf.cap - cs.read_buf.len
+		n := C.recv(fd, unsafe { &u8(cs.read_buf.data) + cs.read_buf.len }, usize(spare),
+			0)
 		if n < 0 {
 			if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
-				if buf.len == 0 {
-					unsafe { buf.free() }
-					return
-				}
-				save_read(mut conns, fd, buf, limits.read_timeout_ms) // partial — resume on next EPOLLIN
-				return
+				break // burst fully drained
 			}
-			unsafe { buf.free() }
-			close_conn(epoll_fd, fd, active_conns, mut conns)
+			close_conn(epoll_fd, fd, active_conns, mut st)
 			return
 		}
 		if n == 0 {
-			unsafe { buf.free() }
-			close_conn(epoll_fd, fd, active_conns, mut conns)
+			close_conn(epoll_fd, fd, active_conns, mut st)
 			return
 		}
 		unsafe {
-			buf.len += n
+			cs.read_buf.len += n
 		}
-		req_cap := if limits.max_request_bytes > 0 {
-			limits.max_request_bytes
-		} else {
-			sm_max_request_bytes
-		}
-		if buf.len > req_cap {
-			unsafe { buf.free() }
+		if cs.read_buf.len > req_cap {
 			response.send_status_413_response(fd)
-			close_conn(epoll_fd, fd, active_conns, mut conns)
+			close_conn(epoll_fd, fd, active_conns, mut st)
 			return
 		}
-		total := request_parser.frame_request_length_lim(buf, limits.max_header_bytes,
+	}
+
+	// Answer every complete pipelined request in the buffer.
+	mut pos := 0
+	for pos < cs.read_buf.len {
+		total := request_parser.frame_request_length_lim(cs.read_buf[pos..], limits.max_header_bytes,
 			limits.max_body_bytes) or {
-			unsafe { buf.free() }
+			flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) // drain what was answered
 			match err.code() {
 				413 { response.send_status_413_response(fd) }
 				431 { response.send_status_431_response(fd) }
 				else { response.send_bad_request_response(fd) }
 			}
-
-			close_conn(epoll_fd, fd, active_conns, mut conns)
+			close_conn(epoll_fd, fd, active_conns, mut st)
 			return
 		}
-		if total >= 0 {
-			if buf.len > total {
-				buf.trim(total) // pipelined trailing bytes dropped (documented)
+		if total < 0 {
+			break // incomplete — wait for the next edge
+		}
+		req := cs.read_buf[pos..pos + total] // zero-copy view into the read buffer
+		request_handler(req, fd, mut cs.write_buf) or {
+			cs.write_buf << response.tiny_bad_request_response
+			flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
+			close_conn(epoll_fd, fd, active_conns, mut st)
+			return
+		}
+		pos += total
+	}
+
+	// Compact leftover partial bytes to the buffer start (keeps capacity).
+	leftover := cs.read_buf.len - pos
+	if pos > 0 {
+		if leftover > 0 {
+			unsafe {
+				C.memmove(cs.read_buf.data, &u8(cs.read_buf.data) + pos, usize(leftover))
 			}
-			break
 		}
-		// incomplete — keep draining this burst
-	}
-
-	// Request complete — clear any read deadline on this connection.
-	if conns.len > 0 {
-		if mut cs := conns[fd] {
-			cs.read_deadline = 0
+		unsafe {
+			cs.read_buf.len = leftover
 		}
 	}
 
-	resp := request_handler(buf, fd) or {
-		unsafe { buf.free() }
-		response.send_bad_request_response(fd)
-		close_conn(epoll_fd, fd, active_conns, mut conns)
-		return
+	// Read-timeout bookkeeping: armed once when a request is mid-read,
+	// cleared when the buffer holds no partial request.
+	if leftover > 0 {
+		if limits.read_timeout_ms > 0 && cs.read_deadline == 0 {
+			cs.read_deadline = time.sys_mono_now() + u64(limits.read_timeout_ms) * 1_000_000
+			st.parked++
+		}
+	} else if cs.read_deadline != 0 {
+		cs.read_deadline = 0
+		st.parked--
 	}
-	unsafe { buf.free() }
-	send_or_park(epoll_fd, fd, limits, active_conns, mut conns, resp)
+
+	// One send for the whole batch of responses.
+	if cs.write_buf.len > cs.write_off {
+		flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
+	}
 }
 
-// send_or_park writes the whole response, or parks the remainder for EPOLLOUT.
-// Takes ownership of `resp` (frees it when fully sent or parked-then-drained).
+// flush_batch writes all pending response bytes, or parks the remainder for
+// EPOLLOUT. The write buffer is reset (capacity kept) once fully sent.
 @[manualfree]
-fn send_or_park(epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut conns map[int]&ConnState, resp []u8) {
-	mut sent := 0
-	for sent < resp.len {
-		n := C.send(fd, unsafe { &u8(resp.data) + sent }, usize(resp.len - sent), C.MSG_NOSIGNAL)
+fn flush_batch(epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) {
+	for cs.write_off < cs.write_buf.len {
+		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off }, usize(cs.write_buf.len - cs.write_off),
+			C.MSG_NOSIGNAL)
 		if n > 0 {
-			sent += n
+			cs.write_off += n
 			continue
 		}
 		if n < 0 && (C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK) {
-			park_write(mut conns, fd, resp, sent, limits.write_timeout_ms) // ownership → parked
+			if limits.write_timeout_ms > 0 && cs.write_deadline == 0 {
+				cs.write_deadline = time.sys_mono_now() +
+					u64(limits.write_timeout_ms) * 1_000_000
+				st.parked++
+			}
 			epoll.mod_fd_in_epoll(epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLOUT | C.EPOLLET))
 			return
 		}
-		unsafe { resp.free() }
-		close_conn(epoll_fd, fd, active_conns, mut conns)
+		close_conn(epoll_fd, fd, active_conns, mut st)
 		return
 	}
-	unsafe { resp.free() }
-	cleanup_if_idle(mut conns, fd) // keep-alive; drop empty state
+	cs.write_buf.clear() // len = 0, capacity kept for the next batch
+	cs.write_off = 0
+	if cs.write_deadline != 0 {
+		cs.write_deadline = 0
+		st.parked--
+	}
 }
 
-// handle_writable_plain drains a parked response when the socket is writable.
-@[manualfree]
-fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut conns map[int]&ConnState) {
-	mut cs := conns[fd] or { return }
+// handle_writable_plain drains a parked batch when the socket is writable.
+@[direct_array_access; manualfree]
+fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut st PlainState) {
+	if fd >= st.conns.len {
+		return
+	}
+	mut cs := st.conns[fd]
+	if unsafe { cs == nil } {
+		return
+	}
+	if cs.write_off >= cs.write_buf.len {
+		// Spurious wake — nothing parked; stop watching writability.
+		epoll.mod_fd_in_epoll(epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLET))
+		return
+	}
 	for cs.write_off < cs.write_buf.len {
-		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off },
-			usize(cs.write_buf.len - cs.write_off), C.MSG_NOSIGNAL)
+		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off }, usize(cs.write_buf.len - cs.write_off),
+			C.MSG_NOSIGNAL)
 		if n > 0 {
 			cs.write_off += n
 			continue
@@ -174,89 +248,58 @@ fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut c
 		if n < 0 && (C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK) {
 			return
 		}
-		close_conn(epoll_fd, fd, active_conns, mut conns)
+		close_conn(epoll_fd, fd, active_conns, mut st)
 		return
 	}
-	unsafe { cs.write_buf.free() }
-	cs.write_buf = []u8{}
+	cs.write_buf.clear()
 	cs.write_off = 0
+	if cs.write_deadline != 0 {
+		cs.write_deadline = 0
+		st.parked--
+	}
 	epoll.mod_fd_in_epoll(epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLET)) // stop watching writability
-	cleanup_if_idle(mut conns, fd)
 }
 
-fn save_read(mut conns map[int]&ConnState, fd int, buf []u8, read_timeout_ms int) {
-	mut cs := conns[fd] or {
-		nc := &ConnState{}
-		conns[fd] = nc
-		nc
-	}
-	cs.read_buf = buf
-	// Set the deadline once, from when reading began (don't extend per fragment).
-	if read_timeout_ms > 0 && cs.read_deadline == 0 {
-		cs.read_deadline = time.sys_mono_now() + u64(read_timeout_ms) * 1_000_000
-	}
-}
-
-fn park_write(mut conns map[int]&ConnState, fd int, resp []u8, sent int, write_timeout_ms int) {
-	mut cs := conns[fd] or {
-		nc := &ConnState{}
-		conns[fd] = nc
-		nc
-	}
-	cs.write_buf = resp
-	cs.write_off = sent
-	if write_timeout_ms > 0 {
-		cs.write_deadline = time.sys_mono_now() + u64(write_timeout_ms) * 1_000_000
-	}
-}
-
-// sweep_timeouts closes connections whose read/write deadline has passed. Called
-// from the worker only when there are pending connections and a timeout is set,
+// sweep_timeouts closes connections whose read/write deadline has passed.
+// Called from the worker only when something is parked and a timeout is set,
 // so it costs nothing on an idle/fast server.
-@[manualfree]
-fn sweep_timeouts(epoll_fd int, active_conns &core.Counter, mut conns map[int]&ConnState) {
+@[direct_array_access; manualfree]
+fn sweep_timeouts(epoll_fd int, active_conns &core.Counter, mut st PlainState) {
 	now := time.sys_mono_now()
-	mut expired := []int{}
-	mut timed_out_read := map[int]bool{}
-	for fd, cs in conns {
+	for fd in 0 .. st.conns.len {
+		cs := st.conns[fd]
+		if unsafe { cs == nil } {
+			continue
+		}
 		if cs.read_deadline > 0 && now > cs.read_deadline {
-			expired << fd
-			timed_out_read[fd] = true
-		} else if cs.write_deadline > 0 && now > cs.write_deadline {
-			expired << fd
-		}
-	}
-	for fd in expired {
-		if fd in timed_out_read {
 			response.send_status_408_response(fd) // couldn't finish the request in time
+			close_conn(epoll_fd, fd, active_conns, mut st)
+		} else if cs.write_deadline > 0 && now > cs.write_deadline {
+			close_conn(epoll_fd, fd, active_conns, mut st)
 		}
-		close_conn(epoll_fd, fd, active_conns, mut conns)
 	}
 }
 
-@[manualfree]
-fn close_conn(epoll_fd int, fd int, active_conns &core.Counter, mut conns map[int]&ConnState) {
-	if cs := conns[fd] {
-		unsafe {
-			if cs.read_buf.len > 0 {
-				cs.read_buf.free()
+// close_conn frees the connection's buffers, clears its table slot and
+// releases the fd. The ConnState struct itself is reclaimed by the GC once
+// the slot no longer references it.
+@[direct_array_access; manualfree]
+fn close_conn(epoll_fd int, fd int, active_conns &core.Counter, mut st PlainState) {
+	if fd < st.conns.len {
+		cs := st.conns[fd]
+		if unsafe { cs != nil } {
+			if cs.read_deadline != 0 {
+				st.parked--
 			}
-			if cs.write_buf.len > 0 {
+			if cs.write_deadline != 0 {
+				st.parked--
+			}
+			unsafe {
+				cs.read_buf.free()
 				cs.write_buf.free()
 			}
+			st.conns[fd] = &ConnState(unsafe { nil })
 		}
-		conns.delete(fd)
 	}
 	release_conn(epoll_fd, fd, active_conns)
-}
-
-fn cleanup_if_idle(mut conns map[int]&ConnState, fd int) {
-	if conns.len == 0 {
-		return
-	}
-	if cs := conns[fd] {
-		if cs.read_buf.len == 0 && cs.write_buf.len == 0 {
-			conns.delete(fd)
-		}
-	}
 }

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -80,9 +80,11 @@ fn state_for(mut st PlainState, fd int) &ConnState {
 		for new_len <= fd {
 			new_len *= 2
 		}
-		for st.conns.len < new_len {
-			st.conns << unsafe { nil }
+		mut grown := []&ConnState{len: new_len, init: unsafe { nil }}
+		for i in 0 .. st.conns.len {
+			grown[i] = st.conns[i]
 		}
+		st.conns = grown
 	}
 	if unsafe { st.conns[fd] == nil } {
 		st.conns[fd] = &ConnState{

--- a/http_server/backend_epoll/tls_conn_linux.c.v
+++ b/http_server/backend_epoll/tls_conn_linux.c.v
@@ -77,7 +77,7 @@ fn tls_handshake_step(mut conn TlsConn, epoll_fd int, fd int, active_conns &core
 }
 
 @[direct_array_access; manualfree]
-fn handle_readable_fd_tls(request_handler fn ([]u8, int) ![]u8, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config, mut sessions map[int]&TlsConn) {
+fn handle_readable_fd_tls(request_handler fn ([]u8, int, mut []u8) !, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config, mut sessions map[int]&TlsConn) {
 	stdatomic.add_i64(&counter.n, 1)
 	defer {
 		stdatomic.add_i64(&counter.n, -1)
@@ -169,8 +169,13 @@ fn handle_readable_fd_tls(request_handler fn ([]u8, int) ![]u8, epoll_fd int, fd
 	// Request complete — clear the read deadline.
 	conn.read_deadline = 0
 
-	resp := request_handler(buf, fd) or {
+	// Server-owned response buffer: the handler appends raw response bytes.
+	// (The TLS path keeps a per-request buffer; the persistent-buffer
+	// batching is implemented on the plain path.)
+	mut resp := []u8{len: 0, cap: 4096}
+	request_handler(buf, fd, mut resp) or {
 		unsafe { buf.free() }
+		unsafe { resp.free() }
 		close_tls(epoll_fd, fd, active_conns, mut sessions)
 		return
 	}

--- a/http_server/backend_epoll/tls_conn_linux.c.v
+++ b/http_server/backend_epoll/tls_conn_linux.c.v
@@ -77,7 +77,7 @@ fn tls_handshake_step(mut conn TlsConn, epoll_fd int, fd int, active_conns &core
 }
 
 @[direct_array_access; manualfree]
-fn handle_readable_fd_tls(request_handler fn ([]u8, int, mut []u8) !, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config, mut sessions map[int]&TlsConn) {
+fn handle_readable_fd_tls(request_handler core.RequestHandler, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config, mut sessions map[int]&TlsConn) {
 	stdatomic.add_i64(&counter.n, 1)
 	defer {
 		stdatomic.add_i64(&counter.n, -1)

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -96,19 +96,19 @@ fn handle_accept_loop(socket_fd int, main_epoll_fd int, epoll_fds []int, limits 
 	}
 }
 
-// Plain (HTTP) worker: owns the per-fd connection state map for cross-edge
-// reads + EPOLLOUT writes.
+// Plain (HTTP) worker: owns the per-fd connection state table (persistent
+// buffers, cross-edge reads, EPOLLOUT writes).
 @[direct_array_access; manualfree]
-fn process_events_plain(epoll_fd int, request_handler fn ([]u8, int) ![]u8, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
+fn process_events_plain(epoll_fd int, request_handler fn ([]u8, int, mut []u8) !, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
 	mut events := [socket.max_connection_size]C.epoll_event{}
-	mut conns := map[int]&ConnState{}
+	mut st := new_plain_state()
 	// Only arm the timeout sweep if a deadline is actually configured.
 	sweep_on := limits.read_timeout_ms > 0 || limits.write_timeout_ms > 0
 	for {
 		// Block indefinitely unless there are connections parked mid-transfer and a
 		// timeout is set — then wake periodically to sweep stale ones. Zero cost on
-		// an idle/fast server (conns stays empty ⇒ -1, the original behaviour).
-		wait_ms := if sweep_on && conns.len > 0 { 250 } else { -1 }
+		// an idle/fast server (nothing parked ⇒ -1, the original behaviour).
+		wait_ms := if sweep_on && st.parked > 0 { 250 } else { -1 }
 		num_events := C.epoll_wait(epoll_fd, &events[0], socket.max_connection_size, wait_ms)
 		if num_events < 0 {
 			if C.errno == C.EINTR {
@@ -121,28 +121,28 @@ fn process_events_plain(epoll_fd int, request_handler fn ([]u8, int) ![]u8, limi
 			fd := epoll.event_fd(events[i])
 			ev := events[i].events
 			if ev & u32(C.EPOLLHUP | C.EPOLLERR) != 0 {
-				close_conn(epoll_fd, fd, active_conns, mut conns)
+				close_conn(epoll_fd, fd, active_conns, mut st)
 				continue
 			}
 			if ev & u32(C.EPOLLOUT) != 0 {
-				handle_writable_plain(epoll_fd, fd, active_conns, mut conns)
+				handle_writable_plain(epoll_fd, fd, active_conns, mut st)
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
 				handle_readable_plain(request_handler, epoll_fd, fd, limits, counter, active_conns, mut
-					conns)
+					st)
 			}
 		}
 		// After handling this batch (or a timeout wake with num_events == 0),
 		// reap any connection whose read/write deadline has passed.
-		if sweep_on && conns.len > 0 {
-			sweep_timeouts(epoll_fd, active_conns, mut conns)
+		if sweep_on && st.parked > 0 {
+			sweep_timeouts(epoll_fd, active_conns, mut st)
 		}
 	}
 }
 
 // TLS (HTTPS) worker: owns the per-fd TLS session map (handshake + ssl read/write).
 @[direct_array_access; manualfree]
-fn process_events_tls(epoll_fd int, request_handler fn ([]u8, int) ![]u8, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config) {
+fn process_events_tls(epoll_fd int, request_handler fn ([]u8, int, mut []u8) !, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config) {
 	mut events := [socket.max_connection_size]C.epoll_event{}
 	mut sessions := map[int]&TlsConn{}
 	sweep_on := limits.read_timeout_ms > 0 || limits.write_timeout_ms > 0
@@ -177,7 +177,7 @@ fn process_events_tls(epoll_fd int, request_handler fn ([]u8, int) ![]u8, limits
 	}
 }
 
-pub fn run_epoll_backend(socket_fd int, request_handler fn ([]u8, int) ![]u8, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
+pub fn run_epoll_backend(socket_fd int, request_handler fn ([]u8, int, mut []u8) !, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
 	if socket_fd < 0 {
 		return
 	}

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -99,7 +99,7 @@ fn handle_accept_loop(socket_fd int, main_epoll_fd int, epoll_fds []int, limits 
 // Plain (HTTP) worker: owns the per-fd connection state table (persistent
 // buffers, cross-edge reads, EPOLLOUT writes).
 @[direct_array_access; manualfree]
-fn process_events_plain(epoll_fd int, request_handler fn ([]u8, int, mut []u8) !, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
+fn process_events_plain(epoll_fd int, request_handler core.RequestHandler, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
 	mut events := [socket.max_connection_size]C.epoll_event{}
 	mut st := new_plain_state()
 	// Only arm the timeout sweep if a deadline is actually configured.
@@ -125,7 +125,9 @@ fn process_events_plain(epoll_fd int, request_handler fn ([]u8, int, mut []u8) !
 				continue
 			}
 			if ev & u32(C.EPOLLOUT) != 0 {
-				handle_writable_plain(epoll_fd, fd, active_conns, mut st)
+				if !handle_writable_plain(epoll_fd, fd, active_conns, mut st) {
+					continue // connection closed — skip the EPOLLIN half of this event
+				}
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
 				handle_readable_plain(request_handler, epoll_fd, fd, limits, counter, active_conns, mut
@@ -142,7 +144,7 @@ fn process_events_plain(epoll_fd int, request_handler fn ([]u8, int, mut []u8) !
 
 // TLS (HTTPS) worker: owns the per-fd TLS session map (handshake + ssl read/write).
 @[direct_array_access; manualfree]
-fn process_events_tls(epoll_fd int, request_handler fn ([]u8, int, mut []u8) !, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config) {
+fn process_events_tls(epoll_fd int, request_handler core.RequestHandler, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config) {
 	mut events := [socket.max_connection_size]C.epoll_event{}
 	mut sessions := map[int]&TlsConn{}
 	sweep_on := limits.read_timeout_ms > 0 || limits.write_timeout_ms > 0
@@ -165,6 +167,9 @@ fn process_events_tls(epoll_fd int, request_handler fn ([]u8, int, mut []u8) !, 
 			}
 			if ev & u32(C.EPOLLOUT) != 0 {
 				handle_writable_fd_tls(epoll_fd, fd, active_conns, mut sessions)
+				if fd !in sessions {
+					continue // session closed — skip the EPOLLIN half of this event
+				}
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
 				handle_readable_fd_tls(request_handler, epoll_fd, fd, limits, counter,
@@ -177,7 +182,7 @@ fn process_events_tls(epoll_fd int, request_handler fn ([]u8, int, mut []u8) !, 
 	}
 }
 
-pub fn run_epoll_backend(socket_fd int, request_handler fn ([]u8, int, mut []u8) !, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
+pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
 	if socket_fd < 0 {
 		return
 	}

--- a/http_server/core/core.v
+++ b/http_server/core/core.v
@@ -11,6 +11,19 @@ import runtime
 // counter array sizing) and the backend (worker fan-out) need this count.
 pub const max_thread_pool_size = runtime.nr_cpus()
 
+// RequestHandler is the raw, zero-allocation handler contract: it receives the
+// complete request bytes (a view into the connection's read buffer — copy
+// anything that must outlive the call) and APPENDS the complete raw HTTP
+// response (status line + headers + body) to `out`, the connection's
+// persistent write buffer. The server owns `out`: it batches everything
+// appended during one readiness event into a single send and reuses the
+// buffer across requests — the handler must never free or keep it.
+//
+// Static routes append a precomputed `const ... .bytes()`; dynamic routes
+// append a const prefix, the Content-Length digits, '\r\n\r\n' and the body.
+// Returning an error sends 400 and closes the connection.
+pub type RequestHandler = fn (req []u8, fd int, mut out []u8) !
+
 // Counter is a single i64 padded to a full cache line, so independent counters
 // (per-worker in-flight, global active-connections) never false-share. Mutated
 // via atomic add, read via atomic load (sync.stdatomic free funcs on &n).

--- a/http_server/http1_1/response/response.c.v
+++ b/http_server/http1_1/response/response.c.v
@@ -7,8 +7,10 @@ fn C.perror(s &u8)
 
 pub const tiny_bad_request_response = 'HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const status_444_response = 'HTTP/1.1 444 No Response\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
-const status_413_response = 'HTTP/1.1 413 Payload Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
-const status_431_response = 'HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
+// 413/431 are pub so the epoll backend can APPEND them to a batched write
+// buffer (sending them raw would jump the queue of already-batched responses).
+pub const status_413_response = 'HTTP/1.1 413 Payload Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
+pub const status_431_response = 'HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const status_408_response = 'HTTP/1.1 408 Request Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 
 // HTTP response helpers.

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -22,7 +22,7 @@ pub:
 	tls_config      &tls.Config = unsafe { nil } // nil ⇒ plain HTTP; set ⇒ HTTPS
 pub mut:
 	threads         []thread = []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
-	request_handler fn ([]u8, int) ![]u8 @[required]
+	request_handler core.RequestHandler @[required]
 	// Per-worker in-flight request counters (one per worker, each on its own
 	// cache line — written only by its worker, so no contention/false sharing).
 	// shutdown() sums them to drain precisely.
@@ -188,7 +188,7 @@ pub struct ServerConfig {
 pub:
 	port            int       = 3000
 	io_multiplexing IOBackend = unsafe { IOBackend(0) }
-	request_handler fn ([]u8, int) ![]u8 @[required]
+	request_handler core.RequestHandler @[required]
 	certificates    Certificates
 	limits          Limits
 	tls_config      &tls.Config = unsafe { nil } // set for HTTPS (e.g. tls.new_self_signed())

--- a/http_server/http_server_darwin.c.v
+++ b/http_server/http_server_darwin.c.v
@@ -23,7 +23,7 @@ fn C.close(fd int) int
 // read of 0 bytes) cleans up when the client goes away. This matches the
 // `Connection: keep-alive` the example handlers advertise — the previous
 // close-per-request behaviour both lied to clients and crippled throughput.
-fn handle_readable_fd(handler fn ([]u8, int, mut []u8) !, kq_fd int, client_fd int, limits Limits) {
+fn handle_readable_fd(handler fn (req []u8, fd int, mut out []u8) !, kq_fd int, client_fd int, limits Limits) {
 	request_buffer := request.read_request(client_fd, limits.max_header_bytes,
 		limits.max_body_bytes) or {
 		match err.code() {
@@ -103,7 +103,7 @@ fn handle_accept_loop(socket_fd int, main_kq int, worker_kqs []int) {
 	}
 }
 
-pub fn run_kqueue_backend(socket_fd int, handler fn ([]u8, int, mut []u8) !, port int, limits Limits, mut threads []thread) {
+pub fn run_kqueue_backend(socket_fd int, handler fn (req []u8, fd int, mut out []u8) !, port int, limits Limits, mut threads []thread) {
 	main_kq := kqueue.create_kqueue_fd()
 	if main_kq < 0 {
 		return

--- a/http_server/http_server_darwin.c.v
+++ b/http_server/http_server_darwin.c.v
@@ -23,7 +23,7 @@ fn C.close(fd int) int
 // read of 0 bytes) cleans up when the client goes away. This matches the
 // `Connection: keep-alive` the example handlers advertise — the previous
 // close-per-request behaviour both lied to clients and crippled throughput.
-fn handle_readable_fd(handler fn ([]u8, int) ![]u8, kq_fd int, client_fd int, limits Limits) {
+fn handle_readable_fd(handler fn ([]u8, int, mut []u8) !, kq_fd int, client_fd int, limits Limits) {
 	request_buffer := request.read_request(client_fd, limits.max_header_bytes,
 		limits.max_body_bytes) or {
 		match err.code() {
@@ -52,7 +52,10 @@ fn handle_readable_fd(handler fn ([]u8, int) ![]u8, kq_fd int, client_fd int, li
 	}
 	defer { unsafe { request_buffer.free() } }
 
-	response_buffer := handler(request_buffer, client_fd) or {
+	// Server-owned response buffer: the handler appends raw response bytes.
+	mut response_buffer := []u8{len: 0, cap: 4096}
+	defer { unsafe { response_buffer.free() } }
+	handler(request_buffer, client_fd, mut response_buffer) or {
 		response.send_bad_request_response(client_fd)
 		kqueue.remove_fd_from_kqueue(kq_fd, client_fd)
 		return
@@ -100,7 +103,7 @@ fn handle_accept_loop(socket_fd int, main_kq int, worker_kqs []int) {
 	}
 }
 
-pub fn run_kqueue_backend(socket_fd int, handler fn ([]u8, int) ![]u8, port int, limits Limits, mut threads []thread) {
+pub fn run_kqueue_backend(socket_fd int, handler fn ([]u8, int, mut []u8) !, port int, limits Limits, mut threads []thread) {
 	main_kq := kqueue.create_kqueue_fd()
 	if main_kq < 0 {
 		return

--- a/http_server/http_server_darwin.c.v
+++ b/http_server/http_server_darwin.c.v
@@ -23,6 +23,7 @@ fn C.close(fd int) int
 // read of 0 bytes) cleans up when the client goes away. This matches the
 // `Connection: keep-alive` the example handlers advertise — the previous
 // close-per-request behaviour both lied to clients and crippled throughput.
+@[manualfree]
 fn handle_readable_fd(handler fn (req []u8, fd int, mut out []u8) !, kq_fd int, client_fd int, limits Limits) {
 	request_buffer := request.read_request(client_fd, limits.max_header_bytes,
 		limits.max_body_bytes) or {

--- a/http_server/http_server_io_uring_linux.c.v
+++ b/http_server/http_server_io_uring_linux.c.v
@@ -34,7 +34,7 @@ fn handle_io_uring_accept(worker &io_uring.Worker, cqe &C.io_uring_cqe) {
 	}
 }
 
-fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn ([]u8, int) ![]u8) {
+fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn ([]u8, int, mut []u8) !) {
 	res := cqe.res
 	c_ptr := io_uring.decode_connection_ptr(C.io_uring_cqe_get_data64(cqe))
 	if res <= 0 {
@@ -52,14 +52,16 @@ fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn
 			eprintln('[DEBUG] Read ${res} bytes from fd=${conn.fd}')
 		}
 		request_data := unsafe { conn.buf[..conn.bytes_read] }
-		response_data := handler(request_data, conn.fd) or {
+		// Reuse the connection's response buffer across requests: clear()
+		// keeps the capacity, the handler appends the raw response bytes.
+		conn.response_buffer.clear()
+		handler(request_data, conn.fd, mut conn.response_buffer) or {
 			response.send_bad_request_response(conn.fd)
 			io_uring.pool_release_from_ptr(worker, mut *conn)
 			C.io_uring_cqe_seen(&worker.ring, cqe)
 			C.io_uring_submit(&worker.ring)
 			return
 		}
-		conn.response_buffer = response_data
 		conn.bytes_sent = 0
 		$if verbose ? {
 			eprintln('[DEBUG] Preparing write of ${conn.response_buffer.len} bytes')
@@ -89,8 +91,7 @@ fn handle_io_uring_write(worker &io_uring.Worker, cqe &C.io_uring_cqe) {
 					eprintln('[DEBUG] Write complete, keep-alive next read')
 				}
 				conn.bytes_read = 0
-				unsafe { conn.response_buffer.free() }
-				conn.response_buffer = []u8{}
+				conn.response_buffer.clear() // keep capacity for the next response
 				io_uring.prepare_recv(&worker.ring, mut *conn)
 			}
 		}
@@ -105,7 +106,7 @@ fn handle_io_uring_write(worker &io_uring.Worker, cqe &C.io_uring_cqe) {
 	}
 }
 
-fn dispatch_io_uring_cqe(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn ([]u8, int) ![]u8) {
+fn dispatch_io_uring_cqe(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn ([]u8, int, mut []u8) !) {
 	data := C.io_uring_cqe_get_data64(cqe)
 	op := io_uring.decode_op_type(data)
 	match op {
@@ -116,7 +117,7 @@ fn dispatch_io_uring_cqe(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler f
 	}
 }
 
-fn io_uring_worker_loop(worker &io_uring.Worker, handler fn ([]u8, int) ![]u8) {
+fn io_uring_worker_loop(worker &io_uring.Worker, handler fn ([]u8, int, mut []u8) !) {
 	io_uring.prepare_accept(&worker.ring, worker.socket_fd, worker.use_multishot)
 	C.io_uring_submit(&worker.ring)
 	$if verbose ? {
@@ -164,7 +165,7 @@ fn io_uring_worker_loop(worker &io_uring.Worker, handler fn ([]u8, int) ![]u8) {
 	}
 }
 
-pub fn run_io_uring_backend(request_handler fn ([]u8, int) ![]u8, port int, mut threads []thread) {
+pub fn run_io_uring_backend(request_handler fn ([]u8, int, mut []u8) !, port int, mut threads []thread) {
 	num_workers := max_thread_pool_size
 
 	for i in 0 .. num_workers {

--- a/http_server/http_server_io_uring_linux.c.v
+++ b/http_server/http_server_io_uring_linux.c.v
@@ -34,7 +34,7 @@ fn handle_io_uring_accept(worker &io_uring.Worker, cqe &C.io_uring_cqe) {
 	}
 }
 
-fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn ([]u8, int, mut []u8) !) {
+fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn (req []u8, fd int, mut out []u8) !) {
 	res := cqe.res
 	c_ptr := io_uring.decode_connection_ptr(C.io_uring_cqe_get_data64(cqe))
 	if res <= 0 {
@@ -58,8 +58,9 @@ fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn
 		handler(request_data, conn.fd, mut conn.response_buffer) or {
 			response.send_bad_request_response(conn.fd)
 			io_uring.pool_release_from_ptr(worker, mut *conn)
-			C.io_uring_cqe_seen(&worker.ring, cqe)
-			C.io_uring_submit(&worker.ring)
+			// The worker loop marks this CQE seen and submits after dispatch
+			// returns — doing it here too would advance the CQ head twice and
+			// silently consume the next completion.
 			return
 		}
 		conn.bytes_sent = 0
@@ -106,7 +107,7 @@ fn handle_io_uring_write(worker &io_uring.Worker, cqe &C.io_uring_cqe) {
 	}
 }
 
-fn dispatch_io_uring_cqe(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn ([]u8, int, mut []u8) !) {
+fn dispatch_io_uring_cqe(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn (req []u8, fd int, mut out []u8) !) {
 	data := C.io_uring_cqe_get_data64(cqe)
 	op := io_uring.decode_op_type(data)
 	match op {
@@ -117,7 +118,7 @@ fn dispatch_io_uring_cqe(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler f
 	}
 }
 
-fn io_uring_worker_loop(worker &io_uring.Worker, handler fn ([]u8, int, mut []u8) !) {
+fn io_uring_worker_loop(worker &io_uring.Worker, handler fn (req []u8, fd int, mut out []u8) !) {
 	io_uring.prepare_accept(&worker.ring, worker.socket_fd, worker.use_multishot)
 	C.io_uring_submit(&worker.ring)
 	$if verbose ? {
@@ -165,7 +166,7 @@ fn io_uring_worker_loop(worker &io_uring.Worker, handler fn ([]u8, int, mut []u8
 	}
 }
 
-pub fn run_io_uring_backend(request_handler fn ([]u8, int, mut []u8) !, port int, mut threads []thread) {
+pub fn run_io_uring_backend(request_handler fn (req []u8, fd int, mut out []u8) !, port int, mut threads []thread) {
 	num_workers := max_thread_pool_size
 
 	for i in 0 .. num_workers {

--- a/http_server/http_server_windows.c.v
+++ b/http_server/http_server_windows.c.v
@@ -124,6 +124,7 @@ fn handle_accept_completion(io_data &iocp.IOData, handler fn (req []u8, fd int, 
 	// (We need to get the listening socket from somewhere - stored in context)
 }
 
+@[manualfree]
 fn handle_read_completion(io_data &iocp.IOData, handler fn (req []u8, fd int, mut out []u8) !,
 	mut ctx WorkerContext) {
 	socket_fd := io_data.socket_fd

--- a/http_server/http_server_windows.c.v
+++ b/http_server/http_server_windows.c.v
@@ -24,7 +24,7 @@ const buffer_size = 8192
 struct WorkerContext {
 pub mut:
 	iocp_handle voidptr
-	handler     fn ([]u8, int, mut []u8) ! @[required]
+	handler     fn (req []u8, fd int, mut out []u8) ! @[required]
 	running     bool
 	thread_id   u32
 }
@@ -101,7 +101,7 @@ fn worker_thread(mut ctx WorkerContext) {
 	println('[iocp-worker] Worker thread exiting')
 }
 
-fn handle_accept_completion(io_data &iocp.IOData, handler fn ([]u8, int, mut []u8) !,
+fn handle_accept_completion(io_data &iocp.IOData, handler fn (req []u8, fd int, mut out []u8) !,
 	mut ctx WorkerContext) {
 	socket_fd := io_data.socket_fd
 
@@ -124,7 +124,7 @@ fn handle_accept_completion(io_data &iocp.IOData, handler fn ([]u8, int, mut []u
 	// (We need to get the listening socket from somewhere - stored in context)
 }
 
-fn handle_read_completion(io_data &iocp.IOData, handler fn ([]u8, int, mut []u8) !,
+fn handle_read_completion(io_data &iocp.IOData, handler fn (req []u8, fd int, mut out []u8) !,
 	mut ctx WorkerContext) {
 	socket_fd := io_data.socket_fd
 	bytes_read := io_data.bytes_transferred
@@ -280,7 +280,7 @@ fn accept_thread(listen_socket int, iocp_handle voidptr) {
 	println('[iocp-accept] Accept thread exiting')
 }
 
-pub fn run_iocp_backend(socket_fd int, handler fn ([]u8, int, mut []u8) !, port int, mut threads []thread) {
+pub fn run_iocp_backend(socket_fd int, handler fn (req []u8, fd int, mut out []u8) !, port int, mut threads []thread) {
 	println('[iocp] Starting IOCP backend on port ${port}')
 
 	// Create IOCP handle

--- a/http_server/http_server_windows.c.v
+++ b/http_server/http_server_windows.c.v
@@ -24,7 +24,7 @@ const buffer_size = 8192
 struct WorkerContext {
 pub mut:
 	iocp_handle voidptr
-	handler     fn ([]u8, int) ![]u8 @[required]
+	handler     fn ([]u8, int, mut []u8) ! @[required]
 	running     bool
 	thread_id   u32
 }
@@ -101,7 +101,7 @@ fn worker_thread(mut ctx WorkerContext) {
 	println('[iocp-worker] Worker thread exiting')
 }
 
-fn handle_accept_completion(io_data &iocp.IOData, handler fn ([]u8, int) ![]u8,
+fn handle_accept_completion(io_data &iocp.IOData, handler fn ([]u8, int, mut []u8) !,
 	mut ctx WorkerContext) {
 	socket_fd := io_data.socket_fd
 
@@ -124,7 +124,7 @@ fn handle_accept_completion(io_data &iocp.IOData, handler fn ([]u8, int) ![]u8,
 	// (We need to get the listening socket from somewhere - stored in context)
 }
 
-fn handle_read_completion(io_data &iocp.IOData, handler fn ([]u8, int) ![]u8,
+fn handle_read_completion(io_data &iocp.IOData, handler fn ([]u8, int, mut []u8) !,
 	mut ctx WorkerContext) {
 	socket_fd := io_data.socket_fd
 	bytes_read := io_data.bytes_transferred
@@ -136,9 +136,11 @@ fn handle_read_completion(io_data &iocp.IOData, handler fn ([]u8, int) ![]u8,
 		return
 	}
 
-	// Process the request
+	// Process the request — server-owned response buffer, handler appends raw bytes.
 	request_data := io_data.buffer[..bytes_read]
-	response_data := handler(request_data, socket_fd) or {
+	mut response_data := []u8{len: 0, cap: 4096}
+	handler(request_data, socket_fd, mut response_data) or {
+		unsafe { response_data.free() }
 		response.send_bad_request_response(socket_fd)
 		socket.close_socket(socket_fd)
 		iocp.free_io_data(io_data)
@@ -151,6 +153,7 @@ fn handle_read_completion(io_data &iocp.IOData, handler fn ([]u8, int) ![]u8,
 		C.memcpy(&write_io_data.buffer[0], response_data.data, response_data.len)
 	}
 	write_io_data.wsabuf.len = u32(response_data.len)
+	unsafe { response_data.free() } // copied into write_io_data above
 
 	// Post write operation
 	flags := u32(0)
@@ -277,7 +280,7 @@ fn accept_thread(listen_socket int, iocp_handle voidptr) {
 	println('[iocp-accept] Accept thread exiting')
 }
 
-pub fn run_iocp_backend(socket_fd int, handler fn ([]u8, int) ![]u8, port int, mut threads []thread) {
+pub fn run_iocp_backend(socket_fd int, handler fn ([]u8, int, mut []u8) !, port int, mut threads []thread) {
 	println('[iocp] Starting IOCP backend on port ${port}')
 
 	// Create IOCP handle

--- a/http_server/io_uring/io_uring_linux.c.v
+++ b/http_server/io_uring/io_uring_linux.c.v
@@ -196,6 +196,7 @@ fn pool_has_capacity(w &Worker) bool {
 	return w.free_top > 0
 }
 
+@[manualfree]
 pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	if w.free_top == 0 {
 		return unsafe { nil }
@@ -215,6 +216,7 @@ pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	return c
 }
 
+@[manualfree]
 pub fn pool_release(mut w Worker, mut c Connection) {
 	if unsafe { c.owner == nil } {
 		return

--- a/http_server/server_test.v
+++ b/http_server/server_test.v
@@ -1,10 +1,11 @@
 module http_server
 
-fn dummy_handler(req []u8, _ int) ![]u8 {
+fn dummy_handler(req []u8, _ int, mut out []u8) ! {
 	if req.bytestr().contains('/notfound') {
-		return 'HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\n\r\nNot Found'.bytes()
+		out << 'HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\n\r\nNot Found'.bytes()
+		return
 	}
-	return 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK'.bytes()
+	out << 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK'.bytes()
 }
 
 fn test_server_end_to_end() ! {


### PR DESCRIPTION
# Raw handler contract + epoll pipelining with persistent buffers

## Summary

Implements the benchmark-validated subset of `docs/PERF_GAP_ANALYSIS.md` (items 2, 3 and 9): the handler API becomes the rawest possible zero-allocation contract, and the epoll plain path gets persistent per-connection buffers, a flat fd-indexed state table, and HTTP/1.1 pipelining with one batched send per readiness burst.

**BREAKING CHANGE** — the handler contract changes from `fn (req []u8, fd int) ![]u8` to:

```v
fn (req []u8, fd int, mut out []u8) !
```

The handler appends the complete raw HTTP response (status line + headers + body) to `out`, a buffer the server owns and reuses. No writer abstraction, no finalize step — benchmarks showed a gutter-style ResponseWriter is *slower* than raw sequential writes (4.6 ns vs 2.2 ns small body; loses even to malloc at 1 KiB).

## Why

End-to-end C model benchmarks (`bench/e2e.c`, loopback, 4 cores):

| model | depth=1 | depth=16 pipelined |
|---|---|---|
| persistent buffers + raw write + batched send | 60.4k req/s | **977k req/s** |
| same loop, malloc/copy/free per response | 61.3k | 961–979k |
| fresh grow buffer + malloc + send per response (old) | 61.0k | **606k** |

The per-request allocation itself is noise (~7 ns); what costs 38% is the send-per-response structure. Server ownership of `out` is what makes the batched send possible. It also removes a latent use-after-free: the server used to `resp.free()` whatever the handler returned, while bundled examples return module-level consts.

## What changed

- **core**: new `core.RequestHandler` type + contract docs.
- **epoll plain path** (rewritten): persistent 8 KiB read / 16 KiB write buffers per connection; flat `[]&ConnState` fd table (no map); parse-all-then-one-send pipelining (the old path *dropped* trailing pipelined bytes); leftover compaction via memmove; EPOLLOUT backpressure and read/write timeout sweeps preserved (gated by a parked counter); write-side cap (8 MiB) against peers that pipeline but never read.
- **io_uring**: reuses the pooled connection's `response_buffer` via `clear()`; fixes a pre-existing double `io_uring_cqe_seen` on the handler-error path.
- **kqueue / IOCP / TLS**: adapted to the new contract with a server-owned scratch buffer (behavior otherwise unchanged).
- **examples, e2e tests, middleware bench, README**: migrated; middleware wrappers now transform `out[start..]` in place so they stay correct under pipelining.
- **docs**: `docs/PERF_GAP_ANALYSIS.md` (full analysis of tokio/minima-sync/rust-epoll/zeemo/libreactorng/liburing vs vanilla) + `bench/micro.c` / `bench/e2e.c` to reproduce the numbers.

## Validation done / needed

Written and self-reviewed without a V toolchain (sandboxed environment). Review pass already caught and fixed: double-close on fatal send, stale EPOLLIN after EPOLLOUT close, out-of-order canned error responses, unbounded write buffer, per-burst vs per-request `max_request_bytes` semantics.

Before merge, please run locally:

```sh
v fmt -w .
v test http_server/
v -prod run examples/simple   # + wrk plain and pipelined profiles
valgrind --tool=helgrind ...  # per CONTRIBUTING.md
```

Compiler-sensitive spots to watch (flagged during review, no in-repo precedent): `[]&ConnState{len: n, init: unsafe { nil }}`, `st.conns << unsafe { nil }`, and passing `mut cs.write_buf` through a `&ConnState`. Each has a trivial rewrite if the checker complains.

Follow-ups (next PRs, per the doc): per-worker SO_REUSEPORT listeners for epoll (kill the accept thread), io_uring batched submit/drain loop + DEFER_TASKRUN/SINGLE_ISSUER instead of SQPOLL, multishot accept + partial-read fix, adaptive epoll_wait timeout, CPU pinning.
