### PR TITLE
feat(http_server): opt-in per-thread state primitive (StatefulHandler + make_state)

### DIFF
--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -185,8 +185,7 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 				}
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
-				handle_readable_plain(handler, epoll_fd, fd, limits, counter, active_conns, mut
-					st)
+				handle_readable_plain(handler, epoll_fd, fd, limits, counter, active_conns, mut st)
 			}
 		}
 		// After handling this batch (or a timeout wake with num_events == 0),
@@ -229,8 +228,8 @@ fn process_events_tls(worker_id int, epoll_fd int, request_handler core.RequestH
 				}
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
-				handle_readable_fd_tls(handler, epoll_fd, fd, limits, counter,
-					active_conns, cfg, mut sessions)
+				handle_readable_fd_tls(handler, epoll_fd, fd, limits, counter, active_conns, cfg, mut
+					sessions)
 			}
 		}
 		if sweep_on && sessions.len > 0 {
@@ -281,11 +280,11 @@ pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, sta
 		// has no TLS code at all, so the plain hot path carries zero TLS cost.
 		counter := inflight[i] // this worker's own in-flight counter
 		if tls_config != unsafe { nil } {
-			threads[i] = spawn process_events_tls(i, epoll_fds[i], request_handler, stateful_handler,
-				make_state, limits, counter, active_conns, tls_config)
+			threads[i] = spawn process_events_tls(i, epoll_fds[i], request_handler,
+				stateful_handler, make_state, limits, counter, active_conns, tls_config)
 		} else {
-			threads[i] = spawn process_events_plain(i, epoll_fds[i], request_handler, stateful_handler,
-				make_state, limits, counter, active_conns)
+			threads[i] = spawn process_events_plain(i, epoll_fds[i], request_handler,
+				stateful_handler, make_state, limits, counter, active_conns)
 		}
 	}
 

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -113,11 +113,32 @@ fn handle_accept_loop(socket_fd int, main_epoll_fd int, epoll_fds []int, limits 
 	}
 }
 
+// build_handler resolves the effective per-worker handler. With no make_state it
+// is just the stateless request_handler. With make_state it runs ONCE on the
+// calling (worker) thread to build that thread's state, then returns a stateless
+// closure that forwards every request through stateful_handler with that state —
+// so the rest of the hot path stays a plain RequestHandler and the state is
+// thread-local (no sharing, no lock). Must be called from inside the worker.
+fn build_handler(request_handler core.RequestHandler, stateful_handler core.StatefulHandler, make_state fn () voidptr) core.RequestHandler {
+	if make_state == unsafe { nil } {
+		return request_handler
+	}
+	state := make_state()
+	return fn [state, stateful_handler] (req []u8, fd int, mut out []u8) ! {
+		stateful_handler(req, fd, mut out, state)!
+	}
+}
+
 // Plain (HTTP) worker: owns the per-fd connection state table (persistent
 // buffers, cross-edge reads, EPOLLOUT writes).
 @[direct_array_access; manualfree]
-fn process_events_plain(worker_id int, epoll_fd int, request_handler core.RequestHandler, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
+fn process_events_plain(worker_id int, epoll_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
 	maybe_pin_worker(worker_id)
+	// Per-thread state path: build THIS worker's state once, then bind it into a
+	// plain RequestHandler closure so the rest of the hot path is unchanged. The
+	// state is constructed here, inside the spawned worker, so it is thread-local
+	// (e.g. this worker's own DB connection) — no sharing, no lock.
+	handler := build_handler(request_handler, stateful_handler, make_state)
 	// This worker can stream file bodies with sendfile(2): let handlers hand a
 	// file off via core.queue_file instead of copying it through write_buf.
 	core.enable_sendfile()
@@ -164,7 +185,7 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 				}
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
-				handle_readable_plain(request_handler, epoll_fd, fd, limits, counter, active_conns, mut
+				handle_readable_plain(handler, epoll_fd, fd, limits, counter, active_conns, mut
 					st)
 			}
 		}
@@ -178,8 +199,9 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 
 // TLS (HTTPS) worker: owns the per-fd TLS session map (handshake + ssl read/write).
 @[direct_array_access; manualfree]
