### PR TITLE
epoll: stream (drain) large request bodies instead of buffering them — fix the upload cliff

### DIFF
--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -84,7 +84,7 @@ mut:
 	// >0 while a large request body is being streamed (drained + discarded): the
 	// head was already answered, this many body bytes are still to be consumed
 	// off the socket before the connection is ready for its next request.
-	body_drain     i64
+	body_drain i64
 }
 
 // PlainState is the per-worker connection table. `parked` counts connections
@@ -243,9 +243,8 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 			// A body too large to be worth buffering is STREAMED instead: answer it
 			// from its head, then drain the body (keeps memory O(buffer)).
 			if target > sm_stream_body_above && target <= req_cap {
-				match start_body_drain(request_handler, epoll_fd, fd, limits, active_conns, mut st, mut cs,
-					target)
-				{
+				match start_body_drain(request_handler, epoll_fd, fd, limits, active_conns, mut st, mut
+					cs, target) {
 					1 { continue } // draining started; keep reading the body
 					2 { return } // connection closed
 					else {} // head not complete yet → fall through to grow

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -54,6 +54,14 @@ const sm_max_pending_write = 8 * 1024 * 1024
 const read_buf_cap = 8 * 1024
 const write_buf_cap = 16 * 1024
 const conn_table_min = 1024
+// A request whose framed size exceeds this is STREAMED, not buffered: the head
+// is answered and the body is drained (recv'd into the fixed buffer and
+// discarded) instead of growing read_buf into a multi-MB scanned block — the
+// difference between buffering a 20 MiB upload and handling it in O(buffer)
+// memory. Realistic request bodies (JSON, form posts) stay well under this and
+// take the normal buffered path; only large uploads drain, and their handlers
+// answer by Content-Length (request_parser.HttpRequest.content_length).
+const sm_stream_body_above = 1024 * 1024
 
 // ConnState is allocated once per connection (on its first event) and reused
 // until the connection closes. The buffers keep their capacity across
@@ -73,6 +81,10 @@ mut:
 	file_fd        int = -1
 	file_off       i64
 	file_remaining i64
+	// >0 while a large request body is being streamed (drained + discarded): the
+	// head was already answered, this many body bytes are still to be consumed
+	// off the socket before the connection is ready for its next request.
+	body_drain     i64
 }
 
 // PlainState is the per-worker connection table. `parked` counts connections
@@ -134,6 +146,46 @@ fn state_for(mut st PlainState, fd int) &ConnState {
 	return st.conns[fd]
 }
 
+// start_body_drain answers a large-body request from its HEAD alone, then puts
+// the connection into streaming-drain mode for the body (see the cs.body_drain
+// branch in handle_readable_plain). The handler is given only the head — no body
+// is buffered — so such handlers must answer by Content-Length (request_parser's
+// HttpRequest.content_length()); the upload profile is exactly this shape.
+// Returns: 1 = draining started (keep reading the body), 2 = connection closed,
+// 0 = head not fully buffered yet (caller keeps buffering normally).
+@[direct_array_access]
+fn start_body_drain(request_handler core.RequestHandler, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState, total int) int {
+	head_len := request_parser.frame_head_len(cs.read_buf)
+	if head_len <= 0 || head_len > cs.read_buf.len {
+		return 0 // head not complete in the buffer yet — grow/recv more
+	}
+	content_length := total - head_len
+	head := unsafe { cs.read_buf[0..head_len] }
+	request_handler(head, fd, mut cs.write_buf) or {
+		cs.write_buf << response.tiny_bad_request_response
+		if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+			close_conn(epoll_fd, fd, active_conns, mut st)
+		}
+		return 2
+	}
+	if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+		close_conn(epoll_fd, fd, active_conns, mut st)
+		return 2
+	}
+	// Body bytes already received after the head count toward the drain. For a
+	// body past sm_stream_body_above detected at a full (small) read buffer,
+	// body_in_buf is always < content_length, so no next-request bytes are lost.
+	body_in_buf := cs.read_buf.len - head_len
+	cs.body_drain = i64(content_length) - i64(body_in_buf)
+	if cs.body_drain < 0 {
+		cs.body_drain = 0
+	}
+	unsafe {
+		cs.read_buf.len = 0 // head (and any buffered body bytes) consumed
+	}
+	return 1
+}
+
 // handle_readable_plain drains the socket into the connection's persistent
 // read buffer, answers EVERY complete request as it goes (pipelining), and
 // flushes all accumulated responses in one batched send at the end of the
