### PR TITLE
perf: keep per-connection buffers no-scan across growth (fix static c…

### DIFF
--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -107,10 +107,20 @@ fn state_for(mut st PlainState, fd int) &ConnState {
 		st.conns = grown
 	}
 	if unsafe { st.conns[fd] == nil } {
-		st.conns[fd] = &ConnState{
+		mut cs := &ConnState{
 			read_buf:  []u8{len: 0, cap: read_buf_cap}
 			write_buf: []u8{len: 0, cap: write_buf_cap}
 		}
+		// Keep both buffers in a no-scan GC block ACROSS growth. A large response
+		// grows write_buf past write_buf_cap; without this flag grow_cap reallocates
+		// as a *scanned* block, and thousands of big per-conn buffers at high
+		// keep-alive conn counts turn GC scanning + stop-the-world into the
+		// bottleneck (the "static cliff"). The flag survives resize.
+		unsafe {
+			cs.read_buf.flags.set(.noscan_data)
+			cs.write_buf.flags.set(.noscan_data)
+		}
+		st.conns[fd] = cs
 	}
 	return st.conns[fd]
 }

--- a/http_server/io_uring/io_uring_linux.c.v
+++ b/http_server/io_uring/io_uring_linux.c.v
@@ -292,6 +292,16 @@ pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	// (noscan) capacity — recv fills read_buf, the handler fills response_buffer.
 	c.read_buf = []u8{len: 0, cap: read_buf_cap}
 	c.response_buffer = []u8{len: 0, cap: write_buf_cap}
+	// Keep both buffers in a no-scan GC block ACROSS growth. A large response
+	// (e.g. a 300 KiB static asset) grows response_buffer past write_buf_cap, and
+	// without this flag grow_cap reallocates as a *scanned* block — thousands of
+	// such multi-hundred-KB buffers at high keep-alive conn counts make GC
+	// scanning + stop-the-world dominate (the "static cliff"). The flag is
+	// preserved across resize, so the buffer stays atomic however large it grows.
+	unsafe {
+		c.read_buf.flags.set(.noscan_data)
+		c.response_buffer.flags.set(.noscan_data)
+	}
 	return c
 }
 


### PR DESCRIPTION
…liff)

A response larger than write_buf_cap (16 KiB) — e.g. a 300 KiB static asset — grows the per-connection write buffer via grow_cap, which WITHOUT the .noscan_data flag reallocates into a *scanned* GC block. At high keep-alive connection counts thousands of these multi-hundred-KB scanned buffers make GC scanning + Boehm stop-the-world the bottleneck, and it scales catastrophically with worker/core count — the "static cliff" (on the 64-core arena io_uring static fell 242K→15K rps from 1024→4096 conns, CPU 5663%→312%).

Set .noscan_data on read_buf + write_buf/response_buffer at allocation in both backends. The flag is preserved across resize (vlib array ensure_cap), so the buffer stays in a no-scan/atomic block however large it grows — bytes-only response data never needs scanning anyway.

Isolated locally (4096 conns, single file): the gap is the response SIZE, not the count — reset.css (8 KiB, fits the buffer) ran io_uring 231K ≈ epoll 241K, while vendor.js (307 KiB, grows the buffer) collapsed to io_uring 5.9K / epoll 14.5K. This keeps the large case off the GC scan path.