### PR TITLE
http_server: gate .noscan_data behind -d vanilla_noscan (restore 0.5.1 build)

### DIFF
--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -116,9 +116,18 @@ fn state_for(mut st PlainState, fd int) &ConnState {
 		// as a *scanned* block, and thousands of big per-conn buffers at high
 		// keep-alive conn counts turn GC scanning + stop-the-world into the
 		// bottleneck (the "static cliff"). The flag survives resize.
-		unsafe {
-			cs.read_buf.flags.set(.noscan_data)
-			cs.write_buf.flags.set(.noscan_data)
+		//
+		// `.noscan_data` only exists on V after the 0.5.1 release, so it is gated
+		// behind `-d vanilla_noscan` to keep the library buildable on the 0.5.1
+		// release. (`$if flag ? {}` is comptime-eliminated when the flag is unset,
+		// so the enum value is never type-checked there.) Enable it once a V
+		// release ships `.noscan_data` without the unrelated codegen slowdown that
+		// currently makes post-0.5.1 master far slower (vlang/v#27468).
+		$if vanilla_noscan ? {
+			unsafe {
+				cs.read_buf.flags.set(.noscan_data)
+				cs.write_buf.flags.set(.noscan_data)
+			}
 		}
 		st.conns[fd] = cs
 	}

--- a/http_server/io_uring/io_uring_linux.c.v
+++ b/http_server/io_uring/io_uring_linux.c.v
@@ -298,9 +298,17 @@ pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	// such multi-hundred-KB buffers at high keep-alive conn counts make GC
 	// scanning + stop-the-world dominate (the "static cliff"). The flag is
 	// preserved across resize, so the buffer stays atomic however large it grows.
-	unsafe {
-		c.read_buf.flags.set(.noscan_data)
-		c.response_buffer.flags.set(.noscan_data)
+	//
+	// Gated behind `-d vanilla_noscan`: `.noscan_data` only exists on V after the
+	// 0.5.1 release, and `$if flag ? {}` is comptime-eliminated (and not
+	// type-checked) when the flag is unset, so the library still builds on 0.5.1.
+	// Enable once a V release ships `.noscan_data` without the post-0.5.1 codegen
+	// slowdown (vlang/v#27468).
+	$if vanilla_noscan ? {
+		unsafe {
+			c.read_buf.flags.set(.noscan_data)
+			c.response_buffer.flags.set(.noscan_data)
+		}
 	}
 	return c
 }


### PR DESCRIPTION
## Why

PR #28 set `ArrayFlags.noscan_data` on the per-connection read/write buffers to fix the io_uring **static cliff**. But `.noscan_data` only exists on V **after** the 0.5.1 release, so merging #28 **broke every build on the pinned 0.5.1 release** — HttpArena's vanilla engine, the-benchmarker, and any consumer on the stable release now fail with `enum \`ArrayFlags\` does not have a value \`noscan_data\``.

## What

Gate both `.noscan_data` sites (`backend_epoll/conn_state_linux.c.v`, `io_uring/io_uring_linux.c.v`) behind `$if vanilla_noscan ? {}`. That branch is comptime-eliminated **and not type-checked** when the define is unset, so the library builds on 0.5.1 again. Pass `-d vanilla_noscan` on a V that has the flag to re-enable the static-cliff fix.

## Why off by default

The only V versions exposing `.noscan_data` are post-0.5.1 master, which currently carries a large **unrelated codegen regression** — single-element array push (`arr << x`) is **4–7× slower** (filed [vlang/v#27468](https://github.com/vlang/v/issues/27468); it also explains the `x.json2` regression [#27467](https://github.com/vlang/v/issues/27467)). On the 64-core benchmark that slowdown dwarfs the static-cliff win. Flip the flag on once a V release ships `.noscan_data` without it.

## Verified

| build | result |
|---|---|
| V 0.5.1, no flag | compiles (guard elided) ✓ |
| V 0.5.1, `-d vanilla_noscan` | errors on `.noscan_data` (intended — flag only valid where the enum exists) |
| V master, `-d vanilla_noscan` | compiles, `.noscan_data` active ✓ |

Static-cliff behaviour is unchanged on any V where it was already active (pass the flag); only the *default* build is restored to 0.5.1-compatible.