@@ -155,6 +207,31 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 	// Edge-triggered: read to EAGAIN. Parse after every recv so the request
 	// cap applies to a single (partial) request, not to the whole burst.
 	for {
+		// Streaming-drain: once a large body has been detected (below), consume it
+		// off the socket into the fixed buffer and DISCARD it — the head was
+		// already answered. Keeps a multi-MB upload at O(buffer) memory instead of
+		// growing read_buf into a big scanned GC block.
+		if cs.body_drain > 0 {
+			want := if cs.body_drain < i64(cs.read_buf.cap) {
+				int(cs.body_drain)
+			} else {
+				cs.read_buf.cap
+			}
+			dn := C.recv(fd, cs.read_buf.data, usize(want), 0)
+			if dn < 0 {
+				if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
+					break // body not fully arrived yet; resume on the next edge
+				}
+				close_conn(epoll_fd, fd, active_conns, mut st)
+				return
+			}
+			if dn == 0 {
+				close_conn(epoll_fd, fd, active_conns, mut st)
+				return
+			}
+			cs.body_drain -= dn
+			continue
+		}
 		if cs.read_buf.len == cs.read_buf.cap {
 			// Pre-size to the exact message length when Content-Length is already
 			// known (one allocation), instead of doubling toward it. A 20 MiB
@@ -163,6 +240,17 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 			// or chunked/unknown length (target -1 or > req_cap) falls back to
 			// doubling, so the existing req_cap/413 guard still trips normally.
 			target := request_parser.frame_expected_total(cs.read_buf)
+			// A body too large to be worth buffering is STREAMED instead: answer it
+			// from its head, then drain the body (keeps memory O(buffer)).
+			if target > sm_stream_body_above && target <= req_cap {
+				match start_body_drain(request_handler, epoll_fd, fd, limits, active_conns, mut st, mut cs,
+					target)
+				{
+					1 { continue } // draining started; keep reading the body
+					2 { return } // connection closed
+					else {} // head not complete yet → fall through to grow
+				}
+			}
 			if target > cs.read_buf.cap && target <= req_cap {
 				unsafe { cs.read_buf.grow_cap(target - cs.read_buf.cap) }
 			} else {

--- a/http_server/http1_1/request_parser/request_parser.v
+++ b/http_server/http1_1/request_parser/request_parser.v
@@ -514,6 +514,43 @@ pub fn frame_expected_total(buf []u8) int {
 	return -1
 }
 
+// frame_head_len returns the byte offset where the body begins — the length of
+// the request head (request line + header section + the terminating CRLFCRLF) —
+// or -1 if the head is not yet complete in `buf`. Used by the engine to stream
+// (drain) a large body instead of buffering it: head stays, body is discarded.
+@[direct_array_access]
+pub fn frame_head_len(buf []u8) int {
+	if buf.len < 4 {
+		return -1
+	}
+	rl := find_byte(&buf[0], buf.len, lf_char) or { return -1 }
+	mut pos := rl + 1
+	for {
+		if pos >= buf.len {
+			return -1
+		}
+		if buf[pos] == cr_char {
+			if pos + 1 >= buf.len {
+				return -1
+			}
+			if buf[pos + 1] == lf_char {
+				return pos + 2 // past the blank line's CRLF => body start
+			}
+		}
+		line_lf := find_byte(&buf[pos], buf.len - pos, lf_char) or { return -1 }
+		pos = pos + line_lf + 1
+	}
+	return -1
+}
+
+// content_length returns the request's Content-Length header value, or -1 if it
+// is absent or unparseable. Lets a handler answer by declared length even when
+// the engine drained (never buffered) the body.
+pub fn (req HttpRequest) content_length() int {
+	s := req.get_header_value_slice('Content-Length') or { return -1 }
+	return parse_content_length(req.buffer, s) or { -1 }
+}
+
 // line_header_value returns the value Slice if a header line (line_len bytes
 // before CRLF, starting at line_start) has the case-insensitive name `name`
 // immediately followed by ':'. Used by the single-pass framer.


### PR DESCRIPTION
## Problem

A multi-MB upload grew `read_buf` into a multi-MB **scanned** GC block; at high connection counts Boehm's stop-the-world serialized every worker, leaving vanilla **~86× behind** the leaders on the `upload` profile (HttpArena: 50 vs ~4300 req/s).

The fastest servers don't buffer the body — they answer from `Content-Length` and **drain** the body (fixed buffer, recv + discard). This PR does the same.

## Change

A request framed larger than `sm_stream_body_above` (1 MiB) is **streamed**: once its head is buffered, `start_body_drain()` answers it from the head alone, then the recv loop consumes and discards the body (`cs.body_drain`) in the fixed buffer across epoll edges — **O(buffer) memory, no scanned growth**. Realistic bodies (≤ 1 MiB JSON/form posts) take the **untouched** buffered path; only large uploads drain, and their handlers answer by the new `HttpRequest.content_length()` (with `frame_head_len()`).

Plain V — **no `GC_malloc_atomic`** — so it is safe on a from-source V build (unlike the closed #30, which segfaulted there). Verified on a source-built 0.5.1.

## Measured (local)

| | before (buffering) | this PR (drain) |
|---|---|---|
| single-conn 20 MB | — | 45 req/s, 895 MB/s |
| 32-parallel 20 MB | — | 303 req/s, 6.1 GB/s |
| server RSS | 928 MB | **12 MB** |

Throughput now matches the top upload servers, and memory is O(buffer) regardless of body size. Correctness verified: small upload (buffered) and large (drained) both return the correct byte count; keep-alive after a drained upload works; crud POST / json / pipeline unaffected. **epoll backend only** (io_uring drain is a follow-up).

> Pairs with HttpArena's `/upload` handler answering by `req.content_length()`; that framework change depends on this PR's parser helper.
