### PR TITLE
feat(async): flat fd-indexed reactor + flush-on-suspend, with 5 runtime examples

### DIFF
--- a/examples/async_incremental_read/main.v
+++ b/examples/async_incremental_read/main.v
@@ -1,0 +1,88 @@
+module main
+
+// Async-runtime example: incremental read from a slow fd, forwarded as it
+// arrives. A child process produces a few lines with pauses; we wrap its pipe,
+// watch it readable, and each time bytes show up we forward them as one HTTP
+// chunk and re-arm — never blocking the worker while the producer sleeps. This
+// is the reverse-proxy / `tail -f` shape: read what's available, stream it, wait
+// for more.
+//
+// Run:   v run examples/async_incremental_read/
+// Try:   curl -N http://localhost:8093/stream
+//        # -> "line 1" ... "line 5", each ~200ms apart, chunk-encoded
+//
+// epoll only watches pollable fds (pipes/sockets), NOT regular files — a file
+// reads as "always ready", so streaming one needs no async at all. The pipe here
+// is the realistic case: the bytes genuinely arrive over time.
+import http_server
+import http_server.core
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+
+fn C.popen(command &char, mode &char) voidptr
+fn C.pclose(stream voidptr) int
+fn C.fileno(stream voidptr) int
+fn C.fcntl(fd int, cmd int, arg int) int
+fn C.read(fd int, buf voidptr, count usize) int
+
+const chunk_headers = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+const not_found = 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+fn handle(req []u8, mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	if !req.bytestr().contains('/stream') {
+		out << not_found
+		return .done
+	}
+	// A producer whose output is spread over time — the whole point of streaming.
+	fp := C.popen(c'for i in 1 2 3 4 5; do echo "line $i"; sleep 0.2; done', c'r')
+	if fp == unsafe { nil } {
+		out << not_found
+		return .done
+	}
+	fd := C.fileno(fp)
+	C.fcntl(fd, C.F_SETFL, C.O_NONBLOCK) // so read() returns EAGAIN instead of blocking
+	out << chunk_headers // flushed after the initial .suspend
+	ac.watch(fd, .readable, on_chunk, fp) // carry FILE* so we can pclose at EOF
+	return .suspend
+}
+
+// on_chunk runs whenever the pipe has bytes (or hit EOF): forward what is there
+// as one chunk and re-arm. Each chunk flushes on .suspend, so the client sees
+// output as the producer emits it.
+fn on_chunk(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	mut buf := [4096]u8{}
+	n := C.read(ac.ready_fd(), &buf[0], 4096)
+	if n > 0 {
+		// HTTP chunk = <hex length>\r\n<bytes>\r\n
+		out << '${n.hex()}\r\n'.bytes()
+		out << buf[..n]
+		out << '\r\n'.bytes()
+		ac.watch(ac.ready_fd(), .readable, on_chunk, ac.udata)
+		return .suspend
+	}
+	if n == 0 {
+		out << '0\r\n\r\n'.bytes() // terminating chunk
+		C.pclose(ac.udata)
+		return .done
+	}
+	// n < 0: nothing ready yet (EAGAIN) → wait for the next readable edge.
+	if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
+		ac.watch(ac.ready_fd(), .readable, on_chunk, ac.udata)
+		return .suspend
+	}
+	C.pclose(ac.udata) // a real read error → drop the connection
+	return .close
+}
+
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:            8093
+		io_multiplexing: .epoll
+		async_handler:   handle
+	})!
+	server.run()
+}

