### PR TITLE
feat(pg_async): native async PostgreSQL driver for the async runtime

### DIFF
--- a/examples/async_db_pg/src/main.v
+++ b/examples/async_db_pg/src/main.v
@@ -1,0 +1,129 @@
+module main
+
+import os
+import http_server
+import http_server.core
+import pg_async
+
+// End-to-end demo of the native async Postgres driver (pg_async) on the epoll
+// async runtime. Each worker owns its own connection pool (via make_state); a
+// GET /db request acquires a connection, issues a query, parks on the PG socket
+// with ac.watch, and the continuation renders the rows once they arrive — all on
+// the worker's single epoll loop, never blocking it. This is the template the
+// HttpArena framework's async-db/fortunes endpoints follow.
+//
+// Bring up the demo table first, e.g.:
+//   create table pg_async_demo (id int4 primary key, name text);
+//   insert into pg_async_demo values (1,'alpha'),(2,'beta'),(3,'gamma');
+// Then run with PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE set.
+
+const pool_size = 4
+
+const resp_500 = 'HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+const resp_503 = 'HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+const resp_ok = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
+
+fn env_or(name string, dflt string) string {
+	v := os.getenv(name)
+	return if v != '' { v } else { dflt }
+}
+
+// build_pool brings up this worker's Postgres pool from the standard PG* env
+// vars and returns it as the opaque per-worker state.
+fn build_pool() voidptr {
+	port_env := os.getenv('PGPORT')
+	cfg := pg_async.ConnConfig{
+		host:     env_or('PGHOST', 'localhost')
+		port:     if port_env != '' { port_env.int() } else { 5432 }
+		user:     os.getenv('PGUSER')
+		password: os.getenv('PGPASSWORD')
+		database: os.getenv('PGDATABASE')
+	}
+	pool := pg_async.new_pool(cfg, pool_size) or {
+		panic('async_db_pg: pool bring-up failed: ${err}')
+	}
+	return voidptr(pool)
+}
+
+fn targets_db(req []u8) bool {
+	return req.bytestr().contains(' /db') // crude routing — fine for a demo
+}
+
+// handler: GET /db runs a query via the pool + a watch on the PG socket; any
+// other path replies synchronously.
+fn handler(req []u8, mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	if !targets_db(req) {
+		out << resp_ok
+		return .done
+	}
+	mut pool := unsafe { &pg_async.PgPool(ac.state) }
+	idx := pool.acquire() or {
+		out << resp_503
+		return .done
+	}
+	mut conn := pool.conn(idx)
+	conn.async_submit(r'select id, name from pg_async_demo order by id', []?[]u8{})
+	flushed := conn.async_flush() or {
+		pool.release(idx)
+		out << resp_500
+		return .done
+	}
+	if !flushed {
+		// Tiny queries flush in one write; a partial send is a v1 edge we don't handle.
+		pool.release(idx)
+		out << resp_500
+		return .done
+	}
+	ac.watch(pool.fd(idx), .readable, on_db_ready, unsafe { nil })
+	return .suspend
+}
+
+// on_db_ready runs when the watched PG socket is readable: it pumps the result
+// and, once complete, renders the rows as JSON and releases the connection.
+fn on_db_ready(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	mut pool := unsafe { &pg_async.PgPool(ac.state) }
+	idx := pool.idx_of_fd(ac.ready_fd) or { return .close }
+	mut conn := pool.conn(idx)
+	poll := conn.async_on_readable() or {
+		pool.release(idx)
+		out << resp_500
+		return .done
+	}
+	if !poll.ready {
+		ac.watch(pool.fd(idx), .readable, on_db_ready, unsafe { nil }) // re-arm: more bytes to come
+		return .suspend
+	}
+	mut body := []u8{cap: 512}
+	body << `[`
+	mut it := poll.result.rows()
+	mut first := true
+	for {
+		row := it.next() or { break }
+		if !first {
+			body << `,`
+		}
+		first = false
+		id := row.int4(0) or { -1 }
+		name := row.text(1) or { ''.bytes() }
+		body << '{"id":${id},"name":"'.bytes()
+		body << name
+		body << '"}'.bytes()
+	}
+	body << `]`
+	pool.release(idx)
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${body.len}\r\nConnection: keep-alive\r\n\r\n'.bytes()
+	out << body
+	return .done
+}
+
+fn main() {
+	mut s := http_server.new_server(http_server.ServerConfig{
+		port:          8099
+		async_handler: handler
+		make_state:    build_pool
+	})!
+	println('async_db_pg listening on http://localhost:8099/ (GET /db, GET /health)')
+	s.run()
+}

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -51,7 +51,7 @@ mut:
 }
 
 // async_register is installed into AsyncCtx.register; it is what `ac.watch(...)`
-// ultimately calls. It records the watch and adds the external fd to this
+// ultimately calls. It records the watch and arms the external fd in this
 // worker's epoll (level-triggered: simplest correct default for arbitrary
 // consumer fds). Runs on the worker thread, so no synchronization is needed.
 fn async_register(mut ac core.AsyncCtx, ext_fd int, interest core.WatchInterest, cont core.WakeFn, udata voidptr) {
@@ -62,7 +62,13 @@ fn async_register(mut ac core.AsyncCtx, ext_fd int, interest core.WatchInterest,
 		udata:     udata
 	}
 	events := if interest == .writable { u32(C.EPOLLOUT) } else { u32(C.EPOLLIN) }
-	epoll.add_fd_to_epoll(ac.loop_fd, ext_fd, events)
+	// Re-arm if the fd is already in this worker's epoll (a pool-owned connection
+	// re-watched across queries), otherwise add it (a fresh request-owned fd).
+	// Trying MOD first avoids an EEXIST perror on every pool-fd reuse and needs no
+	// extra bookkeeping: a fresh fd's MOD fails with ENOENT and falls through to ADD.
+	if epoll.mod_fd_in_epoll(ac.loop_fd, ext_fd, events) != 0 {
+		epoll.add_fd_to_epoll(ac.loop_fd, ext_fd, events)
+	}
 	ac.last_watched = ext_fd
 }
 

