### PR TITLE
feat(http_server): async runtime in the epoll worker — watch(fd)+continuation primitive

### DIFF
--- a/.github/workflows/build_test_examples_on_linux.yml
+++ b/.github/workflows/build_test_examples_on_linux.yml
@@ -33,7 +33,12 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
-          sudo apt update && sudo apt upgrade -y linux-generic
+          # Just the build deps. The previous `apt upgrade -y linux-generic` pulled a
+          # full kernel package set (linux-image/headers/firmware) on every run — slow
+          # and flaky (dpkg "cannot perform the following tasks"), and pointless for
+          # building examples: liburing-dev is userspace and linux-libc-dev already
+          # ships the io_uring headers, neither needs a running-kernel upgrade.
+          sudo apt-get update
           sudo apt-get install -y libsqlite3-dev liburing-dev linux-libc-dev
       - name: Build ${{ matrix.folder }}
         shell: bash

--- a/examples/async_timer/main.v
+++ b/examples/async_timer/main.v
@@ -1,0 +1,67 @@
+module main
+
+// Async-runtime example (no database needed): the smallest consumer of the
+// opt-in `watch(fd)+continuation` primitive. `/delay?ms=N` PARKS the request on
+// a `timerfd` and replies "delayed" when it fires — the single worker keeps
+// serving other connections meanwhile, so N concurrent /delay requests overlap
+// instead of serializing. Every other path replies immediately.
+//
+// Run:   v run examples/async_timer/
+// Try:   curl 'http://localhost:8091/delay?ms=300'
+//        # 20 concurrent 500ms delays finish in ~0.5s, not 10s:
+//        seq 20 | xargs -P20 -I{} curl -s 'http://localhost:8091/delay?ms=500' >/dev/null
+//
+// The same `ac.watch(...)` primitive drives an async DB query (watch the DB
+// socket), a reverse proxy (watch the upstream socket), or SSE/WebSocket
+// backpressure (watch the client for EPOLLOUT). See core.AsyncHandler.
+import http_server
+import http_server.core
+
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+fn C.timerfd_create(clockid int, flags int) int
+fn C.timerfd_settime(fd int, flags int, new_value voidptr, old_value voidptr) int
+fn C.read(fd int, buf voidptr, count usize) int
+
+const resp_ok = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
+
+// handle is the async request handler. For /delay it arms a one-shot timerfd and
+// parks the request on it (returns .suspend); the worker resumes `timer_done`
+// when the timer fires. Anything else is answered immediately (.done).
+fn handle(req []u8, mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	if req.bytestr().contains('/delay') {
+		ms := 200
+		tfd := C.timerfd_create(C.CLOCK_MONOTONIC, 0)
+		// struct itimerspec = { it_interval{sec,nsec}, it_value{sec,nsec} } = 4×i64.
+		mut spec := [4]i64{}
+		spec[2] = i64(ms / 1000)
+		spec[3] = i64(ms % 1000) * 1_000_000
+		C.timerfd_settime(tfd, 0, voidptr(&spec[0]), unsafe { nil })
+		ac.watch(tfd, u32(C.EPOLLIN), timer_done, unsafe { nil })
+		return .suspend
+	}
+	out << resp_ok
+	return .done
+}
+
+// timer_done runs when the timerfd is readable: drain it, close it (the request
+// owns it), append the response, and finish.
+fn timer_done(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	mut tmp := [8]u8{}
+	C.read(ac.ready_fd(), &tmp[0], 8)
+	C.close(ac.ready_fd())
+	body := 'delayed'
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ${body.len}\r\nConnection: keep-alive\r\n\r\n${body}'.bytes()
+	return .done
+}
+
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:            8091
+		io_multiplexing: .epoll
+		async_handler:   handle
+	})!
+	server.run()
+}

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -21,7 +21,6 @@ module backend_epoll
 // (no pipelining-while-suspended), request-owned watched fds (the continuation
 // or close path owns ext_fd's lifetime). Pipelining-while-suspended, parked-conn
 // timeouts, and pool-owned (non-closing) watched fds are follow-ups.
-
 import http_server.core
 import http_server.epoll
 import http_server.socket
@@ -109,8 +108,8 @@ fn process_events_async(worker_id int, epoll_fd int, async_handler core.AsyncHan
 				}
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
-				async_handle_readable(async_handler, mut reactor, epoll_fd, fd, limits,
-					counter, active_conns, mut st, state)
+				async_handle_readable(async_handler, mut reactor, epoll_fd, fd, limits, counter,
+					active_conns, mut st, state)
 			}
 		}
 	}
@@ -132,7 +131,11 @@ fn async_handle_readable(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd
 		}
 		return
 	}