--- a/examples/async_multi_watch/main.v
+++ b/examples/async_multi_watch/main.v
@@ -1,0 +1,78 @@
+module main
+
+// Async-runtime example: a multi-step chain that watches SEVERAL fds in sequence
+// over one request. `/chain` waits on timer A, then on a DIFFERENT timer B, then
+// answers — each `.suspend` re-arms the worker on the next fd. This is the shape
+// of any "do X, then once it is ready do Y, then reply" flow: connect → send →
+// recv, or query → second query → render. v1 runs one in-flight watch per
+// connection, so the steps are sequential (not concurrent fan-in).
+//
+// Run:   v run examples/async_multi_watch/
+// Try:   curl http://localhost:8094/chain
+//        # -> "stage A done (80ms), then stage B done (140ms)" after ~220ms
+//
+// The worker is free between stages, so many /chain requests overlap their waits
+// instead of serializing. See core.AsyncHandler / core.WakeFn.
+import http_server
+import http_server.core
+
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+fn C.timerfd_create(clockid int, flags int) int
+fn C.timerfd_settime(fd int, flags int, new_value voidptr, old_value voidptr) int
+fn C.read(fd int, buf voidptr, count usize) int
+
+const not_found = 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+// one_shot_timer returns a timerfd that fires once after `ms`.
+fn one_shot_timer(ms int) int {
+	tfd := C.timerfd_create(C.CLOCK_MONOTONIC, 0)
+	mut spec := [4]i64{} // { it_interval{0,0}, it_value{sec,nsec} } → one-shot
+	spec[2] = i64(ms / 1000)
+	spec[3] = i64(ms % 1000) * 1_000_000
+	C.timerfd_settime(tfd, 0, voidptr(&spec[0]), unsafe { nil })
+	return tfd
+}
+
+// drain_close reads the expiry count off a fired timerfd and closes it (each
+// stage owns its own timerfd).
+fn drain_close(fd int) {
+	mut tmp := [8]u8{}
+	C.read(fd, &tmp[0], 8)
+	C.close(fd)
+}
+
+fn handle(req []u8, mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	if !req.bytestr().contains('/chain') {
+		out << not_found
+		return .done
+	}
+	ac.watch(one_shot_timer(80), .readable, after_a, unsafe { nil }) // stage A
+	return .suspend
+}
+
+// after_a runs when timer A fires: close it, then arm a DIFFERENT fd (timer B)
+// and park again — demonstrating that a continuation can re-watch a new fd.
+fn after_a(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	drain_close(ac.ready_fd())
+	ac.watch(one_shot_timer(140), .readable, after_b, unsafe { nil }) // stage B
+	return .suspend
+}
+
+// after_b runs when timer B fires: close it and produce the response.
+fn after_b(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	drain_close(ac.ready_fd())
+	body := 'stage A done (80ms), then stage B done (140ms)'
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ${body.len}\r\nConnection: keep-alive\r\n\r\n${body}'.bytes()
+	return .done
+}
+
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:            8094
+		io_multiplexing: .epoll
+		async_handler:   handle
+	})!
+	server.run()
+}

--- a/examples/async_sse/main.v
+++ b/examples/async_sse/main.v
@@ -1,0 +1,96 @@
+module main
+
+// Async-runtime example: Server-Sent Events (SSE), the canonical user of
+// flush-on-suspend. One periodic `timerfd` drives the stream; each time it fires
+// the continuation appends ONE `data:` event and re-arms — and because a
+// continuation that wrote bytes before returning `.suspend` has them flushed
+// immediately (not buffered until `.done`), the client receives each event the
+// instant it is produced. The single worker keeps serving everyone else between
+// ticks, so thousands of open streams cost ~one timerfd + a small struct each,
+// not a thread each.
+//
+// Run:   v run examples/async_sse/
+// Try:   curl -N http://localhost:8092/events
+//        # -> data: tick 1 of 5   (one line per second, then "bye")
+//
+// The same append-flush-suspend loop is how a chat feed, a progress stream, or a
+// log tail would push to many clients from one thread. See core.AsyncHandler.
+import http_server
+import http_server.core
+
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+fn C.timerfd_create(clockid int, flags int) int
+fn C.timerfd_settime(fd int, flags int, new_value voidptr, old_value voidptr) int
+fn C.read(fd int, buf voidptr, count usize) int
+
+// Stream is the per-connection cursor, carried across ticks via ac.udata — ONE
+// heap allocation for the whole stream, freed when it ends (not per event).
+struct Stream {
+mut:
+	tfd  int // the periodic timerfd this stream is parked on
+	sent int // events emitted so far
+	max  int // stop (and close) after this many
+}
+
+const sse_headers = 'HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+const not_found = 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+// arm_periodic programs a timerfd to fire every `ms` (it_value = it_interval).
+fn arm_periodic(tfd int, ms int) {
+	// struct itimerspec = { it_interval{sec,nsec}, it_value{sec,nsec} } = 4×i64.
+	mut spec := [4]i64{}
+	spec[0] = i64(ms / 1000)
+	spec[1] = i64(ms % 1000) * 1_000_000
+	spec[2] = spec[0]
+	spec[3] = spec[1]
+	C.timerfd_settime(tfd, 0, voidptr(&spec[0]), unsafe { nil })
+}
+
+fn handle(req []u8, mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	if !req.bytestr().contains('/events') {
+		out << not_found
+		return .done
+	}
+	tfd := C.timerfd_create(C.CLOCK_MONOTONIC, 0)
+	arm_periodic(tfd, 1000) // one event per second
+	st := &Stream{
+		tfd:  tfd
+		sent: 0
+		max:  5
+	}
+	// Headers go out NOW: async_serve flushes the write buffer after the initial
+	// .suspend, so the client sees `200 text/event-stream` before any tick.
+	out << sse_headers
+	ac.watch(tfd, .readable, sse_tick, voidptr(st))
+	return .suspend
+}
+
+// sse_tick fires once per timer expiry: emit one event and re-arm. The appended
+// bytes are flushed on .suspend (the streaming primitive), so each event ships
+// immediately instead of waiting for the stream to finish.
+fn sse_tick(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	mut tmp := [8]u8{}
+	C.read(ac.ready_fd(), &tmp[0], 8) // drain the timerfd expiry count
+	mut st := unsafe { &Stream(ac.udata) }
+	st.sent++
+	out << 'data: tick ${st.sent} of ${st.max}\n\n'.bytes()
+	if st.sent >= st.max {
+		out << 'data: bye\n\n'.bytes()
+		C.close(st.tfd) // request owns the timerfd; closing it removes it from epoll
+		return .done
+	}
+	ac.watch(st.tfd, .readable, sse_tick, ac.udata) // keep streaming
+	return .suspend
+}
+
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:            8092
+		io_multiplexing: .epoll
+		async_handler:   handle
+	})!
+	server.run()
+}