--- a/pg_async/conn.v
+++ b/pg_async/conn.v
@@ -23,7 +23,16 @@ pub:
 pub struct PgConn {
 mut:
 	sock     &net.TcpConn = unsafe { nil }
+	fd       int          = -1 // the raw socket fd (for the non-blocking path; see conn_async.v)
 	recv_buf []u8
+	// In-flight non-blocking query state (one query per connection at a time).
+	send_buf        []u8
+	send_off        int
+	q_frames        []u8
+	q_error         string
+	q_sqlstate      string
+	q_rows_affected u64
+	q_active        bool
 }
 
 struct Msg {
@@ -37,6 +46,7 @@ pub fn PgConn.connect(cfg ConnConfig) !PgConn {
 	mut sock := net.dial_tcp('${cfg.host}:${cfg.port}')!
 	mut c := PgConn{
 		sock:     sock
+		fd:       sock.sock.handle
 		recv_buf: []u8{cap: 16 * 1024}
 	}
 	c.handshake(cfg)!

--- a/pg_async/conn.v
+++ b/pg_async/conn.v
@@ -1,0 +1,191 @@
+module pg_async
+
+import net
+
+// PgConn is a single PostgreSQL connection: the TCP socket plus the v3 startup /
+// SCRAM-SHA-256 handshake and extended-query execution.
+//
+// This is the BLOCKING form. It is used for pool bring-up (connecting + auth
+// happen once, before the worker starts serving) and to validate the protocol
+// and SCRAM layers against a live server. The non-blocking, reactor-driven
+// query path that the async worker uses is built on the same wire encoding
+// (protocol.v) — only the I/O pump differs.
+
+pub struct ConnConfig {
+pub:
+	host     string = 'localhost'
+	port     int    = 5432
+	user     string
+	password string
+	database string
+}
+
+pub struct PgConn {
+mut:
+	sock     &net.TcpConn = unsafe { nil }
+	recv_buf []u8
+}
+
+struct Msg {
+	typ     u8
+	payload []u8
+}
+
+// PgConn.connect opens a TCP connection and runs the startup + SCRAM-SHA-256
+// handshake, returning once the server reports ReadyForQuery.
+pub fn PgConn.connect(cfg ConnConfig) !PgConn {
+	mut sock := net.dial_tcp('${cfg.host}:${cfg.port}')!
+	mut c := PgConn{
+		sock:     sock
+		recv_buf: []u8{cap: 16 * 1024}
+	}
+	c.handshake(cfg)!
+	return c
+}
+
+// close sends a best-effort Terminate and closes the socket.
+pub fn (mut c PgConn) close() {
+	mut out := []u8{}
+	write_terminate(mut out)
+	c.send(out) or {}
+	c.sock.close() or {}
+}
+
+fn (mut c PgConn) send(data []u8) ! {
+	mut sent := 0
+	for sent < data.len {
+		n := c.sock.write(data[sent..])!
+		if n <= 0 {
+			return error('pg: send failed')
+		}
+		sent += n
+	}
+}
+
+// read_msg blocks until one complete backend message is buffered, returns it,
+// and consumes it from the receive buffer.
+fn (mut c PgConn) read_msg() !Msg {
+	for {
+		if hdr := next_message(c.recv_buf) {
+			typ := c.recv_buf[0]
+			payload := c.recv_buf[5..hdr.total].clone()
+			c.recv_buf.delete_many(0, hdr.total)
+			return Msg{
+				typ:     typ
+				payload: payload
+			}
+		}
+		mut tmp := []u8{len: 16 * 1024}
+		n := c.sock.read(mut tmp)!
+		if n <= 0 {
+			return error('pg: connection closed by server')
+		}
+		c.recv_buf << tmp[..n]
+	}
+	return error('pg: unreachable')
+}
+
+fn (mut c PgConn) handshake(cfg ConnConfig) ! {
+	mut startup := []u8{}
+	write_startup(mut startup, cfg.user, cfg.database)
+	c.send(startup)!
+
+	mut scram := ScramClient.new(cfg.user, cfg.password)!
+	for {
+		msg := c.read_msg()!
+		match msg.typ {
+			bt_authentication {
+				c.handle_auth(msg.payload, mut scram)!
+			}
+			bt_error_response {
+				info := parse_error_response(msg.payload)
+				return error('pg: startup failed: ${info.message.bytestr()} (SQLSTATE ${info.code.bytestr()})')
+			}
+			bt_ready_for_query {
+				return
+			}
+			else {
+				// ParameterStatus / BackendKeyData / NoticeResponse — ignored.
+			}
+		}
+	}
+}
+
+fn (mut c PgConn) handle_auth(payload []u8, mut scram ScramClient) ! {
+	sub := auth_subtype(payload)
+	data := if payload.len > 4 { payload[4..] } else { []u8{} }
+	match sub {
+		0 {
+			// AuthenticationOk — ReadyForQuery follows.
+		}
+		10 {
+			// AuthenticationSASL — offer SCRAM-SHA-256, send the client-first message.
+			mut m := []u8{}
+			write_sasl_initial(mut m, scram_sha_256, scram.client_first())
+			c.send(m)!
+		}
+		11 {
+			// AuthenticationSASLContinue — server-first → client-final.
+			client_final := scram.handle_server_first(data)!
+			mut m := []u8{}
+			write_sasl_response(mut m, client_final)
+			c.send(m)!
+		}
+		12 {
+			// AuthenticationSASLFinal — verify the server signature.
+			scram.handle_server_final(data)!
+		}
+		else {
+			return error('pg: unsupported authentication method (code ${sub}); only SCRAM-SHA-256 is implemented')
+		}
+	}
+}
+
+// query runs one extended-protocol query (Parse/Bind/Describe/Execute/Sync,
+// binary results) and returns the collected Result. Blocking. Parameters are
+// text-format and bind to $1, $2, … (a null option element is SQL NULL).
+pub fn (mut c PgConn) query(query_text string, params []?[]u8) !Result {
+	mut out := []u8{}
+	write_parse(mut out, '', query_text)
+	write_bind(mut out, '', '', params)
+	write_describe_portal(mut out, '')
+	write_execute(mut out, '', 0)
+	write_sync(mut out)
+	c.send(out)!
+
+	mut frames := []u8{}
+	mut rows_affected := u64(0)
+	mut server_error := ''
+	mut sqlstate := ''
+	for {
+		msg := c.read_msg()!
+		match msg.typ {
+			bt_ready_for_query {
+				break
+			}
+			bt_command_complete {
+				rows_affected = parse_command_complete(msg.payload)
+			}
+			bt_error_response {
+				info := parse_error_response(msg.payload)
+				server_error = info.message.bytestr()
+				sqlstate = info.code.bytestr()
+			}
+			else {}
+		}
+
+		// Re-frame the message into the result region so Result.rows()
+		// (FrameIter) can walk the DataRows.
+		mut framed := [msg.typ]
+		put_u32(mut framed, u32(4 + msg.payload.len))
+		framed << msg.payload
+		frames << framed
+	}
+	if server_error != '' {
+		return error('pg: query failed: ${server_error} (SQLSTATE ${sqlstate})')
+	}
+	return Result{
+		frames:        frames
+		rows_affected: rows_affected
+	}
+}

--- a/pg_async/conn_async.v
+++ b/pg_async/conn_async.v
@@ -1,0 +1,146 @@
+module pg_async
+
+// Non-blocking query pump on a PgConn. Reactor-agnostic: the caller flips the
+// socket to non-blocking once (after bring-up), submits a query, then drives it
+// from readiness events — async_flush() on writable, async_on_readable() on
+// readable. This is the exact mechanism the async HTTP worker uses via
+// ac.watch(conn_fd, ...); here it is split out so any event loop can drive it
+// (and so it can be tested with a simple pump loop against a live server).
+//
+// The wire encoding, framing, binary decode and error handling are all the
+// already-validated protocol.v layer — only the I/O pump is new.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+
+fn C.recv(fd int, buf voidptr, len usize, flags int) int
+fn C.send(fd int, buf voidptr, len usize, flags int) int
+fn C.fcntl(fd int, cmd int, arg int) int
+
+// set_nonblocking flips the connection socket to non-blocking. Call once, after
+// the connection is ready (connect + handshake done blocking).
+pub fn (mut c PgConn) set_nonblocking() ! {
+	flags := C.fcntl(c.fd, C.F_GETFL, 0)
+	if flags < 0 {
+		return error('pg: fcntl(F_GETFL) failed')
+	}
+	if C.fcntl(c.fd, C.F_SETFL, flags | int(C.O_NONBLOCK)) < 0 {
+		return error('pg: fcntl(F_SETFL, O_NONBLOCK) failed')
+	}
+}
+
+// is_busy reports whether a query is in flight on this connection.
+pub fn (c &PgConn) is_busy() bool {
+	return c.q_active
+}
+
+// async_submit serializes one extended-protocol query (binary results) into the
+// send buffer and marks a query in flight. Pair with async_flush (on writable)
+// and async_on_readable (on readable). One in-flight query per connection.
+pub fn (mut c PgConn) async_submit(query_text string, params []?[]u8) {
+	c.send_buf = []u8{cap: 256}
+	write_parse(mut c.send_buf, '', query_text)
+	write_bind(mut c.send_buf, '', '', params)
+	write_describe_portal(mut c.send_buf, '')
+	write_execute(mut c.send_buf, '', 0)
+	write_sync(mut c.send_buf)
+	c.send_off = 0
+	c.q_frames = []u8{cap: 8 * 1024}
+	c.q_error = ''
+	c.q_sqlstate = ''
+	c.q_rows_affected = 0
+	c.q_active = true
+}
+
+// async_wants_write reports whether request bytes are still pending (so the
+// reactor should keep writable interest armed).
+pub fn (c &PgConn) async_wants_write() bool {
+	return c.send_off < c.send_buf.len
+}
+
+// async_flush sends as much of the pending request as the socket will take.
+// Returns true once the whole request is sent; false on EAGAIN (leave writable
+// interest armed and call again when writable).
+pub fn (mut c PgConn) async_flush() !bool {
+	for c.send_off < c.send_buf.len {
+		n := C.send(c.fd, unsafe { &u8(c.send_buf.data) + c.send_off },
+			usize(c.send_buf.len - c.send_off), C.MSG_NOSIGNAL)
+		if n > 0 {
+			c.send_off += n
+			continue
+		}
+		if n < 0 && (C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK) {
+			return false
+		}
+		return error('pg: async send failed (errno ${C.errno})')
+	}
+	return true
+}
+
+// QueryPoll is the outcome of one async_on_readable call: ready=false means
+// more bytes are needed (stay parked); ready=true means `result` is the
+// complete result. (V has no `!?T`, so completion is a flag, not an Option.)
+pub struct QueryPoll {
+pub:
+	ready  bool
+	result Result
+}
+
+// async_on_readable drains the socket to EAGAIN, frames complete backend
+// messages, and returns a ready QueryPoll once ReadyForQuery arrives — at which
+// point the connection is idle again and reusable. Returns a not-ready poll if
+// more data is needed (stay parked). A server ErrorResponse is surfaced as an
+// error AFTER the stream is drained through ReadyForQuery, so the connection
+// stays in sync for reuse.
+pub fn (mut c PgConn) async_on_readable() !QueryPoll {
+	for {
+		mut tmp := []u8{len: 16 * 1024}
+		n := C.recv(c.fd, tmp.data, usize(tmp.len), 0)
+		if n > 0 {
+			c.recv_buf << tmp[..n]
+			continue
+		}
+		if n == 0 {
+			return error('pg: connection closed by server')
+		}
+		if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
+			break
+		}
+		return error('pg: async recv failed (errno ${C.errno})')
+	}
+	for {
+		hdr := next_message(c.recv_buf) or { break }
+		typ := c.recv_buf[0]
+		payload := c.recv_buf[5..hdr.total]
+		match typ {
+			bt_command_complete {
+				c.q_rows_affected = parse_command_complete(payload)
+			}
+			bt_error_response {
+				info := parse_error_response(payload)
+				c.q_error = info.message.bytestr()
+				c.q_sqlstate = info.code.bytestr()
+			}
+			else {}
+		}
+
+		c.q_frames << c.recv_buf[..hdr.total]
+		is_ready := typ == bt_ready_for_query
+		c.recv_buf.delete_many(0, hdr.total)
+		if is_ready {
+			c.q_active = false
+			if c.q_error != '' {
+				return error('pg: query failed: ${c.q_error} (SQLSTATE ${c.q_sqlstate})')
+			}
+			return QueryPoll{
+				ready:  true
+				result: Result{
+					frames:        c.q_frames.clone()
+					rows_affected: c.q_rows_affected
+				}
+			}
+		}
+	}
+	return QueryPoll{} // not ready — need more bytes
+}

--- a/pg_async/conn_async_integration_test.v
+++ b/pg_async/conn_async_integration_test.v
@@ -1,0 +1,67 @@
+module pg_async
+
+import os
+
+// Live-Postgres test of the NON-BLOCKING query pump. Skipped unless PGHOST is
+// set. Drives the connection with a simple pump loop — exactly the
+// flush-on-writable / read-on-readable mechanism the async HTTP worker performs
+// via ac.watch, minus the epoll. (Each _test.v file is compiled independently,
+// so the env read is inlined rather than shared with conn_integration_test.v.)
+fn test_async_query_pump_against_live_pg() {
+	host := os.getenv('PGHOST')
+	if host == '' {
+		eprintln('pg_async: skipping async pump test (no PGHOST)')
+		return
+	}
+	port_env := os.getenv('PGPORT')
+	cfg := ConnConfig{
+		host:     host
+		port:     if port_env != '' { port_env.int() } else { 5432 }
+		user:     os.getenv('PGUSER')
+		password: os.getenv('PGPASSWORD')
+		database: os.getenv('PGDATABASE')
+	}
+	mut c := PgConn.connect(cfg)!
+	defer {
+		c.close()
+	}
+	c.set_nonblocking()!
+
+	// Two sequential queries prove the connection returns to idle and is reusable.
+	for round in 0 .. 2 {
+		expect := round + 7
+		c.async_submit(r'select $1::int4, $2::text', [?[]u8('${expect}'.bytes()),
+			?[]u8('round'.bytes())])
+		assert c.is_busy()
+
+		// Flush the request (a small request goes out in one write; loop guards EAGAIN).
+		mut sent := false
+		for _ in 0 .. 10000 {
+			if c.async_flush()! {
+				sent = true
+				break
+			}
+		}
+		assert sent, 'request flush did not complete'
+
+		// Pump readable until the result is ready (not-ready = need more bytes).
+		mut got := ?Result(none)
+		for _ in 0 .. 200000 {
+			poll := c.async_on_readable()!
+			if poll.ready {
+				got = poll.result
+				break
+			}
+		}
+		res := got or { panic('async query did not complete') }
+		assert !c.is_busy() // back to idle, reusable for the next round
+
+		mut it := res.rows()
+		row := it.next() or { panic('expected a row') }
+		assert row.int4(0)! == expect
+		assert row.text(1)!.bytestr() == 'round'
+		if _ := it.next() {
+			assert false, 'expected exactly one row'
+		}
+	}
+}

--- a/pg_async/conn_integration_test.v
+++ b/pg_async/conn_integration_test.v
@@ -2,35 +2,40 @@ module pg_async
 
 import os
 
-// Live-Postgres integration test. Skipped unless PGHOST is set, so CI without a
-// database stays green. Run it against a local container, e.g.:
+// Live-Postgres integration tests. Skipped unless PGHOST is set, so CI without a
+// database stays green. Run against a local container, e.g.:
 //
-//   docker run -d --name pgtest -p 5433:5432 \
-//     -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=bench \
-//     -e POSTGRES_HOST_AUTH_METHOD=scram-sha-256 postgres:16-alpine
-//   PGHOST=localhost PGPORT=5433 PGUSER=bench PGPASSWORD=bench PGDATABASE=bench \
+//   docker run -d --name pgtest -p 55432:5432 \
+//     -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=benchpw -e POSTGRES_DB=bench \
+//     -e POSTGRES_HOST_AUTH_METHOD=scram-sha-256 postgres:18.3-alpine
+//   PGHOST=127.0.0.1 PGPORT=55432 PGUSER=bench PGPASSWORD=benchpw PGDATABASE=bench \
 //     v test pg_async/
-fn test_live_postgres_query() {
+
+fn pg_test_cfg() ?ConnConfig {
 	host := os.getenv('PGHOST')
 	if host == '' {
 		eprintln('pg_async: skipping live test (set PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE)')
-		return
+		return none
 	}
 	port_env := os.getenv('PGPORT')
-	cfg := ConnConfig{
+	return ConnConfig{
 		host:     host
 		port:     if port_env != '' { port_env.int() } else { 5432 }
 		user:     os.getenv('PGUSER')
 		password: os.getenv('PGPASSWORD')
 		database: os.getenv('PGDATABASE')
 	}
+}
+
+// Binary scalar decoding, a text-format parameter round-trip, multiple rows,
+// and a SQL NULL in the middle of a result set.
+fn test_live_scalars_params_and_null() {
+	cfg := pg_test_cfg() or { return }
 	mut c := PgConn.connect(cfg)!
 	defer {
 		c.close()
 	}
 
-	// Binary scalar decoding + a text-format parameter round-trip. Raw string so
-	// V does not interpolate the `$1` placeholder.
 	res := c.query(r'select 1::int4, 2::int8, true, $1::text', [?[]u8('hi'.bytes())])!
 	mut it := res.rows()
 	row := it.next() or { panic('expected a row') }
@@ -42,7 +47,6 @@ fn test_live_postgres_query() {
 		assert false, 'expected exactly one row'
 	}
 
-	// Multiple rows + a SQL NULL in the middle (g=2 → NULL).
 	res2 := c.query(r'select g, (case when g = 2 then null else g end)::int4 from generate_series(1,3) g order by 1',
 		[]?[]u8{})!
 	mut it2 := res2.rows()
@@ -51,11 +55,94 @@ fn test_live_postgres_query() {
 	for {
 		r := it2.next() or { break }
 		ids << r.int4(0)!
-		dv := r.col(1)!
-		if dv.is_null {
+		if r.col(1)!.is_null {
 			null_count++
 		}
 	}
 	assert ids == [1, 2, 3]
-	assert null_count == 1 // exactly the g=2 row was NULL
+	assert null_count == 1
+}
+
+// The exact HttpArena async-db workload: an items table with every column type
+// the benchmark reads (incl. jsonb), the real range-scan query, a buffer-spanning
+// large result, the empty-range anti-cheat, and error recovery. A test-specific
+// table name avoids clobbering a real `items` table if PGHOST points at a bench DB.
+fn test_async_db_workload() {
+	cfg := pg_test_cfg() or { return }
+	mut c := PgConn.connect(cfg)!
+	defer {
+		c.close()
+	}
+
+	c.query('drop table if exists pg_async_test_items', []?[]u8{})!
+	c.query('create table pg_async_test_items (id int4 primary key, name text, category text,
+		price int4, quantity int4, active bool, tags jsonb, rating_score int4, rating_count int4)',
+		[]?[]u8{})!
+	c.query("insert into pg_async_test_items
+		select g, 'item' || g, 'cat' || (g % 5), g, g * 2, (g % 2 = 0),
+		       jsonb_build_array('a', 'b', g), g % 100, g
+		from generate_series(1, 500) g",
+		[]?[]u8{})!
+
+	// The real async-db query shape: price range + limit, all nine columns.
+	res := c.query(r'select id, name, category, price, quantity, active, tags, rating_score, rating_count
+		from pg_async_test_items where price between $1 and $2 limit $3', [
+		?[]u8('10'.bytes()),
+		?[]u8('60'.bytes()),
+		?[]u8('50'.bytes()),
+	])!
+	mut it := res.rows()
+	mut n := 0
+	for {
+		row := it.next() or { break }
+		id := row.int4(0)!
+		assert id >= 10 && id <= 60
+		assert row.text(1)!.len > 0 // name
+		assert row.text(2)!.len > 0 // category
+		assert row.int4(3)! == id // price == g == id
+		assert row.int4(4)! == id * 2 // quantity
+		assert row.boolean(5)! == (id % 2 == 0) // active
+		// jsonb arrives binary: a 0x01 version byte + JSON text. Strip it and the
+		// remainder is a real JSON array.
+		tags := jsonb_text(row.text(6)!)
+		assert tags.len > 0 && tags[0] == `[`
+		assert row.int4(7)! == id % 100 // rating_score
+		assert row.int4(8)! == id // rating_count
+		n++
+	}
+	assert n == 50 // 51 ids in [10,60], capped by limit 50
+
+	// Large result: 500 rows exceed the 16 KiB read buffer, so this exercises
+	// message framing across multiple reads (the same next_message path the
+	// async worker relies on).
+	big := c.query('select id, name, tags from pg_async_test_items', []?[]u8{})!
+	mut bit := big.rows()
+	mut total := 0
+	for {
+		bit.next() or { break }
+		total++
+	}
+	assert total == 500
+
+	// Empty range (the async-db anti-cheat): zero matching rows, clean iteration.
+	empty := c.query(r'select id from pg_async_test_items where price between $1 and $2', [
+		?[]u8('900000'.bytes()),
+		?[]u8('999999'.bytes()),
+	])!
+	mut eit := empty.rows()
+	if _ := eit.next() {
+		assert false, 'expected zero rows for an out-of-range price window'
+	}
+
+	// A query error surfaces as an error (not a crash), and the connection stays
+	// usable afterwards — query() drains through ReadyForQuery even on error.
+	if _ := c.query('select * from no_such_table_xyz', []?[]u8{}) {
+		assert false, 'expected an error for a missing table'
+	}
+	recovered := c.query(r'select 42::int4', []?[]u8{})!
+	mut rit := recovered.rows()
+	rr := rit.next() or { panic('connection unusable after a query error') }
+	assert rr.int4(0)! == 42
+
+	c.query('drop table if exists pg_async_test_items', []?[]u8{})!
 }

--- a/pg_async/conn_integration_test.v
+++ b/pg_async/conn_integration_test.v
@@ -1,0 +1,61 @@
+module pg_async
+
+import os
+
+// Live-Postgres integration test. Skipped unless PGHOST is set, so CI without a
+// database stays green. Run it against a local container, e.g.:
+//
+//   docker run -d --name pgtest -p 5433:5432 \
+//     -e POSTGRES_USER=bench -e POSTGRES_PASSWORD=bench -e POSTGRES_DB=bench \
+//     -e POSTGRES_HOST_AUTH_METHOD=scram-sha-256 postgres:16-alpine
+//   PGHOST=localhost PGPORT=5433 PGUSER=bench PGPASSWORD=bench PGDATABASE=bench \
+//     v test pg_async/
+fn test_live_postgres_query() {
+	host := os.getenv('PGHOST')
+	if host == '' {
+		eprintln('pg_async: skipping live test (set PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE)')
+		return
+	}
+	port_env := os.getenv('PGPORT')
+	cfg := ConnConfig{
+		host:     host
+		port:     if port_env != '' { port_env.int() } else { 5432 }
+		user:     os.getenv('PGUSER')
+		password: os.getenv('PGPASSWORD')
+		database: os.getenv('PGDATABASE')
+	}
+	mut c := PgConn.connect(cfg)!
+	defer {
+		c.close()
+	}
+
+	// Binary scalar decoding + a text-format parameter round-trip. Raw string so
+	// V does not interpolate the `$1` placeholder.
+	res := c.query(r'select 1::int4, 2::int8, true, $1::text', [?[]u8('hi'.bytes())])!
+	mut it := res.rows()
+	row := it.next() or { panic('expected a row') }
+	assert row.int4(0)! == 1
+	assert row.int8(1)! == 2
+	assert row.boolean(2)! == true
+	assert row.text(3)!.bytestr() == 'hi'
+	if _ := it.next() {
+		assert false, 'expected exactly one row'
+	}
+
+	// Multiple rows + a SQL NULL in the middle (g=2 → NULL).
+	res2 := c.query(r'select g, (case when g = 2 then null else g end)::int4 from generate_series(1,3) g order by 1',
+		[]?[]u8{})!
+	mut it2 := res2.rows()
+	mut ids := []int{}
+	mut null_count := 0
+	for {
+		r := it2.next() or { break }
+		ids << r.int4(0)!
+		dv := r.col(1)!
+		if dv.is_null {
+			null_count++
+		}
+	}
+	assert ids == [1, 2, 3]
+	assert null_count == 1 // exactly the g=2 row was NULL
+}

--- a/pg_async/conn_integration_test.v
+++ b/pg_async/conn_integration_test.v
@@ -146,3 +146,51 @@ fn test_async_db_workload() {
 
 	c.query('drop table if exists pg_async_test_items', []?[]u8{})!
 }
+
+// Per-worker pool: bring-up of N connections, acquire/release bookkeeping
+// (including exhaustion), and running a query through a pooled connection via
+// the non-blocking pump.
+fn test_pool_acquire_release_and_query() {
+	cfg := pg_test_cfg() or { return }
+	mut pool := PgPool.connect(cfg, 2)!
+	defer {
+		pool.close()
+	}
+	assert pool.size() == 2
+
+	// Acquire both, confirm exhaustion, release one, re-acquire the same slot.
+	a := pool.acquire() or { panic('acquire 0') }
+	b := pool.acquire() or { panic('acquire 1') }
+	assert a != b
+	if _ := pool.acquire() {
+		assert false, 'pool should be exhausted with both connections busy'
+	}
+	pool.release(a)
+	got := pool.acquire() or { panic('re-acquire after release') }
+	assert got == a
+
+	// Run a query through the pooled connection via the non-blocking pump.
+	mut conn := pool.conn(got)
+	conn.async_submit(r'select $1::int4', [?[]u8('123'.bytes())])
+	mut sent := false
+	for _ in 0 .. 10000 {
+		if conn.async_flush()! {
+			sent = true
+			break
+		}
+	}
+	assert sent
+	mut result := ?Result(none)
+	for _ in 0 .. 200000 {
+		poll := conn.async_on_readable()!
+		if poll.ready {
+			result = poll.result
+			break
+		}
+	}
+	res := result or { panic('pooled query did not complete') }
+	mut it := res.rows()
+	row := it.next() or { panic('expected a row') }
+	assert row.int4(0)! == 123
+	pool.release(got)
+}

--- a/pg_async/pool.v
+++ b/pg_async/pool.v
@@ -43,9 +43,29 @@ fn close_all(mut conns []PgConn) {
 	}
 }
 
+// new_pool brings up a pool and returns it on the heap — convenient for a
+// make_state callback that hands the pool back to the worker as an opaque
+// voidptr (the StatefulHandler / async state contract).
+pub fn new_pool(cfg ConnConfig, size int) !&PgPool {
+	pool := PgPool.connect(cfg, size)!
+	return &pool
+}
+
 // size is the number of connections in the pool.
 pub fn (p &PgPool) size() int {
 	return p.conns.len
+}
+
+// idx_of_fd maps a socket fd back to its connection index — used by a resume
+// continuation to find which connection woke it (ac.ready_fd) without threading
+// the index through udata.
+pub fn (p &PgPool) idx_of_fd(fd int) ?int {
+	for i in 0 .. p.conns.len {
+		if p.conns[i].fd == fd {
+			return i
+		}
+	}
+	return none
 }
 
 // acquire returns the index of an idle connection (marking it busy), or none if

--- a/pg_async/pool.v
+++ b/pg_async/pool.v
@@ -1,0 +1,85 @@
+module pg_async
+
+// PgPool is a per-worker pool of PostgreSQL connections. Each worker owns its
+// own pool — no cross-worker sharing, so no locks (the make_state model). The
+// connections are brought up (connect + SCRAM) blocking at init, then flipped to
+// non-blocking for the reactor-driven query path. v1: one in-flight query per
+// connection (no pipelining-while-busy), so a query needs a fully idle slot.
+
+pub struct PgPool {
+mut:
+	conns []PgConn
+	idle  []bool // idle[i] ⇒ conns[i] is free to take a query
+}
+
+// PgPool.connect brings up `size` connections (size >= 1) and returns a ready
+// pool. On any failure it closes whatever it already opened.
+pub fn PgPool.connect(cfg ConnConfig, size int) !PgPool {
+	if size < 1 {
+		return error('pg pool: size must be >= 1')
+	}
+	mut conns := []PgConn{cap: size}
+	for i in 0 .. size {
+		mut c := PgConn.connect(cfg) or {
+			close_all(mut conns)
+			return error('pg pool: connection ${i} failed: ${err}')
+		}
+		c.set_nonblocking() or {
+			c.close()
+			close_all(mut conns)
+			return error('pg pool: set_nonblocking on connection ${i} failed: ${err}')
+		}
+		conns << c
+	}
+	return PgPool{
+		conns: conns
+		idle:  []bool{len: size, init: true}
+	}
+}
+
+fn close_all(mut conns []PgConn) {
+	for mut c in conns {
+		c.close()
+	}
+}
+
+// size is the number of connections in the pool.
+pub fn (p &PgPool) size() int {
+	return p.conns.len
+}
+
+// acquire returns the index of an idle connection (marking it busy), or none if
+// every connection is busy (the caller sheds load — e.g. 503 — or queues).
+pub fn (mut p PgPool) acquire() ?int {
+	for i in 0 .. p.conns.len {
+		if p.idle[i] {
+			p.idle[i] = false
+			return i
+		}
+	}
+	return none
+}
+
+// release returns a connection to the idle set (call once its query completes).
+pub fn (mut p PgPool) release(idx int) {
+	if idx >= 0 && idx < p.idle.len {
+		p.idle[idx] = true
+	}
+}
+
+// conn returns a mutable reference to connection `idx`. The connection array is
+// fixed after connect(), so the reference stays valid for the pool's lifetime.
+pub fn (mut p PgPool) conn(idx int) &PgConn {
+	return &p.conns[idx]
+}
+
+// fd returns the raw socket fd of connection `idx` — what the reactor registers
+// and watches for readiness.
+pub fn (p &PgPool) fd(idx int) int {
+	return p.conns[idx].fd
+}
+
+// close terminates every connection in the pool.
+pub fn (mut p PgPool) close() {
+	close_all(mut p.conns)
+}

--- a/pg_async/protocol.v
+++ b/pg_async/protocol.v
@@ -1,0 +1,466 @@
+module pg_async
+
+import encoding.binary
+
+// PostgreSQL frontend/backend wire protocol v3 — framing, message builders, and
+// result iteration. Pure and I/O-free: builders append bytes to a caller-owned
+// buffer, parsers read borrowed slices. The connection state machine (client.v)
+// and the async integration sit on top of this layer.
+//
+// Message format: every message is type(1 byte) + length(Int32, big-endian,
+// INCLUDES the 4 length bytes but NOT the type byte) + payload. The only
+// exception is StartupMessage / SSLRequest, which have no type byte.
+
+// Backend message type bytes — the first byte of each backend message. (Module
+// constants rather than an enum: V enum values must be integer literals, and
+// these read most clearly as their wire characters.)
+pub const bt_authentication = u8(`R`)
+pub const bt_backend_key_data = u8(`K`)
+pub const bt_bind_complete = u8(`2`)
+pub const bt_close_complete = u8(`3`)
+pub const bt_command_complete = u8(`C`)
+pub const bt_data_row = u8(`D`)
+pub const bt_empty_query_response = u8(`I`)
+pub const bt_error_response = u8(`E`)
+pub const bt_no_data = u8(`n`)
+pub const bt_notice_response = u8(`N`)
+pub const bt_notification_response = u8(`A`)
+pub const bt_parameter_description = u8(`t`)
+pub const bt_parameter_status = u8(`S`)
+pub const bt_parse_complete = u8(`1`)
+pub const bt_portal_suspended = u8(`s`)
+pub const bt_ready_for_query = u8(`Z`)
+pub const bt_row_description = u8(`T`)
+
+// AuthType is the Int32 sub-code carried by an Authentication ('R') message.
+pub enum AuthType as u32 {
+	ok                 = 0
+	cleartext_password = 3
+	md5_password       = 5
+	sasl               = 10
+	sasl_continue      = 11
+	sasl_final         = 12
+}
+
+// auth_subtype reads the sub-code of an Authentication payload (0xFFFFFFFF on a
+// truncated payload).
+pub fn auth_subtype(payload []u8) u32 {
+	if payload.len < 4 {
+		return 0xFFFF_FFFF
+	}
+	return binary.big_endian_u32(payload[0..4])
+}
+
+// ── backend framing ─────────────────────────────────────────────────────────
+
+// MsgHeader describes the first complete message in a buffer.
+pub struct MsgHeader {
+pub:
+	typ   u8
+	total int // bytes to consume for this message: 1 + length
+}
+
+// next_message returns the header of the first COMPLETE backend message in buf,
+// or none if a full message is not buffered yet. The connection read loop uses
+// it to frame messages off the recv buffer without copying. A length < 4 is a
+// protocol violation; the caller drops the connection.
+pub fn next_message(buf []u8) ?MsgHeader {
+	if buf.len < 5 {
+		return none
+	}
+	msg_len := int(binary.big_endian_u32(buf[1..5]))
+	if msg_len < 4 {
+		return none
+	}
+	total := 1 + msg_len
+	if buf.len < total {
+		return none
+	}
+	return MsgHeader{
+		typ:   buf[0]
+		total: total
+	}
+}
+
+// Frame is one parsed backend message (type + borrowed payload).
+pub struct Frame {
+pub:
+	typ     u8
+	payload []u8
+}
+
+// FrameIter walks complete backend messages in a region (e.g. one op's frames
+// from ParseComplete through CommandComplete).
+pub struct FrameIter {
+	buf []u8
+mut:
+	pos int
+}
+
+pub fn FrameIter.new(buf []u8) FrameIter {
+	return FrameIter{
+		buf: buf
+	}
+}
+
+// next returns the next complete message, or none at end / on a truncated
+// trailer.
+pub fn (mut it FrameIter) next() ?Frame {
+	if it.pos + 5 > it.buf.len {
+		return none
+	}
+	msg_len := int(binary.big_endian_u32(it.buf[it.pos + 1..it.pos + 5]))
+	if msg_len < 4 {
+		return none
+	}
+	total := 1 + msg_len
+	if it.pos + total > it.buf.len {
+		return none
+	}
+	frame := Frame{
+		typ:     it.buf[it.pos]
+		payload: it.buf[it.pos + 5..it.pos + total]
+	}
+	it.pos += total
+	return frame
+}
+
+// ── result rows ─────────────────────────────────────────────────────────────
+
+// Result is one completed query's frames (ParseComplete..CommandComplete) plus
+// the rows-affected count parsed from the CommandComplete tag. Rows borrow the
+// recv buffer and are valid only inside the resume callback.
+pub struct Result {
+pub:
+	frames        []u8
+	rows_affected u64
+}
+
+pub fn (res &Result) rows() RowIter {
+	return RowIter{
+		frames: FrameIter.new(res.frames)
+	}
+}
+
+// RowIter yields the DataRow frames in a result, skipping everything else.
+pub struct RowIter {
+mut:
+	frames FrameIter
+}
+
+pub fn (mut it RowIter) next() ?Row {
+	for {
+		frame := it.frames.next() or { return none }
+		if frame.typ == bt_data_row {
+			return Row{
+				payload: frame.payload
+			}
+		}
+	}
+	return none
+}
+
+// Row is one DataRow payload. Columns are read by index; the payload is walked
+// each access (columns are few, so O(n) is fine at handler scale). All values
+// are binary (Bind requests result-format-code 1 for every column).
+pub struct Row {
+pub:
+	payload []u8
+}
+
+// DataValue is one column's value: either SQL NULL, or the borrowed binary
+// bytes (V has no `!?T`, so NULL is a flag rather than an Option).
+pub struct DataValue {
+pub:
+	is_null bool
+	bytes   []u8
+}
+
+// col returns column i: error on malformed/out-of-range, is_null set for SQL
+// NULL, else the borrowed column bytes.
+pub fn (r Row) col(i int) !DataValue {
+	if r.payload.len < 2 {
+		return error('datarow: short payload')
+	}
+	ncols := int(i16(binary.big_endian_u16(r.payload[0..2])))
+	if i < 0 || i >= ncols {
+		return error('datarow: col ${i} out of range (${ncols} cols)')
+	}
+	mut pos := 2
+	for idx in 0 .. ncols {
+		if pos + 4 > r.payload.len {
+			return error('datarow: truncated length')
+		}
+		clen := int(i32(binary.big_endian_u32(r.payload[pos..pos + 4])))
+		pos += 4
+		if clen < 0 {
+			if idx == i {
+				return DataValue{
+					is_null: true
+				} // SQL NULL
+			}
+			continue
+		}
+		if pos + clen > r.payload.len {
+			return error('datarow: truncated value')
+		}
+		if idx == i {
+			return DataValue{
+				bytes: r.payload[pos..pos + clen]
+			}
+		}
+		pos += clen
+	}
+	return error('datarow: col not found')
+}
+
+fn (r Row) require(i int) ![]u8 {
+	dv := r.col(i)!
+	if dv.is_null {
+		return error('unexpected NULL at col ${i}')
+	}
+	return dv.bytes
+}
+
+pub fn (r Row) int2(i int) !i16 {
+	return decode_int2(r.require(i)!)
+}
+
+pub fn (r Row) int4(i int) !i32 {
+	return decode_int4(r.require(i)!)
+}
+
+pub fn (r Row) int8(i int) !i64 {
+	return decode_int8(r.require(i)!)
+}
+
+pub fn (r Row) boolean(i int) !bool {
+	return decode_bool(r.require(i)!)
+}
+
+pub fn (r Row) float8(i int) !f64 {
+	return decode_float8(r.require(i)!)
+}
+
+pub fn (r Row) text(i int) ![]u8 {
+	return decode_text(r.require(i)!)
+}
+
+// ── backend message details ─────────────────────────────────────────────────
+
+// ErrorInfo is the parsed fields of an ErrorResponse / NoticeResponse.
+pub struct ErrorInfo {
+pub:
+	severity []u8 // field 'S' (or 'V' for the non-localized severity)
+	code     []u8 // field 'C' — SQLSTATE
+	message  []u8 // field 'M'
+}
+
+// parse_error_response walks the field list: (field-type byte, NUL-terminated
+// value)*, terminated by a 0 byte.
+pub fn parse_error_response(payload []u8) ErrorInfo {
+	mut severity := []u8{}
+	mut code := []u8{}
+	mut message := []u8{}
+	mut pos := 0
+	for pos < payload.len {
+		ft := payload[pos]
+		pos++
+		if ft == 0 {
+			break
+		}
+		start := pos
+		for pos < payload.len && payload[pos] != 0 {
+			pos++
+		}
+		val := payload[start..pos]
+		if pos < payload.len {
+			pos++ // skip NUL
+		}
+		// Borrow the payload (the ErrorInfo is valid only while the recv buffer
+		// is — the error path doesn't need a copy).
+		match ft {
+			`S`, `V` {
+				unsafe {
+					severity = val
+				}
+			}
+			`C` {
+				unsafe {
+					code = val
+				}
+			}
+			`M` {
+				unsafe {
+					message = val
+				}
+			}
+			else {}
+		}
+	}
+	return ErrorInfo{
+		severity: severity
+		code:     code
+		message:  message
+	}
+}
+
+// parse_command_complete extracts rows-affected from a CommandComplete tag
+// ("SELECT 5", "INSERT 0 3", "UPDATE 2"): the LAST integer token (0 if none).
+pub fn parse_command_complete(payload []u8) u64 {
+	mut last := u64(0)
+	mut cur := u64(0)
+	mut seen := false
+	for c in payload {
+		if c >= `0` && c <= `9` {
+			cur = cur * 10 + u64(c - `0`)
+			seen = true
+		} else {
+			if seen {
+				last = cur
+			}
+			cur = 0
+			seen = false
+		}
+	}
+	if seen {
+		last = cur
+	}
+	return last
+}
+
+// ── frontend message builders ───────────────────────────────────────────────
+//
+// All builders APPEND to a caller-owned buffer so multiple messages (a full
+// Parse/Bind/Describe/Execute/Sync pipeline) batch into one write.
+
+fn begin_msg(mut buf []u8, typ u8) int {
+	buf << typ
+	lenpos := buf.len
+	buf << [u8(0), 0, 0, 0] // length placeholder, backpatched by finish_msg
+	return lenpos
+}
+
+fn finish_msg(mut buf []u8, lenpos int) {
+	msg_len := u32(buf.len - lenpos) // includes the 4 length bytes, excludes the type byte
+	buf[lenpos] = u8(msg_len >> 24)
+	buf[lenpos + 1] = u8(msg_len >> 16)
+	buf[lenpos + 2] = u8(msg_len >> 8)
+	buf[lenpos + 3] = u8(msg_len)
+}
+
+fn put_u16(mut buf []u8, v u16) {
+	buf << u8(v >> 8)
+	buf << u8(v)
+}
+
+fn put_u32(mut buf []u8, v u32) {
+	buf << u8(v >> 24)
+	buf << u8(v >> 16)
+	buf << u8(v >> 8)
+	buf << u8(v)
+}
+
+fn put_cstr(mut buf []u8, s []u8) {
+	buf << s
+	buf << u8(0)
+}
+
+// write_startup appends a StartupMessage (protocol 3.0): no type byte, Int32
+// length, Int32 protocol version, then user/database key-value pairs and a
+// terminating 0 byte.
+pub fn write_startup(mut buf []u8, user string, database string) {
+	lenpos := buf.len
+	buf << [u8(0), 0, 0, 0]
+	put_u32(mut buf, 0x0003_0000)
+	put_cstr(mut buf, 'user'.bytes())
+	put_cstr(mut buf, user.bytes())
+	if database.len > 0 {
+		put_cstr(mut buf, 'database'.bytes())
+		put_cstr(mut buf, database.bytes())
+	}
+	buf << u8(0) // end of parameters
+	msg_len := u32(buf.len - lenpos)
+	buf[lenpos] = u8(msg_len >> 24)
+	buf[lenpos + 1] = u8(msg_len >> 16)
+	buf[lenpos + 2] = u8(msg_len >> 8)
+	buf[lenpos + 3] = u8(msg_len)
+}
+
+// write_parse appends a Parse ('P'): statement name, SQL, and 0 parameter type
+// oids (let the server infer all parameter types).
+pub fn write_parse(mut buf []u8, stmt_name string, query_text string) {
+	lp := begin_msg(mut buf, `P`)
+	put_cstr(mut buf, stmt_name.bytes())
+	put_cstr(mut buf, query_text.bytes())
+	put_u16(mut buf, 0)
+	finish_msg(mut buf, lp)
+}
+
+// write_bind appends a Bind ('B'): text-format params in (null = length -1),
+// binary-format results out (one result-format-code 1 applied to all columns).
+pub fn write_bind(mut buf []u8, portal string, stmt_name string, params []?[]u8) {
+	lp := begin_msg(mut buf, `B`)
+	put_cstr(mut buf, portal.bytes())
+	put_cstr(mut buf, stmt_name.bytes())
+	put_u16(mut buf, 0) // 0 parameter format codes ⇒ all params are text
+	put_u16(mut buf, u16(params.len))
+	for p in params {
+		if v := p {
+			put_u32(mut buf, u32(v.len))
+			buf << v
+		} else {
+			put_u32(mut buf, 0xFFFF_FFFF) // -1 ⇒ SQL NULL
+		}
+	}
+	put_u16(mut buf, 1) // 1 result-format code...
+	put_u16(mut buf, 1) // ...= binary, applied to every column
+	finish_msg(mut buf, lp)
+}
+
+// write_describe_portal appends a Describe ('D') for a portal — its RowDescription
+// is returned before the rows.
+pub fn write_describe_portal(mut buf []u8, portal string) {
+	lp := begin_msg(mut buf, `D`)
+	buf << u8(`P`)
+	put_cstr(mut buf, portal.bytes())
+	finish_msg(mut buf, lp)
+}
+
+// write_execute appends an Execute ('E'): portal and a max-rows cap (0 = all).
+pub fn write_execute(mut buf []u8, portal string, max_rows int) {
+	lp := begin_msg(mut buf, `E`)
+	put_cstr(mut buf, portal.bytes())
+	put_u32(mut buf, u32(max_rows))
+	finish_msg(mut buf, lp)
+}
+
+// write_sync appends a Sync ('S') — flushes the pipeline and asks for a
+// ReadyForQuery.
+pub fn write_sync(mut buf []u8) {
+	buf << u8(`S`)
+	put_u32(mut buf, 4)
+}
+
+// write_terminate appends a Terminate ('X').
+pub fn write_terminate(mut buf []u8) {
+	buf << u8(`X`)
+	put_u32(mut buf, 4)
+}
+
+// write_sasl_initial appends a SASLInitialResponse ('p'): mechanism name, then
+// the Int32-length-prefixed client-first message.
+pub fn write_sasl_initial(mut buf []u8, mechanism string, client_first []u8) {
+	lp := begin_msg(mut buf, `p`)
+	put_cstr(mut buf, mechanism.bytes())
+	put_u32(mut buf, u32(client_first.len))
+	buf << client_first
+	finish_msg(mut buf, lp)
+}
+
+// write_sasl_response appends a SASLResponse ('p'): the raw client-final bytes.
+pub fn write_sasl_response(mut buf []u8, data []u8) {
+	lp := begin_msg(mut buf, `p`)
+	buf << data
+	finish_msg(mut buf, lp)
+}

--- a/pg_async/protocol_test.v
+++ b/pg_async/protocol_test.v
@@ -142,6 +142,29 @@ fn test_extended_query_pipeline_builds() {
 	assert rest.len == 0
 }
 
+// Framing must be correct when bytes arrive one at a time — exactly the
+// partial-read regime the non-blocking async worker runs in. next_message must
+// return none until a whole message is buffered, then frame it precisely.
+fn test_framing_under_byte_by_byte_fragmentation() {
+	mut full := []u8{}
+	append_msg(mut full, bt_data_row, build_data_row([?[]u8([u8(0), 0, 0, 7])]))
+	append_msg(mut full, bt_command_complete, 'SELECT 1\0'.bytes())
+	append_msg(mut full, bt_ready_for_query, [u8(`I`)])
+
+	mut buf := []u8{}
+	mut framed := []u8{} // the message type of each framed message, in order
+	for i in 0 .. full.len {
+		buf << full[i]
+		for {
+			hdr := next_message(buf) or { break }
+			framed << hdr.typ
+			buf.delete_many(0, hdr.total)
+		}
+	}
+	assert framed == [bt_data_row, bt_command_complete, bt_ready_for_query]
+	assert buf.len == 0 // every byte consumed, nothing left dangling
+}
+
 fn test_startup_message_has_no_type_byte_and_self_lengths() {
 	mut buf := []u8{}
 	write_startup(mut buf, 'bench', 'bench')

--- a/pg_async/protocol_test.v
+++ b/pg_async/protocol_test.v
@@ -1,0 +1,153 @@
+module pg_async
+
+fn test_binary_decoders() {
+	assert decode_int2([u8(0), 5])! == 5
+	assert decode_int4([u8(0), 0, 0, 7])! == 7
+	assert decode_int8([u8(0), 0, 0, 0, 0, 0, 0, 9])! == 9
+	assert decode_bool([u8(1)])! == true
+	assert decode_bool([u8(0)])! == false
+	assert decode_text('hi'.bytes()).bytestr() == 'hi'
+	// negative int4 (two's complement, big-endian): 0xFFFFFFFF == -1
+	assert decode_int4([u8(0xFF), 0xFF, 0xFF, 0xFF])! == -1
+	if _ := decode_int4([u8(0), 0, 7]) {
+		assert false, 'short int4 must error'
+	}
+}
+
+fn test_jsonb_text_strips_version_prefix() {
+	body := '[1,2,3]'.bytes()
+	mut wire := [u8(0x01)]
+	wire << body
+	assert jsonb_text(wire).bytestr() == '[1,2,3]'
+	assert jsonb_text(body).bytestr() == '[1,2,3]' // no prefix → unchanged
+}
+
+fn build_data_row(cols []?[]u8) []u8 {
+	mut p := []u8{}
+	put_u16(mut p, u16(cols.len))
+	for c in cols {
+		if v := c {
+			put_u32(mut p, u32(v.len))
+			p << v
+		} else {
+			put_u32(mut p, 0xFFFF_FFFF)
+		}
+	}
+	return p
+}
+
+fn test_row_column_access() {
+	// columns: int4 7, SQL NULL, text "hi"
+	payload := build_data_row([?[]u8([u8(0), 0, 0, 7]), ?[]u8(none), ?[]u8('hi'.bytes())])
+	r := Row{
+		payload: payload
+	}
+	assert r.int4(0)! == 7
+	assert r.text(2)!.bytestr() == 'hi'
+	// col(1) is SQL NULL
+	col1 := r.col(1)!
+	assert col1.is_null
+	// a typed read of a NULL column errors
+	if _ := r.int4(1) {
+		assert false, 'int4 of NULL must error'
+	}
+	// out-of-range column errors
+	if _ := r.col(3) {
+		assert false, 'col 3 out of range must error'
+	}
+}
+
+fn append_msg(mut buf []u8, typ u8, payload []u8) {
+	buf << typ
+	put_u32(mut buf, u32(4 + payload.len))
+	buf << payload
+}
+
+fn test_frame_iter_and_result_rows() {
+	mut frames := []u8{}
+	append_msg(mut frames, bt_parse_complete, [])
+	append_msg(mut frames, bt_bind_complete, [])
+	append_msg(mut frames, bt_data_row, build_data_row([
+		?[]u8([u8(0), 0, 0, 42]),
+	]))
+	append_msg(mut frames, bt_data_row, build_data_row([
+		?[]u8([u8(0), 0, 0, 43]),
+	]))
+	tag := 'SELECT 2\0'.bytes()
+	append_msg(mut frames, bt_command_complete, tag)
+
+	res := Result{
+		frames:        frames
+		rows_affected: parse_command_complete(tag)
+	}
+	mut it := res.rows()
+	r0 := it.next() or { panic('expected row 0') }
+	assert r0.int4(0)! == 42
+	r1 := it.next() or { panic('expected row 1') }
+	assert r1.int4(0)! == 43
+	if _ := it.next() {
+		assert false, 'expected end of rows'
+	}
+	assert res.rows_affected == 2
+}
+
+fn test_next_message_framing() {
+	mut buf := []u8{}
+	append_msg(mut buf, bt_ready_for_query, [u8(`I`)]) // idle
+	// a partial trailing message: header says more bytes than present
+	buf << bt_data_row
+	put_u32(mut buf, 100)
+	hdr := next_message(buf) or { panic('expected a complete first message') }
+	assert hdr.typ == bt_ready_for_query
+	rest := buf[hdr.total..]
+	if _ := next_message(rest) {
+		assert false, 'partial second message must not frame'
+	}
+}
+
+fn test_parse_error_response() {
+	mut p := []u8{}
+	p << u8(`S`)
+	p << 'ERROR\0'.bytes()
+	p << u8(`C`)
+	p << '23505\0'.bytes()
+	p << u8(`M`)
+	p << 'duplicate key value'.bytes()
+	p << u8(0)
+	p << u8(0) // field-list terminator
+	info := parse_error_response(p)
+	assert info.severity.bytestr() == 'ERROR'
+	assert info.code.bytestr() == '23505'
+	assert info.message.bytestr() == 'duplicate key value'
+}
+
+fn test_extended_query_pipeline_builds() {
+	mut buf := []u8{}
+	write_parse(mut buf, '', 'select id from items')
+	write_bind(mut buf, '', '', []?[]u8{})
+	write_describe_portal(mut buf, '')
+	write_execute(mut buf, '', 0)
+	write_sync(mut buf)
+
+	// First framed message is Parse, and every message frames cleanly back to
+	// back through the whole pipeline.
+	mut rest := buf.clone()
+	mut types := []u8{}
+	for {
+		hdr := next_message(rest) or { break }
+		types << hdr.typ
+		rest = unsafe { rest[hdr.total..] }
+	}
+	assert types == [u8(`P`), `B`, `D`, `E`, `S`]
+	assert rest.len == 0
+}
+
+fn test_startup_message_has_no_type_byte_and_self_lengths() {
+	mut buf := []u8{}
+	write_startup(mut buf, 'bench', 'bench')
+	// length field covers the whole message
+	len := int(u32(buf[0]) << 24 | u32(buf[1]) << 16 | u32(buf[2]) << 8 | u32(buf[3]))
+	assert len == buf.len
+	// protocol version 3.0
+	assert buf[4] == 0 && buf[5] == 3 && buf[6] == 0 && buf[7] == 0
+}

--- a/pg_async/protocol_test.v
+++ b/pg_async/protocol_test.v
@@ -99,7 +99,7 @@ fn test_next_message_framing() {
 	put_u32(mut buf, 100)
 	hdr := next_message(buf) or { panic('expected a complete first message') }
 	assert hdr.typ == bt_ready_for_query
-	rest := buf[hdr.total..]
+	rest := unsafe { buf[hdr.total..] }
 	if _ := next_message(rest) {
 		assert false, 'partial second message must not frame'
 	}

--- a/pg_async/scram.v
+++ b/pg_async/scram.v
@@ -1,0 +1,151 @@
+module pg_async
+
+import crypto.sha256
+import crypto.hmac
+import crypto.pbkdf2
+import crypto.rand
+import encoding.base64
+
+// SCRAM-SHA-256 (RFC 5802 / RFC 7677) client-side authentication for the
+// PostgreSQL SASL handshake. Channel binding is not used — the gs2 header is
+// "n,," — which is what PostgreSQL's `scram-sha-256` (non-`-plus`) method
+// expects. All primitives come from V's stdlib (crypto.{sha256,hmac,pbkdf2},
+// encoding.base64), so there is no external crypto dependency.
+
+pub const scram_sha_256 = 'SCRAM-SHA-256'
+
+const gs2_header = 'n,,' // no channel binding, no authorization identity
+
+// ScramClient drives the three client steps in order:
+//   client_first()          → the SASLInitialResponse payload
+//   handle_server_first(..)  → consumes server-first, returns client-final
+//   handle_server_final(..)  → verifies the server proved it knows the password
+pub struct ScramClient {
+	username string
+	password string
+mut:
+	client_nonce      string
+	client_first_bare string
+	server_signature  []u8 // computed in handle_server_first, checked in handle_server_final
+	done              bool
+}
+
+// ScramClient.new builds a client with a fresh random nonce (base64 of 18
+// random bytes — printable and comma-free, as the nonce grammar requires).
+pub fn ScramClient.new(username string, password string) !ScramClient {
+	nonce := rand.bytes(18)!
+	return ScramClient{
+		username:     username
+		password:     password
+		client_nonce: base64.encode(nonce)
+	}
+}
+
+// ScramClient.with_nonce builds a client with a caller-supplied nonce, for
+// deterministic tests (RFC vectors). Production code uses new().
+fn ScramClient.with_nonce(username string, password string, client_nonce string) ScramClient {
+	return ScramClient{
+		username:     username
+		password:     password
+		client_nonce: client_nonce
+	}
+}
+
+// client_first returns the SASL client-first message: gs2-header followed by
+// "n=<escaped-username>,r=<client-nonce>".
+pub fn (mut c ScramClient) client_first() []u8 {
+	c.client_first_bare = 'n=${scram_escape(c.username)},r=${c.client_nonce}'
+	return '${gs2_header}${c.client_first_bare}'.bytes()
+}
+
+// handle_server_first parses the server-first message (r= combined nonce, s=
+// base64 salt, i= iteration count), runs the SCRAM computation, stashes the
+// expected ServerSignature for the final step, and returns the client-final
+// message carrying the ClientProof.
+pub fn (mut c ScramClient) handle_server_first(server_first []u8) ![]u8 {
+	sf := server_first.bytestr()
+	mut combined_nonce := ''
+	mut salt_b64 := ''
+	mut iter := 0
+	for attr in sf.split(',') {
+		if attr.len < 2 || attr[1] != `=` {
+			continue
+		}
+		val := attr[2..]
+		match attr[0] {
+			`r` { combined_nonce = val }
+			`s` { salt_b64 = val }
+			`i` { iter = val.int() }
+			`e` { return error('scram: server error in server-first: ${val}') }
+			else {}
+		}
+	}
+	if combined_nonce == '' || !combined_nonce.starts_with(c.client_nonce) {
+		return error('scram: server nonce does not extend the client nonce')
+	}
+	if salt_b64 == '' || iter <= 0 {
+		return error('scram: malformed server-first message')
+	}
+
+	// SaltedPassword := Hi(password, salt, i) = PBKDF2-HMAC-SHA256, 32 bytes.
+	salt := base64.decode(salt_b64)
+	salted_password := pbkdf2.key(c.password.bytes(), salt, iter, sha256.size, sha256.new())!
+	// ClientKey := HMAC(SaltedPassword, "Client Key"); StoredKey := H(ClientKey).
+	client_key := hmac.new(salted_password, 'Client Key'.bytes(), sha256.sum, sha256.block_size)
+	stored_key := sha256.sum(client_key)
+
+	// client-final-message-without-proof, then the full AuthMessage.
+	channel_binding := 'c=' + base64.encode(gs2_header.bytes()) // "c=biws"
+	client_final_bare := '${channel_binding},r=${combined_nonce}'
+	auth_message := '${c.client_first_bare},${sf},${client_final_bare}'
+
+	// ClientSignature := HMAC(StoredKey, AuthMessage); ClientProof := ClientKey XOR ClientSignature.
+	client_signature := hmac.new(stored_key, auth_message.bytes(), sha256.sum, sha256.block_size)
+	mut client_proof := []u8{len: client_key.len}
+	for i in 0 .. client_key.len {
+		client_proof[i] = client_key[i] ^ client_signature[i]
+	}
+
+	// ServerSignature := HMAC(ServerKey, AuthMessage), verified in the final step.
+	server_key := hmac.new(salted_password, 'Server Key'.bytes(), sha256.sum, sha256.block_size)
+	c.server_signature = hmac.new(server_key, auth_message.bytes(), sha256.sum, sha256.block_size)
+
+	return '${client_final_bare},p=${base64.encode(client_proof)}'.bytes()
+}
+
+// handle_server_final verifies the server's ServerSignature (the v= field)
+// matches the one computed during handle_server_first — proving the server
+// also knows the password — and marks the handshake complete.
+pub fn (mut c ScramClient) handle_server_final(server_final []u8) ! {
+	sf := server_final.bytestr()
+	mut v_b64 := ''
+	for attr in sf.split(',') {
+		if attr.len < 2 || attr[1] != `=` {
+			continue
+		}
+		match attr[0] {
+			`v` { v_b64 = attr[2..] }
+			`e` { return error('scram: server rejected authentication: ${attr[2..]}') }
+			else {}
+		}
+	}
+	if v_b64 == '' {
+		return error('scram: missing server signature in server-final')
+	}
+	if base64.encode(c.server_signature) != v_b64 {
+		return error('scram: server signature mismatch')
+	}
+	c.done = true
+}
+
+// is_done reports whether the server has been verified.
+pub fn (c &ScramClient) is_done() bool {
+	return c.done
+}
+
+// scram_escape encodes a username for the SASL `n=` field: '=' → "=3D" and
+// ',' → "=2C". '=' must be escaped first, or the '=' introduced by the comma
+// escaping would be double-encoded.
+fn scram_escape(s string) string {
+	return s.replace('=', '=3D').replace(',', '=2C')
+}

--- a/pg_async/scram_test.v
+++ b/pg_async/scram_test.v
@@ -1,0 +1,55 @@
+module pg_async
+
+// Test vectors from RFC 7677 §3 (SCRAM-SHA-256 example): user "user",
+// password "pencil", fixed client nonce. Raw strings (r'...') keep V from
+// interpolating the `$` in the server nonce.
+fn test_scram_sha256_rfc7677_vector() {
+	mut c := ScramClient.with_nonce('user', 'pencil', 'rOprNGfwEbeRWgbNEkqO')
+
+	client_first := c.client_first().bytestr()
+	assert client_first == 'n,,n=user,r=rOprNGfwEbeRWgbNEkqO'
+
+	server_first := r'r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+	client_final := c.handle_server_first(server_first.bytes())!.bytestr()
+	assert client_final == r'c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ='
+
+	// Correct ServerSignature is accepted.
+	c.handle_server_final('v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4='.bytes())!
+	assert c.is_done()
+}
+
+fn test_scram_rejects_wrong_server_signature() {
+	mut c := ScramClient.with_nonce('user', 'pencil', 'rOprNGfwEbeRWgbNEkqO')
+	c.client_first()
+	server_first := r'r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'
+	c.handle_server_first(server_first.bytes())!
+	// A tampered v= must be rejected and must not mark the client done.
+	if _ := c.handle_server_final('v=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='.bytes()) {
+		assert false, 'tampered server signature must be rejected'
+	}
+	assert !c.is_done()
+}
+
+fn test_scram_rejects_bad_nonce() {
+	mut c := ScramClient.with_nonce('user', 'pencil', 'rOprNGfwEbeRWgbNEkqO')
+	c.client_first()
+	// server nonce that does not start with the client nonce → reject
+	if _ := c.handle_server_first('r=DIFFERENT,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096'.bytes()) {
+		assert false, 'mismatched nonce must be rejected'
+	}
+}
+
+fn test_scram_escape() {
+	assert scram_escape('plain') == 'plain'
+	assert scram_escape('a,b') == 'a=2Cb'
+	assert scram_escape('a=b') == 'a=3Db'
+	// '=' is escaped before ',' so the '=' in =2C is not double-encoded
+	assert scram_escape('a=,') == 'a=3D=2C'
+}
+
+fn test_scram_new_generates_random_nonce() {
+	mut c := ScramClient.new('app', 'secret')!
+	cf := c.client_first().bytestr()
+	assert cf.starts_with('n,,n=app,r=')
+	assert cf.len > 'n,,n=app,r='.len // a non-empty nonce was appended
+}

--- a/pg_async/types.v
+++ b/pg_async/types.v
@@ -1,0 +1,69 @@
+module pg_async
+
+import encoding.binary
+
+// Binary (network byte order) decoders for PostgreSQL result columns.
+//
+// The client Binds every column with result-format-code 1, so DataRow values
+// arrive in BINARY — no text int/float parsing on the hot path (this is one of
+// the reasons a native client beats a text-format libpq round-trip). Each
+// decoder takes the raw column bytes already split out of the DataRow by
+// Row.col(); the slice borrows the connection recv buffer and is valid only for
+// the duration of the resume callback.
+
+@[inline]
+pub fn decode_int2(b []u8) !i16 {
+	if b.len != 2 {
+		return error('int2: bad width ${b.len}')
+	}
+	return i16(binary.big_endian_u16(b))
+}
+
+@[inline]
+pub fn decode_int4(b []u8) !i32 {
+	if b.len != 4 {
+		return error('int4: bad width ${b.len}')
+	}
+	return i32(binary.big_endian_u32(b))
+}
+
+@[inline]
+pub fn decode_int8(b []u8) !i64 {
+	if b.len != 8 {
+		return error('int8: bad width ${b.len}')
+	}
+	return i64(binary.big_endian_u64(b))
+}
+
+@[inline]
+pub fn decode_bool(b []u8) !bool {
+	if b.len != 1 {
+		return error('bool: bad width ${b.len}')
+	}
+	return b[0] != 0
+}
+
+@[inline]
+pub fn decode_float8(b []u8) !f64 {
+	if b.len != 8 {
+		return error('float8: bad width ${b.len}')
+	}
+	bits := binary.big_endian_u64(b)
+	return unsafe { *(&f64(&bits)) }
+}
+
+// decode_text returns the bytes as-is (PG text / varchar / numeric-as-text, and
+// the body of a JSONB value once its 1-byte version prefix is stripped). The
+// slice borrows the recv buffer — copy it if it must outlive the continuation.
+@[inline]
+pub fn decode_text(b []u8) []u8 {
+	return b
+}
+
+// jsonb_text strips the JSONB binary version header (a leading 0x01) so the
+// remainder is valid JSON text that re-encodes as a real array/object rather
+// than an escaped string.
+@[inline]
+pub fn jsonb_text(raw []u8) []u8 {
+	return if raw.len > 0 && raw[0] == 0x01 { raw[1..] } else { raw }
+}


### PR DESCRIPTION
## What

A native, **libpq-free** PostgreSQL client (`pg_async/`) for the epoll async runtime — the path the fastest HttpArena async-db framework (swerver) takes: the PG socket lives on the worker's reactor, queries **park and resume** via `ac.watch`, and results decode in **binary**. The driver behind enghitalo/vanilla#32.

Built in layers, every one tested against **live PostgreSQL 18**:

| Layer | File |
|---|---|
| Wire protocol v3 framing + binary decoders | `protocol.v`, `types.v` |
| SCRAM-SHA-256 auth (RFC 5802/7677) | `scram.v` |
| Blocking connection + handshake | `conn.v` |
| Non-blocking, reactor-driven query pump | `conn_async.v` |
| Per-worker connection pool | `pool.v` |

Plus one enabling runtime fix and a full end-to-end example.

## Highlights

- **Binary result format** — no text int parsing; `jsonb` arrives binary (`0x01` version byte stripped to JSON).
- **SCRAM-SHA-256** on V stdlib crypto — verified byte-for-byte against the RFC 7677 vector.
- **Park-and-resume**: `async_submit` → `async_flush` (writable) → `async_on_readable` (readable) → `QueryPoll` ready at `ReadyForQuery`; connection returns to idle, reusable.
- **Per-worker pool** via `make_state` (no cross-worker sharing, no locks).
- **Idempotent watch registration** (`async_register` tries `EPOLL_CTL_MOD` before `ADD`) so a long-lived pool fd re-watched across queries doesn't `perror`-spam — no stale-fd hazard for request-owned fds (async_pipe still passes).

## Validation

- Unit: framing (incl. byte-by-byte fragmentation), binary decoders, SCRAM RFC vector + edge cases.
- Live PG 18: real async-db query shape (9 columns incl. jsonb), 500-row buffer-spanning results, empty-range anti-cheat, error recovery, the non-blocking pump, pool acquire/release.
- **End-to-end** (`examples/async_db_pg/`): 16 workers × 4-conn pools, `GET /db` returns rows as JSON through the real async worker (park on PG socket → resume → response), repeated queries reuse pooled connections cleanly, `GET /health` synchronous path.

Integration tests gated behind `PGHOST` so CI without a database stays green.

## Next

This driver + #38 unblock converting the HttpArena `vanilla-epoll` `async-db`/`fortunes` endpoints to `async_handler` (the `examples/async_db_pg` handler is the template), then the arena benchmark.

Refs #32 #35