-	req_cap := if limits.max_request_bytes > 0 { limits.max_request_bytes } else { sm_max_request_bytes }
+	req_cap := if limits.max_request_bytes > 0 {
+		limits.max_request_bytes
+	} else {
+		sm_max_request_bytes
+	}
 	for {
 		if cs.read_buf.len == cs.read_buf.cap {
 			unsafe { cs.read_buf.grow_cap(cs.read_buf.cap) }
@@ -171,13 +174,14 @@ fn async_handle_readable(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd
 			431 { cs.write_buf << response.status_431_response }
 			else { cs.write_buf << response.tiny_bad_request_response }
 		}
+
 		if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
 			close_conn(epoll_fd, fd, active_conns, mut st)
 		}
 		return
 	}
 	if total < 0 {
-		return // incomplete — wait for the next edge
+		return
 	}
 	req := unsafe { cs.read_buf[0..total] }
 	mut ac := core.AsyncCtx{
@@ -209,7 +213,7 @@ fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, e
 	}
 	mut cs := st.conns[client_fd]
 	if unsafe { cs == nil } {
-		return // client went away
+		return
 	}
 	cs.awaiting_fd = -1
 	mut ac := core.AsyncCtx{

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -2,9 +2,13 @@ module backend_epoll
 
 // Opt-in async runtime for the epoll worker.
 //
-// This is an ISOLATED worker path: when ServerConfig.async_handler is set, the
-// server spawns `process_events_async` instead of the synchronous
-// `process_events_plain`, so the synchronous hot path is untouched.
+// There is ONE worker (process_events_plain in worker_linux.c.v). When
+// ServerConfig.async_handler is set it additionally owns an AsyncReactor and
+// routes watched-fd readiness + client reads through the helpers in this file;
+// when it is not set, a single per-worker `has_async` bool skips all of this, so
+// the synchronous hot path (and all its optimizations: pipelining, the busy-poll
+// hybrid, large-body streaming-drain, sendfile, EPOLLOUT backpressure) is shared
+// by the async path for free and is byte-for-byte unchanged when async is off.
 //
 // The model is a small single-threaded reactor. A handler that needs to wait on
 // something (a DB socket, an upstream connection, a timerfd, the client becoming
@@ -23,7 +27,6 @@ module backend_epoll
 // timeouts, and pool-owned (non-closing) watched fds are follow-ups.
 import http_server.core
 import http_server.epoll
-import http_server.socket
 import http_server.http1_1.request_parser
 import http_server.http1_1.response
 
@@ -62,58 +65,11 @@ fn async_register(mut ac core.AsyncCtx, ext_fd int, events u32, cont core.WakeFn
 	ac.last_watched = ext_fd
 }
 
-// process_events_async is the async worker loop. It owns its connection table
-// (reusing ConnState + the flush/close helpers) and its watch registry. Client
-// fds and watched external fds share this one epoll instance.
-@[direct_array_access; manualfree]
-fn process_events_async(worker_id int, epoll_fd int, async_handler core.AsyncHandler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
-	maybe_pin_worker(worker_id)
-	core.enable_sendfile()
-	mut state := voidptr(unsafe { nil })
-	if make_state != unsafe { nil } {
-		state = make_state()
-	}
-	mut reactor := AsyncReactor{
-		watches: map[int]WatchEntry{}
-	}
-	mut events := [socket.max_connection_size]C.epoll_event{}
-	mut st := new_plain_state()
-	for {
-		num_events := C.epoll_wait(epoll_fd, &events[0], socket.max_connection_size, -1)
-		if num_events < 0 {
-			if C.errno == C.EINTR {
-				continue
-			}
-			C.perror(c'epoll_wait')
-			break
-		}
-		for i in 0 .. num_events {
-			fd := epoll.event_fd(events[i])
-			ev := events[i].events
-			// Is this a watched external fd? Run its continuation.
-			if entry := reactor.watches[fd] {
-				async_on_ready(async_handler, mut reactor, epoll_fd, fd, entry, limits, counter,
-					active_conns, mut st, state)
-				continue
-			}
-			// Otherwise it is a client connection.
-			if ev & u32(C.EPOLLHUP | C.EPOLLERR) != 0 {
-				async_close(mut reactor, epoll_fd, fd, active_conns, mut st)
-				continue
-			}
-			if ev & u32(C.EPOLLOUT) != 0 {
-				// A parked response batch finished draining: reuse the plain writer.
-				if !handle_writable_plain(epoll_fd, fd, active_conns, mut st) {
-					continue
-				}
-			}
-			if ev & u32(C.EPOLLIN) != 0 {
-				async_handle_readable(async_handler, mut reactor, epoll_fd, fd, limits, counter,
-					active_conns, mut st, state)
-			}
-		}
-	}
-}
+// The async runtime is driven by the ONE plain worker (process_events_plain in
+// worker_linux.c.v): when async_handler is set it owns an AsyncReactor and routes
+// watched-fd readiness to async_on_ready and client reads to async_handle_readable
+// (below). This file holds only those async helpers — the event loop, accept, the
+// busy-poll hybrid and the timeout sweep are all shared with the synchronous path.
 
 // async_handle_readable reads the request, calls the async handler ONCE, and
 // reads the socket, answers every complete request, and parks only when a

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -116,21 +116,28 @@ fn process_events_async(worker_id int, epoll_fd int, async_handler core.AsyncHan
 }
 
 // async_handle_readable reads the request, calls the async handler ONCE, and
-// acts on the returned step. v1 serves one request per connection at a time.
+// reads the socket, answers every complete request, and parks only when a
+// handler actually suspends.
 @[direct_array_access; manualfree]
 fn async_handle_readable(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState, state voidptr) {
 	mut cs := state_for(mut st, fd)
-	// Parked on a watch: a readable edge here means the client sent more or hung
-	// up. v1 doesn't pipeline while suspended — peek to detect a close and tear
-	// the watch down; otherwise ignore until the in-flight watch completes.
+	// Already parked on a watch: a readable edge here is either the client hanging
+	// up or pipelining ahead. Peek to detect a close (tear the watch down); any
+	// data stays in the socket buffer and is read once the in-flight watch resumes.
 	if cs.awaiting_fd >= 0 {
 		mut probe := [1]u8{}
-		r := C.recv(fd, &probe[0], 1, C.MSG_PEEK)
-		if r == 0 {
+		if C.recv(fd, &probe[0], 1, C.MSG_PEEK) == 0 {
 			async_close(mut reactor, epoll_fd, fd, active_conns, mut st)
 		}
 		return
 	}
+	async_serve(h, mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs, state)
+}
+
+// async_serve drains the socket into the read buffer (edge-triggered: to EAGAIN),
+// then answers every complete request (pipelining), flushing the batch at the end.
+@[direct_array_access; manualfree]
+fn async_serve(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState, state voidptr) {
 	req_cap := if limits.max_request_bytes > 0 {
 		limits.max_request_bytes
 	} else {
@@ -157,9 +164,6 @@ fn async_handle_readable(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd
 			cs.read_buf.len += n
 		}
 	}
-	if cs.read_buf.len == 0 {
-		return
-	}
 	if cs.read_buf.len > req_cap {
 		cs.write_buf << response.status_413_response
 		if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
@@ -167,40 +171,89 @@ fn async_handle_readable(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd
 		}
 		return
 	}
-	total := request_parser.frame_request_length_lim(cs.read_buf, limits.max_header_bytes,
-		limits.max_body_bytes) or {
-		match err.code() {
-			413 { cs.write_buf << response.status_413_response }
-			431 { cs.write_buf << response.status_431_response }
-			else { cs.write_buf << response.tiny_bad_request_response }
-		}
+	if !async_drain(h, mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs, state) {
+		return // connection closed inside the drain
+	}
+	if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
+		flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
+	}
+}
 
-		if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
-			close_conn(epoll_fd, fd, active_conns, mut st)
+// async_drain answers every complete request currently buffered, appending each
+// response to write_buf, and STOPS at the first request that suspends (it parks;
+// the rest stay buffered and are drained when the watch resumes). Mirrors the
+// synchronous drain_requests but with the async step contract. Returns false if
+// the connection was closed (the caller must not touch it).
+@[direct_array_access; manualfree]
+fn async_drain(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState, state voidptr) bool {
+	mut pos := 0
+	for pos < cs.read_buf.len && cs.awaiting_fd < 0 {
+		total := request_parser.frame_request_length_lim(cs.read_buf[pos..], limits.max_header_bytes,
+			limits.max_body_bytes) or {
+			match err.code() {
+				413 { cs.write_buf << response.status_413_response }
+				431 { cs.write_buf << response.status_431_response }
+				else { cs.write_buf << response.tiny_bad_request_response }
+			}
+			async_compact(mut cs, pos)
+			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+				close_conn(epoll_fd, fd, active_conns, mut st)
+			}
+			return false
 		}
+		if total < 0 {
+			break // incomplete — wait for more bytes
+		}
+		req := unsafe { cs.read_buf[pos..pos + total] }
+		mut ac := core.AsyncCtx{
+			client_fd: fd
+			state:     state
+			epoll_fd:  epoll_fd
+			reactor:   unsafe { voidptr(&reactor) }
+			register:  async_register
+		}
+		step := h(req, mut cs.write_buf, mut ac)
+		pos += total
+		match step {
+			.done {} // response appended; answer the next buffered request
+			.suspend {
+				cs.awaiting_fd = ac.last_watched // park; leftover stays buffered for resume
+			}
+			.close {
+				async_compact(mut cs, pos)
+				if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+					close_conn(epoll_fd, fd, active_conns, mut st)
+				}
+				return false
+			}
+		}
+		// Peer pipelines without reading responses: bail before the batch is unbounded.
+		if cs.write_buf.len - cs.write_off > sm_max_pending_write {
+			async_compact(mut cs, pos)
+			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+				close_conn(epoll_fd, fd, active_conns, mut st)
+			}
+			return false
+		}
+	}
+	async_compact(mut cs, pos)
+	return true
+}
+
+// async_compact drops the first `pos` consumed bytes, keeping the leftover
+// (partial / not-yet-answered) request at the buffer front.
+@[direct_array_access; inline]
+fn async_compact(mut cs ConnState, pos int) {
+	if pos <= 0 {
 		return
 	}
-	if total < 0 {
-		return
-	}
-	req := unsafe { cs.read_buf[0..total] }
-	mut ac := core.AsyncCtx{
-		client_fd: fd
-		state:     state
-		epoll_fd:  epoll_fd
-		reactor:   unsafe { voidptr(&reactor) }
-		register:  async_register
-	}
-	step := h(req, mut cs.write_buf, mut ac)
-	// Consume the request from the read buffer (compact leftover to the front).
-	leftover := cs.read_buf.len - total
+	leftover := cs.read_buf.len - pos
 	if leftover > 0 {
-		unsafe { C.memmove(cs.read_buf.data, &u8(cs.read_buf.data) + total, usize(leftover)) }
+		unsafe { C.memmove(cs.read_buf.data, &u8(cs.read_buf.data) + pos, usize(leftover)) }
 	}
 	unsafe {
 		cs.read_buf.len = leftover
 	}
-	async_apply_step(step, mut ac, epoll_fd, fd, limits, active_conns, mut st, mut cs)
 }
 
 // async_on_ready runs a parked request's continuation when its watched fd fires.
