### PR TITLE
feat(async): surface ready_err on AsyncCtx (error/hangup detection)

### DIFF
--- a/examples/async_watch_hangup/main.v
+++ b/examples/async_watch_hangup/main.v
@@ -1,0 +1,66 @@
+module main
+
+// Async-runtime example: detecting a watched-fd hangup via ac.ready_err().
+//
+// A clientless background watch (armed by on_worker_start) sits on the read end
+// of a pipe whose writer has gone away. epoll delivers that edge as EPOLLHUP; the
+// runtime surfaces it to the continuation as the portable ac.ready_err() == true,
+// so the continuation RELEASES the fd (returns .close) instead of re-arming it.
+// Re-arming a level-triggered watch on a dead fd would busy-spin forever — this
+// is the signal a signalfd / inotify / pipe / upstream-socket background watch
+// needs to give up. (A timerfd never hangs up, so async_date_timerfd ignores it.)
+//
+// on_worker_start simulates "the producer went away" by closing the write end
+// immediately, so the watch fires once with a hangup. The server then sits idle
+// (no CPU spin) and serves normally:
+//   v run examples/async_watch_hangup/
+//   curl http://localhost:8098/        # -> ok
+import http_server
+import http_server.core
+
+#include <unistd.h>
+
+fn C.pipe(fds &int) int
+fn C.close(fd int) int
+
+const resp = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
+
+// on_start arms a clientless watch on a pipe read-end, then closes the write-end
+// so the read-end immediately reports a hangup (the "producer" is gone). Composes
+// with a plain stateless request_handler — no async_handler, no make_state.
+fn on_start(mut ac core.AsyncCtx) {
+	mut fds := [2]int{}
+	if C.pipe(&fds[0]) != 0 {
+		return
+	}
+	read_fd, write_fd := fds[0], fds[1]
+	C.close(write_fd) // producer gone -> read_fd reports EPOLLHUP on the next poll
+	ac.watch(read_fd, .readable, on_source_event, unsafe { nil })
+}
+
+// on_source_event runs when the watched fd fires. On error/hangup it gives up
+// cleanly (return .close — the runtime DEL+closes read_fd); a naive re-arm here
+// would spin every loop iteration on the dead, level-triggered fd.
+fn on_source_event(mut out []u8, mut ac core.AsyncCtx) core.AsyncStep {
+	if ac.ready_err() {
+		eprintln('[worker] background source fd ${ac.ready_fd()} hung up — releasing (no spin)')
+		return .close // runtime tears the fd down; we do NOT re-arm
+	}
+	// A real consumer would read the ready data here, then re-arm:
+	ac.watch(ac.ready_fd(), .readable, on_source_event, unsafe { nil })
+	return .suspend
+}
+
+fn handle(req []u8, fd int, mut out []u8) ! {
+	out << resp
+}
+
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:            8098
+		io_multiplexing: .epoll
+		request_handler: handle
+		on_worker_start: on_start
+	})!
+	server.run()
+}

