### PR TITLE
perf(pg_async): read DataRow column lengths at offset (drop per-read slices)

### DIFF
--- a/pg_async/protocol.v
+++ b/pg_async/protocol.v
@@ -204,7 +204,7 @@ pub fn (r Row) col(i int) !DataValue {
 	if r.payload.len < 2 {
 		return error('datarow: short payload')
 	}
-	ncols := int(i16(binary.big_endian_u16(r.payload[0..2])))
+	ncols := int(i16(binary.big_endian_u16_at(r.payload, 0)))
 	if i < 0 || i >= ncols {
 		return error('datarow: col ${i} out of range (${ncols} cols)')
 	}
@@ -213,7 +213,10 @@ pub fn (r Row) col(i int) !DataValue {
 		if pos + 4 > r.payload.len {
 			return error('datarow: truncated length')
 		}
-		clen := int(i32(binary.big_endian_u32(r.payload[pos..pos + 4])))
+		// read the 4-byte length at offset WITHOUT slicing the payload — the slice
+		// (array descriptor alloc) per length-read dominated the row-decode CPU
+		// (~31% of the async-db per-request profile, O(ncols) per col access).
+		clen := int(i32(binary.big_endian_u32_at(r.payload, pos)))
 		pos += 4
 		if clen < 0 {
 			if idx == i {


### PR DESCRIPTION
## What
`Row.col` read each column's 4-byte length with `binary.big_endian_u32(payload[pos..pos+4])` — a fresh array slice (descriptor) per length read, on every column walk. Since the row is re-scanned from the front on each `col(i)` access, that's O(ncols) slices per access.

Read the length directly at the offset with `binary.big_endian_u32_at(payload, pos)` (no slice), and the column count with `big_endian_u16_at`.

## Why
In the async-db per-request callgrind profile (a handler reading all 9 columns of each of ~50 rows), `array_slice` was **~31%** of the work — dominated by these per-length-read slices.

After: `array_slice` drops **30.94% → 9.91%** (the residual is the *value* slices returned in `DataValue.bytes`, which the caller needs). The per-access scan stays O(ncols) but is now cheap integer reads, which is fine for the few-column rows these queries return.

## Scope / validation
A CPU-efficiency win for the row-decode path (frees worker cores; helps fast/indexed-query DB workloads). Behaviour is unchanged.

Gated: the full `pg_async` suite passes against PG18, including the FIFO-order + mid-pipeline error-isolation integration tests and `protocol_test.v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)