@@ -225,24 +278,18 @@ fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, e
 		reactor:   unsafe { voidptr(&reactor) }
 		register:  async_register
 	}
-	step := entry.cont(mut cs.write_buf, mut ac)
-	async_apply_step(step, mut ac, epoll_fd, client_fd, limits, active_conns, mut st, mut cs)
-}
-
-// async_apply_step performs the worker action for a handler/continuation result.
-@[inline]
-fn async_apply_step(step core.AsyncStep, mut ac core.AsyncCtx, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) {
-	match step {
+	match entry.cont(mut cs.write_buf, mut ac) {
 		.done {
-			if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
-				flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
-			}
+			// Send this response and drain any requests that were pipelined behind it
+			// (and read anything that arrived while parked) — one batched flush.
+			async_serve(h, mut reactor, epoll_fd, client_fd, limits, active_conns, mut st, mut
+				cs, state)
 		}
 		.suspend {
-			cs.awaiting_fd = ac.last_watched // parked; resumed when that fd fires
+			cs.awaiting_fd = ac.last_watched // re-armed (multi-step); stay parked
 		}
 		.close {
-			close_conn(epoll_fd, fd, active_conns, mut st)
+			close_conn(epoll_fd, client_fd, active_conns, mut st)
 		}
 	}
 }

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -172,7 +172,7 @@ fn async_serve(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd i
 		return
 	}
 	if !async_drain(h, mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs, state) {
-		return // connection closed inside the drain
+		return
 	}
 	if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
 		flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