--- a/examples/async_time_limit/main.v
+++ b/examples/async_time_limit/main.v
@@ -1,0 +1,109 @@
+module main
+
+// Async-runtime example: a cooperative deadline over multi-step async work.
+// `/job?steps=N` does N units of work (each a 50ms timer tick), but gives up
+// with 504 the moment total elapsed time crosses a budget (300ms). The budget
+// and remaining steps ride along in ac.udata; every continuation checks the
+// clock before doing more, so a too-big job is cut off instead of running away.
+//
+// Run:   v run examples/async_time_limit/
+// Try:   curl 'http://localhost:8095/job?steps=4'    # ~200ms  -> 200 completed
+//        curl 'http://localhost:8095/job?steps=10'   # would be ~500ms -> 504
+//
+// This is the building block for per-request time limits on anything async (a
+// slow upstream, a long query loop): one monotonic check per resume, no extra
+// watch. (A single hard wall-clock deadline can also be a second timerfd — but
+// v1 allows one in-flight watch per conn, so here we check the clock per step.)
+import http_server
+import http_server.core
+import time
+
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+fn C.timerfd_create(clockid int, flags int) int
+fn C.timerfd_settime(fd int, flags int, new_value voidptr, old_value voidptr) int
+fn C.read(fd int, buf voidptr, count usize) int
+
+const budget_ms = i64(300)
+
+const not_found = 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+// Job is the per-request state carried across ticks via ac.udata.
+struct Job {
+mut:
+	tfd   int // the periodic 50ms work-tick timerfd
+	left  int // work steps still to do
+	start i64 // time.ticks() at request start, for the elapsed-vs-budget check
+}
+
+fn arm_periodic(tfd int, ms int) {
+	mut spec := [4]i64{}
+	spec[0] = i64(ms / 1000)
+	spec[1] = i64(ms % 1000) * 1_000_000
+	spec[2] = spec[0]
+	spec[3] = spec[1]
+	C.timerfd_settime(tfd, 0, voidptr(&spec[0]), unsafe { nil })
+}
+
+// parse_steps pulls N out of `/job?steps=N`, defaulting to 10.
+fn parse_steps(req []u8) int {
+	s := req.bytestr()
+	idx := s.index('steps=') or { return 10 }
+	mut n := 0
+	mut seen := false
+	for i := idx + 6; i < s.len && s[i] >= `0` && s[i] <= `9`; i++ {
+		n = n * 10 + int(s[i] - `0`)
+		seen = true
+	}
+	return if seen && n > 0 { n } else { 10 }
+}
+
+fn handle(req []u8, mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	if !req.bytestr().contains('/job') {
+		out << not_found
+		return .done
+	}
+	tfd := C.timerfd_create(C.CLOCK_MONOTONIC, 0)
+	arm_periodic(tfd, 50)
+	job := &Job{
+		tfd:   tfd
+		left:  parse_steps(req)
+		start: time.ticks()
+	}
+	ac.watch(tfd, .readable, tick, voidptr(job))
+	return .suspend
+}
+
+// tick runs each 50ms: if we are over budget, 504; if all steps are done, 200;
+// otherwise consume one step and re-arm.
+fn tick(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	mut tmp := [8]u8{}
+	C.read(ac.ready_fd(), &tmp[0], 8)
+	mut job := unsafe { &Job(ac.udata) }
+	elapsed := time.ticks() - job.start
+	if elapsed > budget_ms {
+		C.close(job.tfd)
+		body := 'deadline exceeded after ${elapsed}ms (budget ${budget_ms}ms)'
+		out << 'HTTP/1.1 504 Gateway Timeout\r\nContent-Type: text/plain\r\nContent-Length: ${body.len}\r\nConnection: keep-alive\r\n\r\n${body}'.bytes()
+		return .done
+	}
+	job.left--
+	if job.left <= 0 {
+		C.close(job.tfd)
+		body := 'completed within budget (~${elapsed}ms)'
+		out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: ${body.len}\r\nConnection: keep-alive\r\n\r\n${body}'.bytes()
+		return .done
+	}
+	ac.watch(job.tfd, .readable, tick, ac.udata) // more work to do
+	return .suspend
+}
+
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:            8095
+		io_multiplexing: .epoll
+		async_handler:   handle
+	})!
+	server.run()
+}

