### PR TITLE
feat(async): worker-start hook + clientless background watches (the #41 follow-up)

### DIFF
--- a/examples/async_date_timerfd/main.v
+++ b/examples/async_date_timerfd/main.v
@@ -1,0 +1,106 @@
+module main
+
+// Async-runtime example: the architecturally-pure cached `Date:` header — a
+// per-worker timerfd that refreshes the cache from the worker's OWN epoll loop,
+// the nginx model mapped onto this server's per-worker reactor.
+//
+// `on_worker_start` arms a CLIENTLESS background watch (a 1s periodic timerfd) on
+// each worker. Its continuation rebuilds THAT worker's cached Date line and
+// re-arms — no extra thread, no shared state, no lock, no data race (everything
+// touching the cache runs on the one thread that owns it). The request handler
+// then does ZERO time work on the hot path: it just appends the cached bytes.
+//
+// Contrast with examples/efficient_date (lazy per-request refresh: correct and
+// simple, but calls time.utc() on the request that crosses each second). Here the
+// clock advances even with NO traffic — the timerfd wakes the idle loop once a
+// second — so the Date is fresh independent of request rate.
+//
+// Run:   v run examples/async_date_timerfd/
+// Try:   curl -i http://localhost:8097/        # note Date; re-run after a few
+//        sleep 3; curl -i http://localhost:8097/   # Date advanced with no load
+import http_server
+import http_server.core
+import time
+
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+fn C.timerfd_create(clockid int, flags int) int
+fn C.timerfd_settime(fd int, flags int, new_value voidptr, old_value voidptr) int
+fn C.read(fd int, buf voidptr, count usize) int
+
+// DateCache is one worker's pre-formatted `Date: ...\r\n` line. Only ever touched
+// by that worker's thread (make_state + the timerfd continuation), so no lock.
+struct DateCache {
+mut:
+	line []u8
+}
+
+fn make_state() voidptr {
+	return &DateCache{
+		line: []u8{cap: 40}
+	}
+}
+
+// rebuild reformats the cached line for the current second.
+@[direct_array_access]
+fn rebuild(mut dc DateCache) {
+	dc.line.clear()
+	dc.line << 'Date: '.bytes()
+	time.utc().push_to_http_header(mut dc.line) // "Sun, 06 Nov 1994 08:49:37 GMT"
+	dc.line << '\r\n'.bytes()
+}
+
+fn arm_periodic(tfd int, ms int) {
+	mut spec := [4]i64{} // { it_interval{s,ns}, it_value{s,ns} } — both set = periodic
+	spec[0] = i64(ms / 1000)
+	spec[1] = i64(ms % 1000) * 1_000_000
+	spec[2] = spec[0]
+	spec[3] = spec[1]
+	C.timerfd_settime(tfd, 0, voidptr(&spec[0]), unsafe { nil })
+}
+
+// on_start runs once per worker (client_fd = -1): build the cache now so the very
+// first request has a Date, then arm a 1s timerfd as a clientless background watch.
+fn on_start(mut ac core.AsyncCtx) {
+	mut dc := unsafe { &DateCache(ac.state) }
+	rebuild(mut dc)
+	tfd := C.timerfd_create(C.CLOCK_MONOTONIC, 0)
+	arm_periodic(tfd, 1000)
+	ac.watch(tfd, .readable, date_tick, unsafe { nil })
+}
+
+// date_tick fires once a second: drain the timerfd, refresh this worker's cache,
+// and re-arm. Returns .suspend (keep the background watch alive). It never writes
+// to `out` (there is no client) and lives for the worker's whole lifetime.
+fn date_tick(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	mut tmp := [8]u8{}
+	C.read(ac.ready_fd(), &tmp[0], 8) // drain the expiration count to re-level the fd
+	mut dc := unsafe { &DateCache(ac.state) }
+	rebuild(mut dc)
+	ac.watch(ac.ready_fd(), .readable, date_tick, unsafe { nil })
+	return .suspend
+}
+
+const head = 'HTTP/1.1 200 OK\r\n'.bytes()
+
+const tail = 'Content-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
+
+// handle is a plain sync handler: zero time work — just append the cached Date.
+fn handle(req []u8, fd int, mut out []u8, state voidptr) ! {
+	dc := unsafe { &DateCache(state) }
+	out << head
+	out << dc.line
+	out << tail
+}
+
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:             8097
+		io_multiplexing:  .epoll
+		stateful_handler: handle
+		make_state:       make_state
+		on_worker_start:  on_start
+	})!
+	server.run()
+}

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -97,6 +97,12 @@ fn (mut r AsyncReactor) reactor_clear(ext_fd int) {
 // worker's epoll (level-triggered: simplest correct default for arbitrary
 // consumer fds). Runs on the worker thread, so no synchronization is needed.
 fn async_register(mut ac core.AsyncCtx, ext_fd int, interest core.WatchInterest, cont core.WakeFn, udata voidptr) {
+	if ext_fd < 0 {
+		// A consumer handed us a failed fd (e.g. timerfd_create returned -1); never
+		// index the flat table at a negative slot. Arm nothing.
+		ac.last_watched = -1
+		return
+	}
 	mut r := unsafe { &AsyncReactor(ac.reactor) }
 	r.reactor_watch(ext_fd, ac.client_fd, cont, udata)
 	events := if interest == .writable { u32(C.EPOLLOUT) } else { u32(C.EPOLLIN) }
@@ -105,7 +111,14 @@ fn async_register(mut ac core.AsyncCtx, ext_fd int, interest core.WatchInterest,
 	// Trying MOD first avoids an EEXIST perror on every pool-fd reuse and needs no
 	// extra bookkeeping: a fresh fd's MOD fails with ENOENT and falls through to ADD.
 	if epoll.mod_fd_in_epoll(ac.loop_fd, ext_fd, events) != 0 {
-		epoll.add_fd_to_epoll(ac.loop_fd, ext_fd, events)
+		if epoll.add_fd_to_epoll(ac.loop_fd, ext_fd, events) < 0 {
+			// The fd could not be armed (bad fd, epoll limits): don't leave a slot
+			// marked active that the loop would never actually fire — clear it so the
+			// watch is genuinely absent rather than silently dead.
+			r.reactor_clear(ext_fd)
+			ac.last_watched = -1
+			return
+		}
 	}
 	ac.last_watched = ext_fd
 }
@@ -369,6 +382,42 @@ fn async_compact(mut cs ConnState, pos int) {
 @[direct_array_access; manualfree]
 fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, ext_fd int, entry WatchEntry, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState, state voidptr) {
 	reactor.reactor_clear(ext_fd) // consumed; the continuation re-arms if it needs more
+	// Clientless background watch (armed by on_worker_start, e.g. a per-worker
+	// refresh timerfd): there is no parked connection. Run the continuation with a
+	// throwaway buffer and a -1 client_fd; ac.state is the worker state and it
+	// re-arms via ac.watch. The slot was already cleared above, so the ONLY way the
+	// watch stays alive is the continuation re-arming THIS SAME fd and suspending
+	// (the periodic-refresh case). Any other outcome means the continuation stopped
+	// watching ext_fd; we must then ensure ext_fd is neither active nor left in
+	// this worker's epoll, otherwise a later readiness edge on it falls through to
+	// the client read path and is mistaken for a connection (fabricating a phantom
+	// conn and skewing active_conns). The fd OBJECT is the app's: it created it and
+	// closes it — except on a clean .done/.close, where the runtime owns teardown.
+	if entry.client_fd < 0 {
+		mut scratch := []u8{}
+		mut bac := core.AsyncCtx{
+			client_fd: -1
+			ready_fd:  ext_fd
+			udata:     entry.udata
+			state:     state
+			loop_fd:   epoll_fd
+			reactor:   unsafe { voidptr(&reactor) }
+			register:  async_register
+		}
+		step := entry.cont(mut scratch, mut bac)
+		if step == .suspend && bac.last_watched == ext_fd {
+			return
+		}
+		reactor.reactor_clear(ext_fd) // re-arm-then-.done could have re-set active
+		if step == .suspend {
+			// Stepped to a DIFFERENT fd (now armed): detach ext_fd from epoll but do
+			// NOT close it — the app still owns it and may reuse it later.
+			epoll.detach_fd_from_epoll(epoll_fd, ext_fd)
+		} else {
+			epoll.remove_fd_from_epoll(epoll_fd, ext_fd) // done (.done/.close): DEL + close
+		}
+		return
+	}
 	client_fd := entry.client_fd
 	if client_fd >= st.conns.len {
 		return
@@ -403,7 +452,7 @@ fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, e
 			// write error) — then we must NOT re-park it.
 			if cs.write_buf.len > cs.write_off {
 				if !flush_batch(epoll_fd, client_fd, limits, active_conns, mut st, mut cs) {
-					return // connection already torn down by flush_batch
+					return
 				}
 			}
 			cs.awaiting_fd = ac.last_watched // re-armed (multi-step); stay parked

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -134,7 +134,7 @@ fn build_handler(request_handler core.RequestHandler, stateful_handler core.Stat
 // the async branches are skipped entirely (a single per-worker `has_async` bool)
 // so the synchronous hot path is byte-for-byte unchanged.
 @[direct_array_access; manualfree]
-fn process_events_plain(worker_id int, epoll_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, async_handler core.AsyncHandler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
+fn process_events_plain(worker_id int, epoll_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, async_handler core.AsyncHandler, make_state fn () voidptr, on_worker_start core.WorkerStartFn, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
 	maybe_pin_worker(worker_id)
 	// Build THIS worker's per-thread state once (e.g. its own DB connection) — used
 	// by the stateful sync handler closure AND passed to async handlers via AsyncCtx.
@@ -143,6 +143,10 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 		state = make_state()
 	}
 	has_async := async_handler != unsafe { nil }
+	// The watch dispatch runs for async handlers AND for clientless background
+	// watches armed by on_worker_start (e.g. a per-worker refresh timerfd) — a sync
+	// server can own a background watch with no async_handler.
+	has_watches := has_async || on_worker_start != unsafe { nil }
 	handler := build_handler(request_handler, stateful_handler, state) // sync path
 	mut reactor := AsyncReactor{
 		watches: []WatchEntry{len: conn_table_min}
@@ -152,6 +156,19 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 	core.enable_sendfile()
 	mut events := [socket.max_connection_size]C.epoll_event{}
 	mut st := new_plain_state()
+	// Arm clientless background watches (timerfd refresh, signalfd, ...) on THIS
+	// worker's loop, once, before serving. The ctx carries client_fd = -1 so the
+	// watch + its continuation take the clientless path (no conn, scratch buffer).
+	if on_worker_start != unsafe { nil } {
+		mut start_ac := core.AsyncCtx{
+			client_fd: -1
+			state:     state
+			loop_fd:   epoll_fd
+			reactor:   unsafe { voidptr(&reactor) }
+			register:  async_register
+		}
+		on_worker_start(mut start_ac)
+	}
 	// Only arm the timeout sweep if a deadline is actually configured.
 	sweep_on := limits.read_timeout_ms > 0 || limits.write_timeout_ms > 0
 	// Adaptive epoll_wait timeout (busy-poll hybrid). After a wait that returned
@@ -183,8 +200,9 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 		for i in 0 .. num_events {
 			fd := epoll.event_fd(events[i])
 			ev := events[i].events
-			// Async only: a watched external fd became ready → run its continuation.
-			if has_async {
+			// A watched external fd became ready → run its continuation (async request
+			// resume, or a clientless background watch like a refresh timerfd).
+			if has_watches {
 				if fd < reactor.watches.len && reactor.watches[fd].active {
 					async_on_ready(async_handler, mut reactor, epoll_fd, fd, reactor.watches[fd],
 						limits, counter, active_conns, mut st, state)
@@ -264,7 +282,7 @@ fn process_events_tls(worker_id int, epoll_fd int, request_handler core.RequestH
 	}
 }
 
-pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, async_handler core.AsyncHandler, make_state fn () voidptr, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
+pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, async_handler core.AsyncHandler, make_state fn () voidptr, on_worker_start core.WorkerStartFn, port int, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, tls_config &tls.Config, mut threads []thread) {
 	if socket_fd < 0 {
 		return
 	}
@@ -312,7 +330,8 @@ pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, sta
 			// ONE plain worker for both sync and async (async_handler opts in); it skips
 			// all async code via a per-worker bool, so the sync hot path is unchanged.
 			threads[i] = spawn process_events_plain(i, epoll_fds[i], request_handler,
-				stateful_handler, async_handler, make_state, limits, counter, active_conns)
+				stateful_handler, async_handler, make_state, on_worker_start, limits, counter,
+				active_conns)
 		}
 	}
 

--- a/http_server/core/core.v
+++ b/http_server/core/core.v
@@ -87,6 +87,28 @@ pub fn (ac &AsyncCtx) ready_fd() int {
 	return ac.ready_fd
 }
 
+// WorkerStartFn runs ONCE per worker thread, right after make_state and before
+// the event loop, ON the worker thread. It receives an AsyncCtx whose client_fd
+// is -1 (there is no request): use it to arm CLIENTLESS background watches via
+// ac.watch — e.g. a periodic timerfd that refreshes per-worker state, a signalfd,
+// or an inotify fd. Such a watch's continuation later runs on this worker's loop
+// with the same -1 client_fd and is handed a scratch (ignored) `out` buffer.
+// ac.state is this worker's make_state value, or nil when no make_state is set
+// (a stateless watch is fine; a stateful one must configure make_state).
+//
+// CONTRACT for a clientless continuation (a core.WakeFn):
+//   - To keep the watch alive, re-arm THE SAME fd (`ac.watch(ac.ready_fd(), ...)`)
+//     and return .suspend — the periodic-refresh pattern; the fd then lives for
+//     the worker's whole lifetime and is never timed out or torn down as a conn.
+//   - Do NOT close ac.ready_fd() yourself: on .done/.close the runtime detaches
+//     AND closes it (avoiding an fd-reuse race); if you re-arm a DIFFERENT fd the
+//     runtime only detaches the old one (you still own and must close it).
+//
+// It composes with ANY handler path (request_handler / stateful_handler /
+// async_handler): the background watch shares the worker's epoll loop with normal
+// request handling. epoll backend only.
+pub type WorkerStartFn = fn (mut ac AsyncCtx)
+
 // StatefulHandler is the per-thread-state variant of RequestHandler. It receives
 // the same arguments PLUS an opaque `state voidptr` — the value the server's
 // `make_state` callback returned for THIS worker thread (and only this one). It

--- a/http_server/epoll/epoll_linux.c.v
+++ b/http_server/epoll/epoll_linux.c.v
@@ -70,8 +70,15 @@ pub fn mod_fd_in_epoll(epoll_fd int, fd int, events u32) int {
 	return C.epoll_ctl(epoll_fd, C.EPOLL_CTL_MOD, fd, &ev)
 }
 
-// Remove a file descriptor from an epoll instance.
+// Remove a file descriptor from an epoll instance AND close it.
 pub fn remove_fd_from_epoll(epoll_fd int, fd int) {
 	C.epoll_ctl(epoll_fd, C.EPOLL_CTL_DEL, fd, C.NULL)
 	C.close(fd)
+}
+
+// Detach a file descriptor from an epoll instance WITHOUT closing it — for fds
+// the caller still owns (e.g. an application-owned background fd the watch is
+// stepping away from). A DEL on an fd not in the set just returns ENOENT.
+pub fn detach_fd_from_epoll(epoll_fd int, fd int) {
+	C.epoll_ctl(epoll_fd, C.EPOLL_CTL_DEL, fd, C.NULL)
 }

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -28,6 +28,7 @@ pub mut:
 	stateful_handler core.StatefulHandler = unsafe { nil }
 	async_handler    core.AsyncHandler    = unsafe { nil }
 	make_state       fn () voidptr        = unsafe { nil }
+	on_worker_start  core.WorkerStartFn   = unsafe { nil }
 	// Per-worker in-flight request counters (one per worker, each on its own
 	// cache line — written only by its worker, so no contention/false sharing).
 	// shutdown() sums them to drain precisely.
@@ -242,9 +243,14 @@ pub:
 	// timers, EPOLLOUT backpressure). Optional make_state gives each worker its own
 	// state. Linux/epoll only; ignored by other backends. See core.AsyncHandler.
 	async_handler core.AsyncHandler = unsafe { nil }
-	certificates  Certificates
-	limits        Limits
-	tls_config    &tls.Config = unsafe { nil } // set for HTTPS (e.g. tls.new_self_signed())
+	// on_worker_start runs once per worker (after make_state, before the loop) to
+	// arm CLIENTLESS background watches — e.g. a periodic timerfd that refreshes
+	// per-worker state with no shared state and no extra thread. Composes with any
+	// handler path. Linux/epoll only. See core.WorkerStartFn.
+	on_worker_start core.WorkerStartFn = unsafe { nil }
+	certificates    Certificates
+	limits          Limits
+	tls_config      &tls.Config = unsafe { nil } // set for HTTPS (e.g. tls.new_self_signed())
 }
 
 pub fn new_server(config ServerConfig) !Server {
@@ -268,6 +274,20 @@ pub fn new_server(config ServerConfig) !Server {
 	}
 	if has_stateful && config.make_state == unsafe { nil } {
 		return error('stateful_handler requires make_state')
+	}
+	// on_worker_start arms clientless background watches on the epoll worker's
+	// reactor; the TLS worker has none, so it is epoll + plaintext only for now.
+	if config.on_worker_start != unsafe { nil } {
+		$if linux {
+			if config.io_multiplexing != .epoll {
+				return error('on_worker_start requires the epoll backend')
+			}
+		} $else {
+			return error('on_worker_start is only supported on the Linux epoll backend')
+		}
+		if config.tls_config != unsafe { nil } {
+			return error('on_worker_start is not yet supported with TLS')
+		}
 	}
 	// Each backend's IOBackend enum has different values (.epoll on Linux,
 	// .kqueue on macOS, .iocp on Windows), so a value is only ever referenced
@@ -338,6 +358,7 @@ pub fn new_server(config ServerConfig) !Server {
 		stateful_handler: config.stateful_handler
 		async_handler:    config.async_handler
 		make_state:       config.make_state
+		on_worker_start:  config.on_worker_start
 		limits:           config.limits
 		tls_config:       config.tls_config
 		threads:          []thread{len: max_thread_pool_size, cap: max_thread_pool_size}

--- a/http_server/http_server_io_uring_linux.c.v
+++ b/http_server/http_server_io_uring_linux.c.v
@@ -509,6 +509,13 @@ fn iou_release_supports_multishot(release string) bool {
 // inflight counters to drain. The accept handler stops re-arming once draining,
 // so every worker quits accepting and the process can exit cleanly.
 pub fn run_io_uring_backend(server Server, mut threads []thread) {
+	// on_worker_start (clientless background watches) is an epoll-reactor feature;
+	// new_server rejects it for io_uring at config time. Assert defensively so a
+	// future refactor (or a Server built directly, bypassing new_server) fails loud
+	// instead of silently dropping the hook.
+	if server.on_worker_start != unsafe { nil } {
+		panic('on_worker_start is not supported on the io_uring backend')
+	}
 	num_workers := max_thread_pool_size
 
 	for i in 0 .. num_workers {

--- a/http_server/http_server_linux.c.v
+++ b/http_server/http_server_linux.c.v
@@ -15,8 +15,9 @@ fn run_selected_backend(server Server, mut threads []thread) {
 	match server.io_multiplexing {
 		.epoll {
 			backend_epoll.run_epoll_backend(server.socket_fd, server.request_handler,
-				server.stateful_handler, server.async_handler, server.make_state, server.port,
-				server.limits, server.inflight, server.active_conns, server.tls_config, mut threads)
+				server.stateful_handler, server.async_handler, server.make_state,
+				server.on_worker_start, server.port, server.limits, server.inflight,
+				server.active_conns, server.tls_config, mut threads)
 		}
 		.io_uring {
 			run_io_uring_backend(server, mut threads)


### PR DESCRIPTION
## What

The PR #41 follow-up: a **worker-start hook** + **clientless background watches**, so a per-worker `timerfd` (or signalfd/inotify) can refresh per-worker state from the worker's own epoll loop — no extra thread, no shared state, no lock, no data race.

### New API: `ServerConfig.on_worker_start core.WorkerStartFn`
Runs ONCE per worker, after `make_state` and before the loop, on the worker thread, with an `AsyncCtx` whose `client_fd = -1`. It arms clientless background watches via `ac.watch(...)`. Composes with **any** handler path — a plain sync server can own a background watch (new `has_watches` gate = `has_async || on_worker_start != nil`). Epoll + plaintext only (rejected for TLS / non-epoll; defensive panic in the io_uring backend so a bypass fails loud).

### Clientless dispatch in `async_on_ready`
When `entry.client_fd < 0`, the continuation runs with a scratch buffer and no connection. Teardown is keyed on whether it **re-armed the same fd**:

| outcome | action |
|---|---|
| re-arm same fd + `.suspend` | stays watched (periodic-refresh case) |
| re-arm a **different** fd | detach (DEL only) the old fd — app still owns it |
| `.done` / `.close` | DEL + close (runtime owns teardown) |

It always `reactor_clear()`s first, so a slot can never be left `active` and mistaken for a client connection (which would fabricate a phantom conn and skew `active_conns`). `async_register` now rejects a negative fd and rolls the slot back if the epoll arm fails.

## New example: `async_date_timerfd`
The architecturally-pure cached `Date:` header — a per-worker 1s `timerfd` refreshing the cache from the worker's own loop (the nginx model). The request handler does **zero** time work on the hot path.

**Proof it's loop-driven, not request-driven:** request at T0 → idle 3s with no traffic → request at T1 shows the Date advanced ~3s. The cache is fresh independent of request rate.

This complements `examples/efficient_date` (lazy per-request refresh): same once/second formatting, but here the clock advances with zero traffic and the hot path touches no time API.

## Why this design (vs a `spawn` thread)
A background thread updating a shared Date string is a data race that fights the server's thread-per-core / `make_state` zero-shared-state model, and its MESI "win" is zero (the per-worker model has no coherence traffic). This is the nginx model mapped onto the per-worker reactor instead: each worker refreshes its own cache from its own loop. (Full measurement + analysis that motivated this is in the discussion on the previous PR.)

## Review
This change was put through an adversarial review (4 lenses → per-finding verification). The confirmed findings on the clientless path — fd misroute when stepping to a different fd, stale-active slot after re-arm-then-`.done`, fd-reuse double-close, silent dead watch on arm failure — are all addressed by the teardown/`async_register` hardening above and the documented contract on `WorkerStartFn` (re-arm the same fd to stay alive; don't close `ac.ready_fd()` yourself).

**Known follow-ups (out of scope):** surface the readiness mask on `AsyncCtx` so a clientless continuation can detect `EPOLLERR`/`EPOLLHUP` on an fd that can hang up (benign for `timerfd`); kqueue support for clientless watches (currently epoll-only).

## Validation
- `v test examples/async_pipe/` — passes (async client path unaffected).
- `async_date_timerfd` — idle-refresh proof above; `async_sse` re-verified (re-arm path).
- Builds clean; validation rejects TLS + non-epoll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)