@@ -188,13 +188,14 @@ fn async_serve(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd i
 fn async_drain(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState, state voidptr) bool {
 	mut pos := 0
 	for pos < cs.read_buf.len && cs.awaiting_fd < 0 {
-		total := request_parser.frame_request_length_lim(cs.read_buf[pos..], limits.max_header_bytes,
-			limits.max_body_bytes) or {
+		total := request_parser.frame_request_length_lim(cs.read_buf[pos..],
+			limits.max_header_bytes, limits.max_body_bytes) or {
 			match err.code() {
 				413 { cs.write_buf << response.status_413_response }
 				431 { cs.write_buf << response.status_431_response }
 				else { cs.write_buf << response.tiny_bad_request_response }
 			}
+
 			async_compact(mut cs, pos)
 			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
 				close_conn(epoll_fd, fd, active_conns, mut st)
@@ -227,6 +228,7 @@ fn async_drain(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd i
 				return false
 			}
 		}
+
 		// Peer pipelines without reading responses: bail before the batch is unbounded.
 		if cs.write_buf.len - cs.write_off > sm_max_pending_write {
 			async_compact(mut cs, pos)
@@ -282,8 +284,8 @@ fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, e
 		.done {
 			// Send this response and drain any requests that were pipelined behind it
 			// (and read anything that arrived while parked) — one batched flush.
-			async_serve(h, mut reactor, epoll_fd, client_fd, limits, active_conns, mut st, mut
-				cs, state)
+			async_serve(h, mut reactor, epoll_fd, client_fd, limits, active_conns, mut st, mut cs,
+				state)
 		}
 		.suspend {
 			cs.awaiting_fd = ac.last_watched // re-armed (multi-step); stay parked

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -1,0 +1,258 @@
+module backend_epoll
+
+// Opt-in async runtime for the epoll worker.
+//
+// This is an ISOLATED worker path: when ServerConfig.async_handler is set, the
+// server spawns `process_events_async` instead of the synchronous
+// `process_events_plain`, so the synchronous hot path is untouched.
+//
+// The model is a small single-threaded reactor. A handler that needs to wait on
+// something (a DB socket, an upstream connection, a timerfd, the client becoming
+// writable, ...) calls `ac.watch(ext_fd, events, continuation, udata)` and
+// returns `.suspend`. The worker registers the external fd in its OWN epoll,
+// PARKS the connection (its response is not produced yet), and goes on serving
+// other connections. When `ext_fd` is ready the worker runs the continuation,
+// which appends the response and returns `.done` (send + unpark) or re-arms a
+// watch and returns `.suspend` (multi-step chains: connect → send → recv).
+//
+// The DB driver, reverse-proxy/upstream calls, timers, and SSE/WebSocket
+// backpressure are all CONSUMERS of this one `watch` primitive — see the
+// async-runtime umbrella issue. v1 scope: one in-flight watch per connection
+// (no pipelining-while-suspended), request-owned watched fds (the continuation
+// or close path owns ext_fd's lifetime). Pipelining-while-suspended, parked-conn
+// timeouts, and pool-owned (non-closing) watched fds are follow-ups.
+
+import http_server.core
+import http_server.epoll
+import http_server.socket
+import http_server.http1_1.request_parser
+import http_server.http1_1.response
+
+#include <errno.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+
+// WatchEntry records one parked request: which client connection is waiting, the
+// continuation to run when the watched fd is ready, and the consumer's opaque
+// context handed back via AsyncCtx.udata.
+struct WatchEntry {
+	client_fd int
+	cont      core.WakeFn = unsafe { nil }
+	udata     voidptr
+}
+
+// AsyncReactor is the per-worker watch registry: external fd -> parked request.
+// One per worker thread (so it needs no lock).
+struct AsyncReactor {
+mut:
+	watches map[int]WatchEntry
+}
+
+// async_register is installed into AsyncCtx.register; it is what `ac.watch(...)`
+// ultimately calls. It records the watch and adds the external fd to this
+// worker's epoll (level-triggered: simplest correct default for arbitrary
+// consumer fds). Runs on the worker thread, so no synchronization is needed.
+fn async_register(mut ac core.AsyncCtx, ext_fd int, events u32, cont core.WakeFn, udata voidptr) {
+	mut r := unsafe { &AsyncReactor(ac.reactor) }
+	r.watches[ext_fd] = WatchEntry{
+		client_fd: ac.client_fd
+		cont:      cont
+		udata:     udata
+	}
+	epoll.add_fd_to_epoll(ac.epoll_fd, ext_fd, events)
+	ac.last_watched = ext_fd
+}
+
+// process_events_async is the async worker loop. It owns its connection table
+// (reusing ConnState + the flush/close helpers) and its watch registry. Client
+// fds and watched external fds share this one epoll instance.
+@[direct_array_access; manualfree]
+fn process_events_async(worker_id int, epoll_fd int, async_handler core.AsyncHandler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
+	maybe_pin_worker(worker_id)
+	core.enable_sendfile()
+	mut state := voidptr(unsafe { nil })
+	if make_state != unsafe { nil } {
+		state = make_state()
+	}
+	mut reactor := AsyncReactor{
+		watches: map[int]WatchEntry{}
+	}
+	mut events := [socket.max_connection_size]C.epoll_event{}
+	mut st := new_plain_state()
+	for {
+		num_events := C.epoll_wait(epoll_fd, &events[0], socket.max_connection_size, -1)
+		if num_events < 0 {
+			if C.errno == C.EINTR {
+				continue
+			}
+			C.perror(c'epoll_wait')
+			break
+		}
+		for i in 0 .. num_events {
+			fd := epoll.event_fd(events[i])
+			ev := events[i].events
+			// Is this a watched external fd? Run its continuation.
+			if entry := reactor.watches[fd] {
+				async_on_ready(async_handler, mut reactor, epoll_fd, fd, entry, limits, counter,
+					active_conns, mut st, state)
+				continue
+			}
+			// Otherwise it is a client connection.
+			if ev & u32(C.EPOLLHUP | C.EPOLLERR) != 0 {
+				async_close(mut reactor, epoll_fd, fd, active_conns, mut st)
+				continue
+			}
+			if ev & u32(C.EPOLLOUT) != 0 {
+				// A parked response batch finished draining: reuse the plain writer.
+				if !handle_writable_plain(epoll_fd, fd, active_conns, mut st) {
+					continue
+				}
+			}
+			if ev & u32(C.EPOLLIN) != 0 {
+				async_handle_readable(async_handler, mut reactor, epoll_fd, fd, limits,
+					counter, active_conns, mut st, state)
+			}
+		}
+	}
+}
+
+// async_handle_readable reads the request, calls the async handler ONCE, and
+// acts on the returned step. v1 serves one request per connection at a time.
+@[direct_array_access; manualfree]
+fn async_handle_readable(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState, state voidptr) {
+	mut cs := state_for(mut st, fd)
+	// Parked on a watch: a readable edge here means the client sent more or hung
+	// up. v1 doesn't pipeline while suspended — peek to detect a close and tear
+	// the watch down; otherwise ignore until the in-flight watch completes.
+	if cs.awaiting_fd >= 0 {
+		mut probe := [1]u8{}
+		r := C.recv(fd, &probe[0], 1, C.MSG_PEEK)
+		if r == 0 {
+			async_close(mut reactor, epoll_fd, fd, active_conns, mut st)
+		}
+		return
+	}
+	req_cap := if limits.max_request_bytes > 0 { limits.max_request_bytes } else { sm_max_request_bytes }
+	for {
+		if cs.read_buf.len == cs.read_buf.cap {
+			unsafe { cs.read_buf.grow_cap(cs.read_buf.cap) }
+		}
+		spare := cs.read_buf.cap - cs.read_buf.len
+		n := C.recv(fd, unsafe { &u8(cs.read_buf.data) + cs.read_buf.len }, usize(spare), 0)
+		if n < 0 {
+			if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
+				break
+			}
+			close_conn(epoll_fd, fd, active_conns, mut st)
+			return
+		}
+		if n == 0 {
+			close_conn(epoll_fd, fd, active_conns, mut st)
+			return
+		}
+		unsafe {
+			cs.read_buf.len += n
+		}
+	}
+	if cs.read_buf.len == 0 {
+		return
+	}
+	if cs.read_buf.len > req_cap {
+		cs.write_buf << response.status_413_response
+		if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+			close_conn(epoll_fd, fd, active_conns, mut st)
+		}
+		return
+	}
+	total := request_parser.frame_request_length_lim(cs.read_buf, limits.max_header_bytes,
+		limits.max_body_bytes) or {
+		match err.code() {
+			413 { cs.write_buf << response.status_413_response }
+			431 { cs.write_buf << response.status_431_response }
+			else { cs.write_buf << response.tiny_bad_request_response }
+		}
+		if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+			close_conn(epoll_fd, fd, active_conns, mut st)
+		}
+		return
+	}
+	if total < 0 {
+		return // incomplete — wait for the next edge
+	}
+	req := unsafe { cs.read_buf[0..total] }
+	mut ac := core.AsyncCtx{
+		client_fd: fd
+		state:     state
+		epoll_fd:  epoll_fd
+		reactor:   unsafe { voidptr(&reactor) }
+		register:  async_register
+	}
+	step := h(req, mut cs.write_buf, mut ac)
+	// Consume the request from the read buffer (compact leftover to the front).
+	leftover := cs.read_buf.len - total
+	if leftover > 0 {
+		unsafe { C.memmove(cs.read_buf.data, &u8(cs.read_buf.data) + total, usize(leftover)) }
+	}
+	unsafe {
+		cs.read_buf.len = leftover
+	}
+	async_apply_step(step, mut ac, epoll_fd, fd, limits, active_conns, mut st, mut cs)
+}
+
+// async_on_ready runs a parked request's continuation when its watched fd fires.
+@[direct_array_access; manualfree]
+fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, ext_fd int, entry WatchEntry, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState, state voidptr) {
+	reactor.watches.delete(ext_fd) // consumed; the continuation re-arms if it needs more
+	client_fd := entry.client_fd
+	if client_fd >= st.conns.len {
+		return
+	}
+	mut cs := st.conns[client_fd]
+	if unsafe { cs == nil } {
+		return // client went away
+	}
+	cs.awaiting_fd = -1
+	mut ac := core.AsyncCtx{
+		client_fd: client_fd
+		ready_fd:  ext_fd
+		udata:     entry.udata
+		state:     state
+		epoll_fd:  epoll_fd
+		reactor:   unsafe { voidptr(&reactor) }
+		register:  async_register
+	}
+	step := entry.cont(mut cs.write_buf, mut ac)
+	async_apply_step(step, mut ac, epoll_fd, client_fd, limits, active_conns, mut st, mut cs)
+}
+
+// async_apply_step performs the worker action for a handler/continuation result.
+@[inline]
+fn async_apply_step(step core.AsyncStep, mut ac core.AsyncCtx, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) {
+	match step {
+		.done {
+			if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
+				flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
+			}
+		}
+		.suspend {
+			cs.awaiting_fd = ac.last_watched // parked; resumed when that fd fires
+		}
+		.close {
+			close_conn(epoll_fd, fd, active_conns, mut st)
+		}
+	}
+}
+
+// async_close tears down a connection, first removing any watch it is parked on
+// (which closes that request-owned fd, e.g. a timerfd) so nothing leaks.
+@[direct_array_access; manualfree]
+fn async_close(mut reactor AsyncReactor, epoll_fd int, fd int, active_conns &core.Counter, mut st PlainState) {
+	if fd < st.conns.len {
+		cs := st.conns[fd]
+		if unsafe { cs != nil } && cs.awaiting_fd >= 0 {
+			reactor.watches.delete(cs.awaiting_fd)
+			epoll.remove_fd_from_epoll(epoll_fd, cs.awaiting_fd) // DEL + close the ext fd
+		}
+	}
+	close_conn(epoll_fd, fd, active_conns, mut st)
+}

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -85,6 +85,10 @@ mut:
 	// head was already answered, this many body bytes are still to be consumed
 	// off the socket before the connection is ready for its next request.
 	body_drain i64
+	// Async runtime only (unused by the synchronous path): the external fd this
+	// connection is parked on while awaiting a watch (-1 = not parked). Lets the
+	// async worker tear the watch down if the client closes mid-await.
+	awaiting_fd int = -1
 }
 
 // PlainState is the per-worker connection table. `parked` counts connections

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -113,32 +113,39 @@ fn handle_accept_loop(socket_fd int, main_epoll_fd int, epoll_fds []int, limits 
 	}
 }
 