--- a/examples/efficient_date/main.v
+++ b/examples/efficient_date/main.v
@@ -1,0 +1,74 @@
+module main
+
+// Performance example: a cheap, correct `Date:` header. Every HTTP response is
+// supposed to carry a Date, but formatting an RFC-1123 timestamp per request is
+// pure waste — the value only changes once a second. This caches the formatted
+// `Date: ...\r\n` line PER WORKER and rebuilds it only when the wall-clock second
+// advances, so almost every request just appends the cached bytes (no time
+// syscall, no formatting, no allocation).
+//
+// Per-worker state (make_state) means the cache is lock-free: each epoll worker
+// owns its own DateCache, nothing is shared across threads. This is the same
+// trick nginx uses (a coarse cached time string refreshed by the event loop).
+//
+// Run:   v run examples/efficient_date/
+// Try:   curl -i http://localhost:8096/        # note the Date header
+//
+// A background timerfd could refresh the cache proactively instead of lazily,
+// but that needs a worker-start hook for a watch not tied to any request — a
+// noted async-runtime follow-up. Lazy refresh is simpler and just as cheap.
+import http_server
+import time
+
+// DateCache is one worker's cached Date line + the unix second it is valid for.
+struct DateCache {
+mut:
+	sec  i64  // unix second the cached line was built for
+	line []u8 // "Date: <rfc1123>\r\n", reused until `sec` changes
+}
+
+// make_state runs once per worker — each gets its own cache (no lock needed).
+fn make_state() voidptr {
+	return &DateCache{
+		sec:  0
+		line: []u8{cap: 40}
+	}
+}
+
+// refresh rebuilds the cached Date line only when the second has advanced.
+@[direct_array_access]
+fn (mut dc DateCache) refresh() {
+	now := time.utc()
+	if now.unix() == dc.sec {
+		return
+	}
+	dc.sec = now.unix()
+	dc.line.clear()
+	dc.line << 'Date: '.bytes()
+	now.push_to_http_header(mut dc.line) // appends "Sun, 06 Nov 1994 08:49:37 GMT"
+	dc.line << '\r\n'.bytes()
+}
+
+const body = 'ok'.bytes()
+
+const head = 'HTTP/1.1 200 OK\r\n'.bytes()
+
+const tail = 'Content-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
+
+fn handle(req []u8, fd int, mut out []u8, state voidptr) ! {
+	mut dc := unsafe { &DateCache(state) }
+	dc.refresh()
+	out << head
+	out << dc.line // cached: no per-request formatting in the common case
+	out << tail
+}
+
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:             8096
+		io_multiplexing:  .epoll
+		stateful_handler: handle
+		make_state:       make_state
+	})!
+	server.run()
+}

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -36,18 +36,60 @@ import http_server.http1_1.response
 
 // WatchEntry records one parked request: which client connection is waiting, the
 // continuation to run when the watched fd is ready, and the consumer's opaque
-// context handed back via AsyncCtx.udata.
+// context handed back via AsyncCtx.udata. `active` is the slot's occupancy flag:
+// the table is indexed by fd (a flat array, not a hashmap), so a cleared slot is
+// just `active = false` rather than an erased key.
 struct WatchEntry {
+mut:
+	active    bool
 	client_fd int
 	cont      core.WakeFn = unsafe { nil }
 	udata     voidptr
 }
 