--- a/http_server/async_darwin.c.v
+++ b/http_server/async_darwin.c.v
@@ -83,7 +83,8 @@ fn process_kqueue_async(kq int, async_handler core.AsyncHandler, make_state fn (
 			// A watched ext fd became ready → run its continuation.
 			if w := reactor.watches[fd] {
 				reactor.watches.delete(fd)
-				kq_run_cont(mut reactor, kq, w, fd, state)
+				rerr := (events[i].flags & (kqueue.ev_eof | kqueue.ev_error)) != 0
+				kq_run_cont(mut reactor, kq, w, fd, rerr, state)
 				continue
 			}
 			// Client connection.
@@ -158,12 +159,13 @@ fn kq_handle_request(h core.AsyncHandler, mut reactor KqReactor, kq int, fd int,
 }
 
 // kq_run_cont resumes a parked request when its watched fd fires.
-fn kq_run_cont(mut reactor KqReactor, kq int, w KqWatch, ext_fd int, state voidptr) {
+fn kq_run_cont(mut reactor KqReactor, kq int, w KqWatch, ext_fd int, ready_err bool, state voidptr) {
 	mut conn := reactor.conns[w.client_fd] or { return } // client went away
 	conn.awaiting_fd = -1
 	mut ac := core.AsyncCtx{
 		client_fd: w.client_fd
 		ready_fd:  ext_fd
+		ready_err: ready_err
 		udata:     w.udata
 		state:     state
 		loop_fd:   kq

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -379,9 +379,13 @@ fn async_compact(mut cs ConnState, pos int) {
 }
 
 // async_on_ready runs a parked request's continuation when its watched fd fires.
+// `ev` is the raw epoll event mask for this edge; an error/hangup (EPOLLERR|
+// EPOLLHUP) is surfaced to the continuation as the portable AsyncCtx.ready_err so
+// it can release a dead fd instead of re-arming it into a busy-spin.
 @[direct_array_access; manualfree]
-fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, ext_fd int, entry WatchEntry, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState, state voidptr) {
+fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, ext_fd int, entry WatchEntry, ev u32, limits core.Limits, counter &core.Counter, active_conns &core.Counter, mut st PlainState, state voidptr) {
 	reactor.reactor_clear(ext_fd) // consumed; the continuation re-arms if it needs more
+	ready_err := ev & (u32(C.EPOLLHUP) | u32(C.EPOLLERR)) != 0
 	// Clientless background watch (armed by on_worker_start, e.g. a per-worker
 	// refresh timerfd): there is no parked connection. Run the continuation with a
 	// throwaway buffer and a -1 client_fd; ac.state is the worker state and it
@@ -398,6 +402,7 @@ fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, e
 		mut bac := core.AsyncCtx{
 			client_fd: -1
 			ready_fd:  ext_fd
+			ready_err: ready_err
 			udata:     entry.udata
 			state:     state
 			loop_fd:   epoll_fd
@@ -430,6 +435,7 @@ fn async_on_ready(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, e
 	mut ac := core.AsyncCtx{
 		client_fd: client_fd
 		ready_fd:  ext_fd
+		ready_err: ready_err
 		udata:     entry.udata
 		state:     state
 		loop_fd:   epoll_fd

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -205,7 +205,7 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 			if has_watches {
 				if fd < reactor.watches.len && reactor.watches[fd].active {
 					async_on_ready(async_handler, mut reactor, epoll_fd, fd, reactor.watches[fd],
-						limits, counter, active_conns, mut st, state)
+						ev, limits, counter, active_conns, mut st, state)
 					continue
 				}
 			}

--- a/http_server/core/core.v
+++ b/http_server/core/core.v
@@ -67,6 +67,7 @@ pub struct AsyncCtx {
 pub mut:
 	client_fd    int
 	ready_fd     int = -1 // the fd that woke this continuation (-1 on the initial call)
+	ready_err    bool    // backend-filled: ready_fd woke with an error/hangup (epoll EPOLLERR|EPOLLHUP, kqueue EV_ERROR|EV_EOF), not normal readiness — the watched fd is dead, release it
 	udata        voidptr // consumer context carried from watch() to the continuation
 	state        voidptr // this worker's per-thread state (see StatefulHandler/make_state)
 	loop_fd      int     // backend-filled: the worker's event-loop fd (epoll on Linux, kqueue on macOS)
@@ -87,6 +88,17 @@ pub fn (ac &AsyncCtx) ready_fd() int {
 	return ac.ready_fd
 }
 
+// ready_err reports whether ready_fd became ready because of an error or hangup
+// (the peer/other end closed, the fd is broken) rather than normal readiness —
+// epoll EPOLLERR|EPOLLHUP, kqueue EV_ERROR|EV_EOF. A continuation that observes
+// this should stop watching the fd (return .done/.close so the runtime releases
+// it) instead of re-arming, otherwise a level-triggered watch on a dead fd
+// re-fires every loop iteration (a busy-spin). It is a portable boolean on
+// purpose: handlers never name a platform event constant (cf. WatchInterest).
+pub fn (ac &AsyncCtx) ready_err() bool {
+	return ac.ready_err
+}
+
 // WorkerStartFn runs ONCE per worker thread, right after make_state and before
 // the event loop, ON the worker thread. It receives an AsyncCtx whose client_fd
 // is -1 (there is no request): use it to arm CLIENTLESS background watches via
@@ -103,6 +115,9 @@ pub fn (ac &AsyncCtx) ready_fd() int {
 //   - Do NOT close ac.ready_fd() yourself: on .done/.close the runtime detaches
 //     AND closes it (avoiding an fd-reuse race); if you re-arm a DIFFERENT fd the
 //     runtime only detaches the old one (you still own and must close it).
+//   - Check ac.ready_err(): if the fd woke with an error/hangup, return .done or
+//     .close (do NOT re-arm) — a re-armed watch on a dead level-triggered fd
+//     busy-spins. (A timerfd never hangs up, so a refresh watch can ignore it.)
 //
 // It composes with ANY handler path (request_handler / stateful_handler /
 // async_handler): the background watch shares the worker's epoll loop with normal


### PR DESCRIPTION
## What

Follow-up to #42. A continuation woken on a watched fd had no way to tell a normal readiness edge from an **error/hangup**. Because the worker routes a watched fd into the continuation *before* the `EPOLLHUP`/`EPOLLERR` branch, a clientless watch on an fd that can hang up (signalfd, inotify, pipe, upstream socket) would re-arm a dead, **level-triggered** fd and **busy-spin**. (A `timerfd` never hangs up, so `async_date_timerfd` was unaffected.)

## Change

Add the portable **`AsyncCtx.ready_err`** (+ `ac.ready_err()`): the backend maps epoll `EPOLLERR|EPOLLHUP` (kqueue `EV_ERROR|EV_EOF`) to **one boolean** — "this fd is dead, release it" — so handlers never name a platform event constant (same design as `WatchInterest`). The worker threads the event mask into `async_on_ready`, which sets `ready_err` on both the **clientless** and the **client (request-owned)** continuation contexts.

Contract (documented on `WorkerStartFn`/`ready_err()`): a continuation that sees `ready_err` should return `.done`/`.close` (the runtime tears the fd down) instead of re-arming.

> Design note: I exposed a portable `bool`, not the raw `u32` mask — leaking epoll constants into the platform-agnostic `core` API would break the abstraction `WatchInterest` already establishes. The bool collapses `ERR|HUP` into the one decision a continuation makes ("give up?"). `EPOLLHUP` can coexist with readable data on a half-closed socket, so the runtime surfaces the signal and lets the continuation decide (drain remaining data, or release) rather than force-closing.

## New example: `async_watch_hangup`
A clientless watch on a pipe read-end whose writer is gone; the continuation detects `ac.ready_err()` and releases the fd. **Validated:**
- exactly **one hangup line per worker** (16/16 here), and the count **stays put** after idling — no re-fire,
- idle server sits at **~0.5% CPU** — proving no busy-spin,
- still serves `200 ok` — also exercises the `has_watches` gate with a plain stateless `request_handler` (no `async_handler`, no `make_state`).

`async_pipe` e2e and `async_date_timerfd` idle-refresh remain green.

## Note on the kqueue (macOS) path
The kqueue plumbing mirrors the epoll change (it already computed `EV_EOF|EV_ERROR` for client conns; now it threads it into the watched-fd continuation too). I could **not** locally build-verify it — the dev/CI sandbox is Linux-only — so a macOS check is worth a look on review. The clientless-watch path itself remains epoll-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)