-fn process_events_tls(worker_id int, epoll_fd int, request_handler core.RequestHandler, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config) {
+fn process_events_tls(worker_id int, epoll_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config) {
 	maybe_pin_worker(worker_id)
+	handler := build_handler(request_handler, stateful_handler, make_state)
 	mut events := [socket.max_connection_size]C.epoll_event{}
 	mut sessions := map[int]&TlsConn{}
 	sweep_on := limits.read_timeout_ms > 0 || limits.write_timeout_ms > 0
@@ -207,7 +229,7 @@ fn process_events_tls(worker_id int, epoll_fd int, request_handler core.RequestH
 				}
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
-				handle_readable_fd_tls(request_handler, epoll_fd, fd, limits, counter,
+				handle_readable_fd_tls(handler, epoll_fd, fd, limits, counter,
 					active_conns, cfg, mut sessions)
 			}
 		}
@@ -217,7 +239,7 @@ fn process_events_tls(worker_id int, epoll_fd int, request_handler core.RequestH
 	}
 }
 
-pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
+pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, make_state fn () voidptr, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
 	if socket_fd < 0 {
 		return
 	}
@@ -259,11 +281,11 @@ pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, por
 		// has no TLS code at all, so the plain hot path carries zero TLS cost.
 		counter := inflight[i] // this worker's own in-flight counter
 		if tls_config != unsafe { nil } {
-			threads[i] = spawn process_events_tls(i, epoll_fds[i], request_handler, limits,
-				counter, active_conns, tls_config)
+			threads[i] = spawn process_events_tls(i, epoll_fds[i], request_handler, stateful_handler,
+				make_state, limits, counter, active_conns, tls_config)
 		} else {
-			threads[i] = spawn process_events_plain(i, epoll_fds[i], request_handler, limits,
-				counter, active_conns)
+			threads[i] = spawn process_events_plain(i, epoll_fds[i], request_handler, stateful_handler,
+				make_state, limits, counter, active_conns)
 		}
 	}
 

--- a/http_server/core/core.v
+++ b/http_server/core/core.v
@@ -24,6 +24,22 @@ pub const max_thread_pool_size = runtime.nr_cpus()
 // Returning an error sends 400 and closes the connection.
 pub type RequestHandler = fn (req []u8, fd int, mut out []u8) !
 
+// StatefulHandler is the per-thread-state variant of RequestHandler. It receives
+// the same arguments PLUS an opaque `state voidptr` — the value the server's
+// `make_state` callback returned for THIS worker thread (and only this one). It
+// lets a handler reach per-thread resources (e.g. its own DB connection) with no
+// lock: each worker owns its state, so nothing is shared across threads.
+//
+// The server never inspects `state`; it hands back exactly the pointer make_state
+// produced, so the handler's `unsafe { &MyCtx(state) }` cast is sound. This is the
+// same opaque-context contract as picoev's `cb_arg` or libuv's `data` void*.
+//
+// Wiring: set `make_state` + `stateful_handler` on ServerConfig instead of
+// `request_handler`. Each worker calls make_state ONCE, then every request on that
+// worker is dispatched through stateful_handler with that state. RequestHandler is
+// untouched, so stateless handlers and the other backends are unaffected.
+pub type StatefulHandler = fn (req []u8, fd int, mut out []u8, state voidptr) !
+
 // Counter is a single i64 padded to a full cache line, so independent counters
 // (per-worker in-flight, global active-connections) never false-share. Mutated
 // via atomic add, read via atomic load (sync.stdatomic free funcs on &n).

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -22,7 +22,11 @@ pub:
 	tls_config      &tls.Config = unsafe { nil } // nil ⇒ plain HTTP; set ⇒ HTTPS
 pub mut:
 	threads         []thread = []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