-// AsyncReactor is the per-worker watch registry: external fd -> parked request.
-// One per worker thread (so it needs no lock).
+// AsyncReactor is the per-worker watch registry: a flat array indexed by the
+// external fd (NOT a hashmap) — the same fd-indexed, doubling-grown layout the
+// synchronous path already uses for `PlainState.conns`. Watch/resume/clear are
+// then plain array writes with no hashing or per-request allocation (the event
+// loop's hot lookup is `watches[fd].active`). One per worker thread, no lock.
 struct AsyncReactor {
 mut:
-	watches map[int]WatchEntry
+	watches []WatchEntry
+}
+
+// reactor_watch records (or rearms) the watch for ext_fd, growing the flat table
+// by doubling if the fd is past the current bound — mirroring state_for's growth
+// so high fd numbers stay O(1)-indexed with no hashing.
+@[direct_array_access]
+fn (mut r AsyncReactor) reactor_watch(ext_fd int, client_fd int, cont core.WakeFn, udata voidptr) {
+	if ext_fd >= r.watches.len {
+		mut new_len := if r.watches.len == 0 { conn_table_min } else { r.watches.len }
+		for new_len <= ext_fd {
+			new_len *= 2
+		}
+		mut grown := []WatchEntry{len: new_len}
+		for i in 0 .. r.watches.len {
+			grown[i] = r.watches[i]
+		}
+		r.watches = grown
+	}
+	r.watches[ext_fd] = WatchEntry{
+		active:    true
+		client_fd: client_fd
+		cont:      cont
+		udata:     udata
+	}
+}
+
+// reactor_clear marks ext_fd's slot free. The fd itself stays in epoll (a
+// pool-owned connection is re-armed by the next watch); only the parked-request
+// record is dropped, so a stale readiness edge finds `active == false` and is
+// ignored.
+@[direct_array_access; inline]
+fn (mut r AsyncReactor) reactor_clear(ext_fd int) {
+	if ext_fd >= 0 && ext_fd < r.watches.len {
+		r.watches[ext_fd].active = false
+	}
 }
 
 // async_register is installed into AsyncCtx.register; it is what `ac.watch(...)`
