### PR TITLE
docs: update perf docs to current state + 64-core arena findings

### DIFF
--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -14,21 +14,37 @@ Everything below is a concrete way to honor those rules.
 
 ---
 
-## 1. Handlers are pure functions
+## 1. Handlers append into the connection's write buffer (zero-alloc)
 
-A request handler is a **total function of `(request) -> (response)`**. It must
-not touch the socket, read globals, or perform hidden I/O.
+A request handler is a **pure function of the request that APPENDS the complete
+raw response into `out`** — the connection's persistent, server-owned write
+buffer. It returns nothing, must not touch the socket, read globals, or perform
+hidden I/O.
 
 ```v
-fn handle(req request_parser.HttpRequest) []u8 {
-    // read req fields, build bytes, return. Nothing else.
+// out is the connection's reused write buffer. Append the full response
+// (status line + headers + body) into it; the server batches everything
+// appended during one readiness event into a single send. Never free or keep it.
+fn handle(req []u8, fd int, mut out []u8) ! {
+    // parse req, append bytes into out. Nothing else.
 }
 ```
+
+> **Why append instead of returning `[]u8`?** Returning a freshly-built `[]u8`
+> per request is one heap allocation (plus a copy into `out`) per request. That
+> is invisible on a laptop but **compounds catastrophically under V's GC at high
+> core counts**: on the 64-core HttpArena, switching the handler from
+> `out << build()` to appending directly into `out` took **json from 115K→485K
+> req/s (+322%)** and, once the *last* per-request allocation (the router's
+> `all_before('?')`) was also removed, **pipelined from 2.4M→34.9M (+1365%)**.
+> Per-request allocation is the single biggest performance lever at scale —
+> keep the hot path at **zero allocations**.
 
 **Do**
 
 - Treat the parsed request as immutable input.
-- Build the full response in memory and return it as `[]u8`.
+- Append the full response **into `out`** (status line + headers + body); let
+  the core batch and send it.
 - Keep all framing decisions (Content-Length, chunking) in the core, not in
   the handler.
 
@@ -80,27 +96,34 @@ const status_413_response = 'HTTP/1.1 413 Payload Too Large\r\nContent-Length: 0
 
 No allocation, no formatting — ever.
 
-### 3b. Dynamic responses → pre-sized builder, write parts separately
+### 3b. Dynamic responses → append parts straight into `out`
 
-For responses with dynamic values, use `strings.new_builder` seeded with a
-capacity estimate (grows at most once), write the **literal segments as string
-constants**, and write integers with `write_decimal` — which formats into a
-stack buffer with **no intermediate string allocation**.
+For responses with dynamic values, append the literal segments and the integers
+**directly into `out`** — no intermediate `strings.Builder`, no return-then-copy.
+Two tiny no-alloc helpers are all you need: one that pushes a string's bytes, and
+one that writes an integer's decimal digits (itoa into a stack scratch).
 
 ```v
-fn json_response(status int, reason string, body string) []u8 {
-    mut sb := strings.new_builder(96 + body.len) // header overhead + body
-    sb.write_string('HTTP/1.1 ')
-    sb.write_decimal(status)        // no .str(), no alloc
-    sb.write_u8(` `)
-    sb.write_string(reason)
-    sb.write_string('\r\nContent-Type: application/json\r\nContent-Length: ')
-    sb.write_decimal(body.len)
-    sb.write_string('\r\nConnection: keep-alive\r\n\r\n')
-    sb.write_string(body)
-    return sb
+@[inline]
+fn ws(mut out []u8, s string) {
+    unsafe { out.push_many(s.str, s.len) } // append bytes, no allocation
+}
+
+fn wi(mut out []u8, n i64) { /* itoa into a stack buffer, append digits */ }
+
+fn write_json(mut out []u8, body string) {
+    ws(mut out, 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ')
+    wi(mut out, i64(body.len)) // no .str(), no alloc
+    ws(mut out, '\r\nConnection: keep-alive\r\n\r\n')
+    ws(mut out, body)
 }
 ```
+
+A `strings.new_builder` (seeded with `header_overhead + body.len`, written via
+`write_string`/`write_decimal`) is still fine where you genuinely need a `string`
+result — but on the response hot path, appending into `out` avoids the builder
+allocation *and* the builder→`out` copy. **Fully static** responses should be a
+precomputed `const ... .bytes()` appended with `out << the_const`.
 
 Compare to the slow form — every `${}` here allocates:
 