-	request_handler core.RequestHandler @[required]
+	request_handler core.RequestHandler = unsafe { nil }
+	// Per-thread state path (epoll only); see ServerConfig. make_state runs once
+	// per worker thread, stateful_handler receives its result on every request.
+	stateful_handler core.StatefulHandler = unsafe { nil }
+	make_state       fn () voidptr        = unsafe { nil }
 	// Per-worker in-flight request counters (one per worker, each on its own
 	// cache line — written only by its worker, so no contention/false sharing).
 	// shutdown() sums them to drain precisely.
@@ -221,13 +225,36 @@ pub struct ServerConfig {
 pub:
 	port            int       = 3000
 	io_multiplexing IOBackend = unsafe { IOBackend(0) }
-	request_handler core.RequestHandler @[required]
-	certificates    Certificates
-	limits          Limits
-	tls_config      &tls.Config = unsafe { nil } // set for HTTPS (e.g. tls.new_self_signed())
+	// Provide EITHER request_handler (stateless) OR stateful_handler+make_state
+	// (per-thread state). new_server enforces exactly one is set.
+	request_handler core.RequestHandler = unsafe { nil }
+	// stateful_handler + make_state opt into lock-free per-thread state: each
+	// epoll worker calls make_state ONCE (so the value is thread-local), then every
+	// request on that worker is dispatched through stateful_handler with it. Used to
+	// give each worker its own DB connection — no shared pool, no mutex. Linux/epoll
+	// only; ignored by other backends. See core.StatefulHandler.
+	stateful_handler core.StatefulHandler = unsafe { nil }
+	make_state       fn () voidptr        = unsafe { nil }
+	certificates     Certificates
+	limits           Limits
+	tls_config       &tls.Config = unsafe { nil } // set for HTTPS (e.g. tls.new_self_signed())
 }
 
 pub fn new_server(config ServerConfig) !Server {
+	// Exactly one handler path. The per-thread path needs both halves; otherwise a
+	// plain request_handler is required (it would crash on the first call if nil).
+	stateful := config.make_state != unsafe { nil }
+	if stateful {
+		if config.stateful_handler == unsafe { nil } {
+			return error('make_state requires stateful_handler')
+		}
+		$if !linux {
+			return error('per-thread state (make_state) is only supported on the Linux epoll backend')
+		}
+	} else if config.request_handler == unsafe { nil } {
+		return error('request_handler is required (or set make_state + stateful_handler)')
+	}
+
 	socket_fd := socket.create_server_socket(config.port)
 
 	// Set default backend based on OS
@@ -261,13 +288,15 @@ pub fn new_server(config ServerConfig) !Server {
 	}
 
 	return Server{
-		port:            config.port
-		io_multiplexing: config.io_multiplexing
-		socket_fd:       socket_fd
-		request_handler: config.request_handler
-		limits:          config.limits
-		tls_config:      config.tls_config
-		threads:         []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
-		listener_fds:    listener_fds
+		port:             config.port
+		io_multiplexing:  config.io_multiplexing
+		socket_fd:        socket_fd
+		request_handler:  config.request_handler
+		stateful_handler: config.stateful_handler
+		make_state:       config.make_state
+		limits:           config.limits
+		tls_config:       config.tls_config
+		threads:          []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
+		listener_fds:     listener_fds
 	}
 }

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -21,7 +21,7 @@ pub:
 	limits          Limits
 	tls_config      &tls.Config = unsafe { nil } // nil ⇒ plain HTTP; set ⇒ HTTPS
 pub mut:
-	threads         []thread = []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
+	threads         []thread            = []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
 	request_handler core.RequestHandler = unsafe { nil }
 	// Per-thread state path (epoll only); see ServerConfig. make_state runs once
 	// per worker thread, stateful_handler receives its result on every request.