@@ -56,11 +98,7 @@ mut:
 // consumer fds). Runs on the worker thread, so no synchronization is needed.
 fn async_register(mut ac core.AsyncCtx, ext_fd int, interest core.WatchInterest, cont core.WakeFn, udata voidptr) {
 	mut r := unsafe { &AsyncReactor(ac.reactor) }
-	r.watches[ext_fd] = WatchEntry{
-		client_fd: ac.client_fd
-		cont:      cont
-		udata:     udata
-	}
+	r.reactor_watch(ext_fd, ac.client_fd, cont, udata)
 	events := if interest == .writable { u32(C.EPOLLOUT) } else { u32(C.EPOLLIN) }
 	// Re-arm if the fd is already in this worker's epoll (a pool-owned connection
 	// re-watched across queries), otherwise add it (a fresh request-owned fd).
@@ -330,7 +368,7 @@ fn async_compact(mut cs ConnState, pos int) {
 // async_on_ready runs a parked request's continuation when its watched fd fires.
 @[direct_array_access; manualfree]
 fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, ext_fd int, entry WatchEntry, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState, state voidptr) {
-	reactor.watches.delete(ext_fd) // consumed; the continuation re-arms if it needs more
+	reactor.reactor_clear(ext_fd) // consumed; the continuation re-arms if it needs more
 	client_fd := entry.client_fd
 	if client_fd >= st.conns.len {
 		return
@@ -357,6 +395,17 @@ fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, e
 				state)
 		}
 		.suspend {
+			// Stream-as-you-go: a continuation that appended bytes before re-arming
+			// (e.g. one SSE event) has them sent NOW, not buffered until .done — that
+			// is what makes incremental streaming work. We only flush when something
+			// is pending (the DB-style "park, write later" case appends nothing here).
+			// flush_batch returns false only if it already closed the conn (peer gone /
+			// write error) — then we must NOT re-park it.
+			if cs.write_buf.len > cs.write_off {
+				if !flush_batch(epoll_fd, client_fd, limits, active_conns, mut st, mut cs) {
+					return // connection already torn down by flush_batch
+				}
+			}
 			cs.awaiting_fd = ac.last_watched // re-armed (multi-step); stay parked
 		}
 		.close {
@@ -372,7 +421,7 @@ fn async_close(mut reactor AsyncReactor, epoll_fd int, fd int, active_conns &cor
 	if fd < st.conns.len {
 		cs := st.conns[fd]
 		if unsafe { cs != nil } && cs.awaiting_fd >= 0 {
-			reactor.watches.delete(cs.awaiting_fd)
+			reactor.reactor_clear(cs.awaiting_fd)
 			epoll.remove_fd_from_epoll(epoll_fd, cs.awaiting_fd) // DEL + close the ext fd
 		}
 	}

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -145,8 +145,8 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 	has_async := async_handler != unsafe { nil }
 	handler := build_handler(request_handler, stateful_handler, state) // sync path
 	mut reactor := AsyncReactor{
-		watches: map[int]WatchEntry{}
-	} // async path: ext_fd -> parked request
+		watches: []WatchEntry{len: conn_table_min}
+	} // async path: flat fd-indexed table of parked requests (grows by doubling)
 	// This worker can stream file bodies with sendfile(2): let handlers hand a
 	// file off via core.queue_file instead of copying it through write_buf.
 	core.enable_sendfile()
@@ -185,9 +185,9 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 			ev := events[i].events
 			// Async only: a watched external fd became ready → run its continuation.
 			if has_async {
-				if entry := reactor.watches[fd] {
-					async_on_ready(async_handler, mut reactor, epoll_fd, fd, entry, limits,
-						counter, active_conns, mut st, state)
+				if fd < reactor.watches.len && reactor.watches[fd].active {
+					async_on_ready(async_handler, mut reactor, epoll_fd, fd, reactor.watches[fd],
+						limits, counter, active_conns, mut st, state)
 					continue
 				}
 			}


### PR DESCRIPTION
## What

Two runtime changes to the opt-in epoll async runtime, plus five examples that exercise it.

### 1. Flat fd-indexed reactor (no hashmap, no per-request alloc)
`AsyncReactor.watches` goes from `map[int]WatchEntry` to a flat `[]WatchEntry` indexed by fd — the **same** doubling-grown, fd-indexed layout the synchronous path already uses for `PlainState.conns`. Consequences:

- The event-loop hot lookup is now `watches[fd].active` (a bounds check + a bool), no hashing.
- `watch` / `resume` / `clear` are plain array writes. A cleared slot is `active = false`, not an erased key — so a stale readiness edge on a just-freed fd finds `active == false` and is ignored.
- No per-request map insertion/deletion allocation.

Sized to `conn_table_min` (1024) and grown by doubling exactly like `state_for`, so high fd numbers stay O(1)-indexed. ~32 KB/worker.

### 2. flush-on-suspend (the streaming primitive)
A continuation that appended bytes **before** returning `.suspend` now has them flushed immediately, instead of being buffered until `.done`. Without this, incremental responses (SSE, chunked, `tail -f`-style) cannot push data as it is produced.

The DB-style "park now, write the response later" path appends nothing before re-suspending, so it is unaffected — `examples/async_pipe` e2e stays green.

## Examples (all built **and** run-validated against live `curl`)

| Example | Demonstrates |
|---|---|
| `async_sse` | Server-Sent Events: one periodic `timerfd`, one `data:` event per tick, flushed live (5 ticks 1s apart, verified) |
| `async_incremental_read` | forward a slow pipe to the client as HTTP chunks **as bytes arrive** (5 lines ~200 ms apart, verified) |
| `async_multi_watch` | a sequential chain that waits on several different fds within one request (~220 ms, verified) |
| `async_time_limit` | cooperative deadline: 504 once a multi-step job crosses its budget (`steps=4`→200@200ms, `steps=10`→504@350ms, verified) |
| `efficient_date` | per-worker cached `Date:` header rebuilt at most once/second (nginx-style), via the `make_state`/`stateful_handler` API |

## Validation
- `v test examples/async_pipe/` — passes (regression: DB-style park/resume unaffected by flush-on-suspend).
- Each example built with the pinned local V and smoke-tested with `curl` (timings above are measured).

## Follow-ups (noted, out of scope here)
- A worker-start hook for **clientless** background watches — would let `efficient_date` refresh proactively from a background timerfd rather than lazily; same hook generalizes to "one in-flight watch per connection" being lifted.
- Write-backpressure *during* a stream (a slow client mid-SSE) currently relies on the small-write fast path; a continuation-on-EPOLLOUT for streams is the clean fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)