--- a/docs/PERF_GAP_ANALYSIS.md
+++ b/docs/PERF_GAP_ANALYSIS.md
@@ -6,6 +6,55 @@ Analysis of six reference implementations — HttpArena **tokio**, **minima-sync
 **liburing** library/examples (proxy.c, releases 2.9–2.14) — compared against
 vanilla's epoll and io_uring backends.
 
+## Status (2026-06) — what landed and what it measured
+
+Most of the gaps below are **closed**. Both backends now have persistent
+per-connection buffers, a flat fd-indexed state table, HTTP/1.1 pipelining with a
+single batched send, and the raw append-into-`out []u8` handler contract; the
+io_uring backend uses `SINGLE_ISSUER | DEFER_TASKRUN`, a single
+`submit_and_wait` + batch CQ drain, multishot accept, and recv-at-offset framing;
+the epoll backend uses the adaptive busy-poll `epoll_wait` timeout. The recv
+buffer also now **pre-sizes to `Content-Length`** in one allocation
+(`request_parser.frame_expected_total`) instead of doubling — fixing the upload
+profile's pathological realloc churn.
+
+### Validated on the 64-core HttpArena
+
+The decisive lesson is **#5 (zero hot-path allocation)**. Per-request allocation
+is invisible on a laptop but **compounds catastrophically under V's Boehm GC at
+high core counts** — the GC's stop-the-world serializes all workers, so fewer
+cores do useful work. Removing per-request allocation let CPU utilisation (and
+throughput) scale across all cores. Measured deltas (vanilla-epoll, the framework
+handler riding this lib):
+
+| change | profile | before → after |
+|---|---|---|
+| handler appends into `out` (was `out << build()`) | json | 115K → **485K** (+322%) |
+| + remove the last per-request alloc (router `all_before('?')`) | pipelined | 2.4M → **34.9M** (+1365%) |
+| cache the gzip output per `(count,m)` | json-comp | ~57K → **857K** (now leads the profile) |
+| precomputed `const []u8` query keys, in-place int parse | baseline | → **691K** (+48%) |
+
+Takeaway: keep handlers at **literally zero allocations**; every `[]u8`/`string`
+built per request is a tax that explodes under load. The append-into-`out`
+contract (item #9) is the most important decision in this list, not the last.
+
+### Still open
+
+- **#1 (epoll per-worker `SO_REUSEPORT` accept)** — ATTEMPTED, not shipped. The
+  per-worker accept is correct for a single long-lived server, but the test suite
+  creates/destroys many servers in one process, which races fd reuse + worker
+  lifecycle against per-worker listeners (EBADF on listener registration,
+  segfaults from cross-thread `epoll` fd close, `unable to join thread`). A clean
+  multi-server shutdown lifecycle is needed first. Deprioritized: the arena showed
+  accept was **not** the bottleneck (GC/allocation was, and that is fixed).
+- **DB profiles (async-db, crud, fortunes)** are bound by the stdlib `db.pg`
+  driver (text protocol, lazy pool, no persistent prepared statements/pipelining).
+  `veb` on the same stack is *slower* than vanilla, so vanilla already maxes the
+  driver. Prepared statements (`PQprepare`/`PQexecPrepared`, lazily prepared per
+  pooled connection) give a small win (~+9% async-db); single-pass `escape_html`
+  gives +27% fortunes — but the gap to the top (native binary-protocol drivers)
+  only closes with a faster pg driver, a separate project.
+
 ## What ALL the fast servers have in common
 
 Every one of these servers, regardless of language or backend, shares the same
@@ -114,6 +163,11 @@ Ordered by expected impact. All consistent with the three rules (no slowdown,
 minimal abstraction, keep it simple) and BEST_PRACTICES.md.
 
 ### 1. epoll: kill the accept thread — per-worker `SO_REUSEPORT` listeners
+
+> **Status: attempted, NOT shipped** — see "Still open" at the top. Correct for a
+> single server, but the multi-server test suite races fd reuse + worker lifecycle
+> against per-worker listeners. Deprioritized (arena proved accept isn't the
+> bottleneck). The items below this one are **done**.
 
 Each worker creates its own listening socket (`SO_REUSEADDR + SO_REUSEPORT +
 TCP_NODELAY`, nonblocking), registers it in its own epoll, and runs an
@@ -284,17 +338,25 @@ GC makes the gap larger, in vanilla's favor of the raw contract.
 
 ## Suggested order of work
 
-| Step | Change | Backend | Risk | Expected gain |
+| Step | Change | Backend | Status | Measured gain |
 |---|---|---|---|---|
-| 1 | Per-worker reuseport listeners | epoll | low | large |
-| 2 | Persistent buffers + flat fd table | both | low | large |
-| 3 | Pipelining + batched send | both | medium | very large (pipelined), moderate (plain) |
-| 4 | Batched submit/drain loop | io_uring | low | large |
-| 5 | Drop SQPOLL → DEFER_TASKRUN/SINGLE_ISSUER | io_uring | low | large |
-| 6 | Multishot accept + partial-read fix | io_uring | low | correctness + moderate |
-| 7 | Adaptive epoll timeout | epoll | trivial | moderate |
-| 8 | CPU pinning | both | trivial | small–moderate |
-| 9 | Raw write-buffer handler contract (no writer abstraction) | both | medium | small alone; enables 3 |
+| 1 | Per-worker reuseport listeners | epoll | ⚠️ attempted, blocked | — (accept not the bottleneck) |
+| 2 | Persistent buffers + flat fd table | both | ✅ done | large |
+| 3 | Pipelining + batched send | both | ✅ done | very large (pipelined) |
+| 4 | Batched submit/drain loop | io_uring | ✅ done | large |
+| 5 | Drop SQPOLL → DEFER_TASKRUN/SINGLE_ISSUER | io_uring | ✅ done | large |
+| 6 | Multishot accept + partial-read fix | io_uring | ✅ done | correctness + moderate |
+| 7 | Adaptive epoll timeout | epoll | ✅ done | moderate |
+| 8 | CPU pinning | both | ✅ opt-in (`VANILLA_PIN_CPUS`, off by default) | small–moderate |
+| 9 | **Zero-alloc append-into-`out` handler contract** | both | ✅ done | **the single biggest lever at scale** (json +322%, pipelined +1365%) |
+| 10 | Pre-size recv buffer to Content-Length | both | ✅ done | large on upload (kills doubling-realloc churn) |
 
-Benchmark each step in isolation with `-prod` (wrk/rewrk, plain + pipelined
-profiles) and verify with helgrind, per CONTRIBUTING.md.
+> Item #9 was originally rated "small alone" — the 64-core arena proved the
+> opposite: removing per-request allocation is the dominant win (see the Status
+> section at the top). Allocation cost is hidden at low core counts and explodes
+> under GC at scale.
+
+Benchmark each step in isolation with `-prod` (wrk/rewrk/gcannon, plain +
+pipelined profiles) and verify with helgrind, per CONTRIBUTING.md. Note: a couple
+of small allocs per request look like noise at 4–16 cores but can be a multiple-x
+swing at 64 — confirm perf changes on a high-core run, not just a laptop.

--- a/docs/V_PERF_TOOLBOX.md
+++ b/docs/V_PERF_TOOLBOX.md
@@ -55,6 +55,14 @@ Already used here for the per-worker epoll fd arrays
   big ones on the hot path.
 - `recv` into spare capacity to avoid a scratch buffer + second copy:
   `recv(fd, &u8(buf.data) + buf.len, buf.cap - buf.len)` then `unsafe { buf.len += n }`.
+- **Allocation cost is hidden at low core counts and explodes under GC at scale.**
+  On the 64-core arena, eliminating per-request allocation in the handler was a
+  multiple-x swing (json **+322%**, pipelined **+1365%**) where the *same* change
+  measured within noise at 16 cores — Boehm's stop-the-world serializes every
+  worker, so churn caps how many cores do useful work. Treat any per-request
+  `[]u8` / `string` / `.bytes()` / `all_before()` / builder as a scaling tax:
+  precompute `const` keys, parse ints in place, and append into a reused buffer.
+  Corollary: confirm perf changes on a high-core run, not just a laptop.
 
 ## Pure C escape hatch
 


### PR DESCRIPTION
Brings the performance docs current after the optimization campaign.

- **BEST_PRACTICES**: handler contract is now *append into `out []u8`* (not return `[]u8`); §1 + §3b rewritten with the arena evidence (zero hot-path allocation is the dominant lever).
- **PERF_GAP_ANALYSIS**: new Status section — most items DONE; item #1 (epoll per-worker SO_REUSEPORT) attempted-but-blocked (multi-server shutdown lifecycle race); 64-core results recorded (json +322%, pipelined +1365%, json-comp now leads, baseline +48%); DB profiles are `db.pg`-driver-bound. Order-of-work table updated with status.
- **V_PERF_TOOLBOX**: allocation cost is hidden at low core counts and explodes under GC at scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)