-// build_handler resolves the effective per-worker handler. With no make_state it
-// is just the stateless request_handler. With make_state it runs ONCE on the
-// calling (worker) thread to build that thread's state, then returns a stateless
-// closure that forwards every request through stateful_handler with that state —
-// so the rest of the hot path stays a plain RequestHandler and the state is
-// thread-local (no sharing, no lock). Must be called from inside the worker.
-fn build_handler(request_handler core.RequestHandler, stateful_handler core.StatefulHandler, make_state fn () voidptr) core.RequestHandler {
-	if make_state == unsafe { nil } {
+// build_handler resolves the effective synchronous per-worker handler. With no
+// stateful_handler it is just the stateless request_handler; otherwise it binds
+// this worker's `state` into a plain RequestHandler closure so the hot path stays
+// a plain RequestHandler and the state is thread-local (no sharing, no lock).
+fn build_handler(request_handler core.RequestHandler, stateful_handler core.StatefulHandler, state voidptr) core.RequestHandler {
+	if stateful_handler == unsafe { nil } {
 		return request_handler
 	}
-	state := make_state()
 	return fn [state, stateful_handler] (req []u8, fd int, mut out []u8) ! {
 		stateful_handler(req, fd, mut out, state)!
 	}
 }
 
 // Plain (HTTP) worker: owns the per-fd connection state table (persistent
-// buffers, cross-edge reads, EPOLLOUT writes).
+// buffers, cross-edge reads, EPOLLOUT writes). ONE worker for both the
+// synchronous and the async-runtime paths: with an async_handler it also owns a
+// watch registry and resumes parked requests when a watched fd fires; otherwise
+// the async branches are skipped entirely (a single per-worker `has_async` bool)
+// so the synchronous hot path is byte-for-byte unchanged.
 @[direct_array_access; manualfree]
-fn process_events_plain(worker_id int, epoll_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
+fn process_events_plain(worker_id int, epoll_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, async_handler core.AsyncHandler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
 	maybe_pin_worker(worker_id)
-	// Per-thread state path: build THIS worker's state once, then bind it into a
-	// plain RequestHandler closure so the rest of the hot path is unchanged. The
-	// state is constructed here, inside the spawned worker, so it is thread-local
-	// (e.g. this worker's own DB connection) — no sharing, no lock.
-	handler := build_handler(request_handler, stateful_handler, make_state)
+	// Build THIS worker's per-thread state once (e.g. its own DB connection) — used
+	// by the stateful sync handler closure AND passed to async handlers via AsyncCtx.
+	mut state := voidptr(unsafe { nil })
+	if make_state != unsafe { nil } {
+		state = make_state()
+	}
+	has_async := async_handler != unsafe { nil }
+	handler := build_handler(request_handler, stateful_handler, state) // sync path
+	mut reactor := AsyncReactor{
+		watches: map[int]WatchEntry{}
+	} // async path: ext_fd -> parked request
 	// This worker can stream file bodies with sendfile(2): let handlers hand a
 	// file off via core.queue_file instead of copying it through write_buf.
 	core.enable_sendfile()
@@ -175,8 +182,20 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 		for i in 0 .. num_events {
 			fd := epoll.event_fd(events[i])
 			ev := events[i].events
+			// Async only: a watched external fd became ready → run its continuation.
+			if has_async {
+				if entry := reactor.watches[fd] {
+					async_on_ready(async_handler, mut reactor, epoll_fd, fd, entry, limits,
+						counter, active_conns, mut st, state)
+					continue
+				}
+			}
 			if ev & u32(C.EPOLLHUP | C.EPOLLERR) != 0 {
-				close_conn(epoll_fd, fd, active_conns, mut st)
+				if has_async {
+					async_close(mut reactor, epoll_fd, fd, active_conns, mut st) // tear any watch down first
+				} else {
+					close_conn(epoll_fd, fd, active_conns, mut st)
+				}
 				continue
 			}
 			if ev & u32(C.EPOLLOUT) != 0 {
@@ -185,7 +204,13 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 				}
 			}
 			if ev & u32(C.EPOLLIN) != 0 {
-				handle_readable_plain(handler, epoll_fd, fd, limits, counter, active_conns, mut st)
+				if has_async {
+					async_handle_readable(async_handler, mut reactor, epoll_fd, fd, limits,
+						counter, active_conns, mut st, state)
+				} else {
+					handle_readable_plain(handler, epoll_fd, fd, limits, counter, active_conns, mut
+						st)
+				}
 			}
 		}
 		// After handling this batch (or a timeout wake with num_events == 0),
@@ -282,13 +307,11 @@ pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, sta
 		if tls_config != unsafe { nil } {
 			threads[i] = spawn process_events_tls(i, epoll_fds[i], request_handler,
 				stateful_handler, make_state, limits, counter, active_conns, tls_config)
-		} else if async_handler != unsafe { nil } {
-			// Opt-in async runtime: isolated worker, synchronous path untouched.
-			threads[i] = spawn process_events_async(i, epoll_fds[i], async_handler, make_state,
-				limits, counter, active_conns)
 		} else {
+			// ONE plain worker for both sync and async (async_handler opts in); it skips
+			// all async code via a per-worker bool, so the sync hot path is unchanged.
 			threads[i] = spawn process_events_plain(i, epoll_fds[i], request_handler,
-				stateful_handler, make_state, limits, counter, active_conns)
+				stateful_handler, async_handler, make_state, limits, counter, active_conns)
 		}
 	}
 

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -238,7 +238,7 @@ fn process_events_tls(worker_id int, epoll_fd int, request_handler core.RequestH
 	}
 }
 
-pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, make_state fn () voidptr, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
+pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, async_handler core.AsyncHandler, make_state fn () voidptr, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
 	if socket_fd < 0 {
 		return
 	}
@@ -282,6 +282,10 @@ pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, sta
 		if tls_config != unsafe { nil } {
 			threads[i] = spawn process_events_tls(i, epoll_fds[i], request_handler,
 				stateful_handler, make_state, limits, counter, active_conns, tls_config)
+		} else if async_handler != unsafe { nil } {
+			// Opt-in async runtime: isolated worker, synchronous path untouched.
+			threads[i] = spawn process_events_async(i, epoll_fds[i], async_handler, make_state,
+				limits, counter, active_conns)
 		} else {
 			threads[i] = spawn process_events_plain(i, epoll_fds[i], request_handler,
 				stateful_handler, make_state, limits, counter, active_conns)

--- a/http_server/core/core.v
+++ b/http_server/core/core.v
@@ -24,6 +24,60 @@ pub const max_thread_pool_size = runtime.nr_cpus()
 // Returning an error sends 400 and closes the connection.
 pub type RequestHandler = fn (req []u8, fd int, mut out []u8) !
 
+// --- Async runtime (opt-in) -------------------------------------------------
+//
+// AsyncStep is what an async handler / continuation returns to the worker:
+//   .done    — the response is in `out`; the worker sends it and unparks the conn
+//   .suspend — the handler/continuation registered a watch (ac.watch); the conn
+//              stays parked until that fd is ready (multi-step chains re-suspend)
+//   .close   — error; the worker drops the connection
+pub enum AsyncStep {
+	done
+	suspend
+	close
+}
+
+// WakeFn is a continuation: it runs when a watched fd (ac.ready_fd) becomes
+// ready, may append the response to `out`, and returns the next AsyncStep.
+pub type WakeFn = fn (mut out []u8, mut ac AsyncCtx) AsyncStep
+
+// AsyncHandler is the opt-in async request handler. Like RequestHandler it gets
+// the request bytes and the connection write buffer, but instead of always
+// producing a response it can PARK the request on any fd via `ac.watch(...)` and
+// return .suspend — the worker resumes the registered continuation when that fd
+// is ready, all in the same epoll loop. The DB driver, a reverse proxy, timers,
+// and SSE/WebSocket backpressure are all consumers of this one primitive.
+pub type AsyncHandler = fn (req []u8, mut out []u8, mut ac AsyncCtx) AsyncStep
+
+// AsyncCtx is the per-invocation handle a handler/continuation uses to await an
+// fd. The backend fills it in and installs `register`; handlers only call
+// watch()/ready_fd()/udata()/state(). It is the layering bridge: `core` owns the
+// type and the handler contract, the epoll backend owns the registration logic
+// (added via the `register` fn pointer), so `core` stays backend-free.
+pub struct AsyncCtx {
+pub mut:
+	client_fd    int
+	ready_fd     int = -1 // the fd that woke this continuation (-1 on the initial call)
+	udata        voidptr  // consumer context carried from watch() to the continuation
+	state        voidptr  // this worker's per-thread state (see StatefulHandler/make_state)
+	epoll_fd     int      // backend-filled: the worker's epoll instance
+	reactor      voidptr  // backend-filled: the worker's watch registry
+	last_watched int = -1 // backend-filled: the fd passed to the most recent watch()
+	register     fn (mut ac AsyncCtx, ext_fd int, events u32, cont WakeFn, udata voidptr) = unsafe { nil }
+}
+
+// watch parks the current request and asks the worker to call `cont` when
+// `ext_fd` is ready for `events` (EPOLLIN/EPOLLOUT). `udata` is handed back to
+// the continuation via ac.udata. After calling watch, return .suspend.
+pub fn (mut ac AsyncCtx) watch(ext_fd int, events u32, cont WakeFn, udata voidptr) {
+	ac.register(mut ac, ext_fd, events, cont, udata)
+}
+
+// ready_fd is the fd that woke the running continuation (-1 on the initial call).
+pub fn (ac &AsyncCtx) ready_fd() int {
+	return ac.ready_fd
+}
+
 // StatefulHandler is the per-thread-state variant of RequestHandler. It receives
 // the same arguments PLUS an opaque `state voidptr` — the value the server's
 // `make_state` callback returned for THIS worker thread (and only this one). It

--- a/http_server/core/core.v
+++ b/http_server/core/core.v
@@ -58,10 +58,10 @@ pub struct AsyncCtx {
 pub mut:
 	client_fd    int
 	ready_fd     int = -1 // the fd that woke this continuation (-1 on the initial call)
-	udata        voidptr  // consumer context carried from watch() to the continuation
-	state        voidptr  // this worker's per-thread state (see StatefulHandler/make_state)
-	epoll_fd     int      // backend-filled: the worker's epoll instance
-	reactor      voidptr  // backend-filled: the worker's watch registry
+	udata        voidptr // consumer context carried from watch() to the continuation
+	state        voidptr // this worker's per-thread state (see StatefulHandler/make_state)
+	epoll_fd     int     // backend-filled: the worker's epoll instance
+	reactor      voidptr // backend-filled: the worker's watch registry
 	last_watched int = -1 // backend-filled: the fd passed to the most recent watch()
 	register     fn (mut ac AsyncCtx, ext_fd int, events u32, cont WakeFn, udata voidptr) = unsafe { nil }
 }

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -26,6 +26,7 @@ pub mut:
 	// Per-thread state path (epoll only); see ServerConfig. make_state runs once
 	// per worker thread, stateful_handler receives its result on every request.
 	stateful_handler core.StatefulHandler = unsafe { nil }
+	async_handler    core.AsyncHandler    = unsafe { nil }
 	make_state       fn () voidptr        = unsafe { nil }
 	// Per-worker in-flight request counters (one per worker, each on its own
 	// cache line — written only by its worker, so no contention/false sharing).
@@ -235,24 +236,46 @@ pub:
 	// only; ignored by other backends. See core.StatefulHandler.
 	stateful_handler core.StatefulHandler = unsafe { nil }
 	make_state       fn () voidptr        = unsafe { nil }
-	certificates     Certificates
-	limits           Limits
-	tls_config       &tls.Config = unsafe { nil } // set for HTTPS (e.g. tls.new_self_signed())
+	// async_handler opts into the async runtime: the handler may PARK a request on
+	// any fd via ac.watch(...) and return .suspend, resumed by a continuation when
+	// that fd is ready — all in the worker's epoll loop (DB sockets, upstreams,
+	// timers, EPOLLOUT backpressure). Optional make_state gives each worker its own
+	// state. Linux/epoll only; ignored by other backends. See core.AsyncHandler.
+	async_handler core.AsyncHandler = unsafe { nil }
+	certificates  Certificates
+	limits        Limits
+	tls_config    &tls.Config = unsafe { nil } // set for HTTPS (e.g. tls.new_self_signed())
 }
 
 pub fn new_server(config ServerConfig) !Server {
-	// Exactly one handler path. The per-thread path needs both halves; otherwise a
-	// plain request_handler is required (it would crash on the first call if nil).
-	stateful := config.make_state != unsafe { nil }
-	if stateful {
-		if config.stateful_handler == unsafe { nil } {
-			return error('make_state requires stateful_handler')
-		}
+	// Exactly one handler path: stateless request_handler, per-thread
+	// stateful_handler (+make_state), or async_handler (+optional make_state).
+	has_sync := config.request_handler != unsafe { nil }
+	has_stateful := config.stateful_handler != unsafe { nil }
+	has_async := config.async_handler != unsafe { nil }
+	mut n_handlers := 0
+	if has_sync {
+		n_handlers++
+	}
+	if has_stateful {
+		n_handlers++
+	}
+	if has_async {
+		n_handlers++
+	}
+	if n_handlers != 1 {
+		return error('provide exactly one of request_handler / stateful_handler / async_handler')
+	}
+	if has_stateful && config.make_state == unsafe { nil } {
+		return error('stateful_handler requires make_state')
+	}
+	if has_stateful || has_async {
 		$if !linux {
-			return error('per-thread state (make_state) is only supported on the Linux epoll backend')
+			return error('stateful_handler / async_handler are only supported on the Linux epoll backend')
 		}
-	} else if config.request_handler == unsafe { nil } {
-		return error('request_handler is required (or set make_state + stateful_handler)')
+		if config.io_multiplexing != .epoll {
+			return error('stateful_handler / async_handler require the epoll backend')
+		}
 	}
 
 	socket_fd := socket.create_server_socket(config.port)
@@ -293,6 +316,7 @@ pub fn new_server(config ServerConfig) !Server {
 		socket_fd:        socket_fd
 		request_handler:  config.request_handler
 		stateful_handler: config.stateful_handler
+		async_handler:    config.async_handler
 		make_state:       config.make_state
 		limits:           config.limits
 		tls_config:       config.tls_config

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -270,11 +270,15 @@ pub fn new_server(config ServerConfig) !Server {
 		return error('stateful_handler requires make_state')
 	}
 	if has_stateful || has_async {
-		$if !linux {
+		// epoll-only for now. The `.epoll` enum value exists only in the Linux
+		// IOBackend, so the check must live inside `$if linux` — otherwise this
+		// all-platform file fails to compile on macOS (.kqueue) / Windows (.iocp).
+		$if linux {
+			if config.io_multiplexing != .epoll {
+				return error('stateful_handler / async_handler require the epoll backend')
+			}
+		} $else {
 			return error('stateful_handler / async_handler are only supported on the Linux epoll backend')
-		}
-		if config.io_multiplexing != .epoll {
-			return error('stateful_handler / async_handler require the epoll backend')
 		}
 	}
 

--- a/http_server/http_server_linux.c.v
+++ b/http_server/http_server_linux.c.v
@@ -15,8 +15,8 @@ fn run_selected_backend(server Server, mut threads []thread) {
 	match server.io_multiplexing {
 		.epoll {
 			backend_epoll.run_epoll_backend(server.socket_fd, server.request_handler,
-				server.stateful_handler, server.make_state, server.port, server.limits,
-				server.inflight, server.active_conns, server.tls_config, mut threads)
+				server.stateful_handler, server.async_handler, server.make_state, server.port,
+				server.limits, server.inflight, server.active_conns, server.tls_config, mut threads)
 		}
 		.io_uring {
 			run_io_uring_backend(server, mut threads)


### PR DESCRIPTION
## What

An **opt-in async runtime** in the epoll worker: a handler can **park** a request on **any fd** and resume via a **continuation** when that fd is ready — all in the worker's own epoll loop. This is the general `watch(fd)+continuation` primitive (#35); an async DB query, a reverse-proxy/upstream call, timers, and SSE/WebSocket backpressure are all **consumers** of it.

```v
// async handler: park on any fd, resume later
fn handle(req []u8, mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
    fd := start_something_nonblocking()      // DB socket / upstream / timerfd / ...
    ac.watch(fd, u32(C.EPOLLIN), on_ready, udata)
    return .suspend                           // worker keeps serving others
}
fn on_ready(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
    out << build_response(ac.ready_fd())
    return .done                              // worker sends it + unparks the conn
}
http_server.new_server(ServerConfig{ io_multiplexing: .epoll, async_handler: handle })!
```

## Design

**Core (new, backend-free):** `AsyncStep{done,suspend,close}`, `WakeFn`, `AsyncHandler`, and `AsyncCtx` with `watch()`/`ready_fd()`. `AsyncCtx` carries a `register` fn pointer the backend installs — so `core` owns the type + handler contract while the epoll backend owns the registration logic (no layering cycle). `udata`/`state` carry consumer + per-thread context as `voidptr` (same style as the merged `StatefulHandler`/`make_state`, #34).

**Backend — isolated, the synchronous path is untouched:**
- `backend_epoll/async_linux.c.v`: an `AsyncReactor` (per-worker `ext_fd -> parked request` map) + `process_events_async`. Client request → async handler; `.suspend` parks the connection (the handler registered a watch), `.done` flushes the response, `.close` drops it. A watched fd's readiness runs the continuation. Reuses `ConnState` + `flush_batch`/`close_conn`/`handle_writable_plain`. A client that closes mid-await has its watch (and its request-owned fd) torn down.
- `ConnState` gains `awaiting_fd` (async-only; the sync path ignores it).
- `run_epoll_backend` spawns `process_events_async` **only** when `async_handler` is set — otherwise the existing plain/TLS workers run unchanged. **Zero change to the sync hot path.**

**Config:** `ServerConfig.async_handler` (+ optional `make_state`). `new_server` enforces exactly one of `request_handler` / `stateful_handler` / `async_handler`, and gates async/stateful to the Linux epoll backend.

**Example:** `examples/async_timer` — `/delay?ms=N` parks on a `timerfd` and replies when it fires; N concurrent delays overlap on one worker. No DB dependency (runs anywhere/CI), and it's the simplest proof the primitive isn't DB-specific.

## Validation

- Builds on **V 0.5.1 (release)** and **source-built V** (pure V; no `GC_malloc_atomic`/`.noscan_data`).
- The timer endpoint serves correctly through the real lib; **30 concurrent 500 ms delays complete in ~0.25 s** (blocking would be ~15 s) — decisively non-blocking; keep-alive intact.
- `http_server/server_test.v` and `examples/simple/src/server_end_to_end_test.v` still pass on both V builds — **the synchronous path is unchanged** (the `build_handler` / worker selection short-circuits to the existing path when `async_handler` is nil).

## v1 scope (follow-ups, noted in the source)

- One in-flight watch per connection (no pipelining-while-suspended).
- Request-owned watched fds (the continuation/close path owns the fd's lifetime). Pool-owned, **non-closing** watched fds — needed by the Postgres DB consumer (the pool owns the socket) — are a follow-up alongside the `db_async` module.
- Parked-connection timeouts and async in-flight accounting for graceful shutdown.

Implements #35 (the async-runtime primitive); foundation for the DB consumer (#32, which has a measured PoC: ~6× per-thread, ~3.6× end-to-end), and applicable to #23 (backpressure = `watch(client_fd, EPOLLOUT)`) and #18 (proxy/gRPC). Builds on the per-thread-state primitive (#34).

Refs #35 #32