--- a/http_server/http_server_linux.c.v
+++ b/http_server/http_server_linux.c.v
@@ -14,9 +14,9 @@ pub enum IOBackend {
 fn run_selected_backend(server Server, mut threads []thread) {
 	match server.io_multiplexing {
 		.epoll {
-			backend_epoll.run_epoll_backend(server.socket_fd, server.request_handler, server.stateful_handler,
-				server.make_state, server.port, server.limits, server.inflight, server.active_conns,
-				server.tls_config, mut threads)
+			backend_epoll.run_epoll_backend(server.socket_fd, server.request_handler,
+				server.stateful_handler, server.make_state, server.port, server.limits,
+				server.inflight, server.active_conns, server.tls_config, mut threads)
 		}
 		.io_uring {
 			run_io_uring_backend(server, mut threads)

--- a/http_server/http_server_linux.c.v
+++ b/http_server/http_server_linux.c.v
@@ -14,8 +14,9 @@ pub enum IOBackend {
 fn run_selected_backend(server Server, mut threads []thread) {
 	match server.io_multiplexing {
 		.epoll {
-			backend_epoll.run_epoll_backend(server.socket_fd, server.request_handler, server.port,
-				server.limits, server.inflight, server.active_conns, server.tls_config, mut threads)
+			backend_epoll.run_epoll_backend(server.socket_fd, server.request_handler, server.stateful_handler,
+				server.make_state, server.port, server.limits, server.inflight, server.active_conns,
+				server.tls_config, mut threads)
 		}
 		.io_uring {
 			run_io_uring_backend(server, mut threads)


### PR DESCRIPTION
## What

Adds an **opt-in, additive** way for handlers to receive **per-worker-thread state** via an opaque `voidptr`, so each epoll worker can own thread-local resources (e.g. its own non-blocking DB connection) with **no shared structure and no lock**.

## API (all opt-in)

The existing stateless `RequestHandler` and every other backend are **untouched** — zero ripple.

- **core**: new `StatefulHandler = fn (req []u8, fd int, mut out []u8, state voidptr) !`
- **ServerConfig / Server**: `stateful_handler` + `make_state fn () voidptr` — set these *instead of* `request_handler`. `new_server` enforces exactly one path and rejects `make_state` outside the Linux/epoll backend.
- **backend_epoll**: each worker calls `make_state()` **once on its own thread**, then `build_handler` binds that state into a plain `RequestHandler` closure — so the whole hot path stays a `RequestHandler` and the state is thread-local (no sharing, no mutex). **Zero cost when `make_state` is nil** (`build_handler` returns the stateless handler unchanged).

```v
// usage sketch
struct ThreadCtx { mut: db pg.DB }
http_server.new_server(http_server.ServerConfig{
    io_multiplexing:  .epoll
    make_state:       fn () voidptr { return &ThreadCtx{ db: pg.connect(cfg)! } } // once per worker
    stateful_handler: fn (req []u8, fd int, mut out []u8, state voidptr) ! {
        mut ctx := unsafe { &ThreadCtx(state) }                                   // this thread's own conn
        // ... ctx.db.exec_prepared(...) — no pool, no mutex
    }
})!
```

The opaque-`voidptr` contract is the same one picoev (`cb_arg`) and libuv (`data`) use: the server hands back exactly the pointer `make_state` returned, so the handler's `unsafe { &T(state) }` cast is sound, and the GC keeps the state alive via the worker's thread-local root.

## Why

Foundation for the **async, epoll-integrated DB driver (#32)**: each worker owns its own non-blocking connection(s) and in-flight map. The PoC in #32 shows a single thread going from ~8.7K → ~50K queries/sec (~6×) once it can keep many queries in flight — which needs exactly this per-thread ownership.

**Honest scope:** this is deliberately opt-in and **not used by the bundled frameworks yet**. The per-thread *connection* experiment on its own measured throughput-neutral (the pool mutex was never the bottleneck — it's ~ns vs the ~ms DB round-trip; details in #32). The value here is the async groundwork, not a standalone win, so it ships as a primitive with zero impact on existing users.

## Validation

- Builds on **V 0.5.1 (release)** and **source-built V** (the source-vs-release distinction that bit a prior GC change does not apply — this is pure V, no `GC_malloc_atomic`/`.noscan_data`).
- `http_server/server_test.v` and `examples/simple/src/server_end_to_end_test.v` pass on both.
- 16-worker smoke run: 16 independent, lock-free per-thread states; all endpoints correct.
- The stateless path is **byte-identical** (the `build_handler` short-circuit returns `request_handler` when `make_state == nil`).

Refs #32
