### PR TITLE
perf(pg_async,request_parser): zero-alloc DB request path under -gc none

### DIFF
--- a/http_server/http1_1/request_parser/request_parser.v
+++ b/http_server/http1_1/request_parser/request_parser.v
@@ -382,8 +382,12 @@ pub fn (req HttpRequest) get_query_slice(key []u8) ?Slice {
 	path_start := req.path.start
 	path_len := req.path.len
 
-	// Find '?' in path using memchr
-	q_pos := find_byte(&req.buffer[path_start], path_len, question_mark_u8) or {
+	// Find '?' in path using memchr. find_byte_idx (no `!int` Result) instead of
+	// find_byte: every not-found return from find_byte calls error(), which allocates a
+	// MessageError — a per-request leak under `-gc none` (query parsing runs on every
+	// request, several lookups each).
+	q_pos := find_byte_idx(&req.buffer[path_start], path_len, question_mark_u8)
+	if q_pos < 0 {
 		return none // No query string
 	}
 
@@ -394,7 +398,8 @@ pub fn (req HttpRequest) get_query_slice(key []u8) ?Slice {
 	// Parse query string: key1=val1&key2=val2
 	for pos < path_end {
 		// Find '=' for this key
-		eq_pos := find_byte(&req.buffer[pos], path_end - pos, equal_u8) or {
+		eq_pos := find_byte_idx(&req.buffer[pos], path_end - pos, equal_u8)
+		if eq_pos < 0 {
 			break // No '=' found, malformed query
 		}
 
@@ -406,9 +411,10 @@ pub fn (req HttpRequest) get_query_slice(key []u8) ?Slice {
 			value_start := pos + eq_pos + 1
 
 			// Find '&' or end of path using memchr
-			value_len := find_byte(&req.buffer[value_start], path_end - value_start, amperstand_u8) or {
-				// Last parameter, no '&' found
-				path_end - value_start
+			mut value_len := find_byte_idx(&req.buffer[value_start], path_end - value_start,
+				amperstand_u8)
+			if value_len < 0 {
+				value_len = path_end - value_start // last parameter, no '&'
 			}
 
 			return Slice{
@@ -418,7 +424,8 @@ pub fn (req HttpRequest) get_query_slice(key []u8) ?Slice {
 		}
 
 		// Skip to next parameter (find '&')
-		amp_pos := find_byte(&req.buffer[pos], path_end - pos, amperstand_u8) or {
+		amp_pos := find_byte_idx(&req.buffer[pos], path_end - pos, amperstand_u8)
+		if amp_pos < 0 {
 			break // Last parameter, no match
 		}
 		pos += amp_pos + 1

--- a/pg_async/conn.v
+++ b/pg_async/conn.v
@@ -96,6 +96,11 @@ mut:
 	// buffer back to its slot on completion so growth is preserved across reuse.
 	frame_pool [][]u8
 	frame_ring int
+	// Per-connection reusable wire-frame scratch for async_submit: one query's
+	// Parse+Bind+Describe+Execute+Sync is serialized here, then copied into send_buf.
+	// Allocated once (lazy), reset to len 0 each submit, grows to a high-water mark —
+	// so a submit never allocates a throwaway frame (which would leak under -gc none).
+	submit_scratch []u8
 }
 
 struct Msg {

--- a/pg_async/conn.v
+++ b/pg_async/conn.v
@@ -89,6 +89,13 @@ mut:
 	send_off int  // [0, send_off) already sent
 	send_len int  // [send_off, send_len) written, still to send
 	inflight []PendingQuery
+	// Per-connection reply-accumulator pool: max_inflight buffers (frame_buf_cap each)
+	// allocated ONCE and reused round-robin via frame_ring, so a pipelined query never
+	// allocates its accumulator per submit — essential under `-gc none`, where a
+	// per-query allocation would leak. async_on_readable writes the (possibly grown)
+	// buffer back to its slot on completion so growth is preserved across reuse.
+	frame_pool [][]u8
+	frame_ring int
 }
 
 struct Msg {

--- a/pg_async/conn_async.v
+++ b/pg_async/conn_async.v
@@ -29,16 +29,27 @@ const max_inflight = 8
 // protocol queries vanilla issues; append_send sheds if a frame won't fit.
 const send_buf_cap = 64 * 1024
 
+// frame_buf_cap is the per-accumulator reply-buffer size in the per-connection
+// frames pool (see PgConn.frame_pool). Sized to hold a typical query's full reply
+// (RowDescription + a LIMIT-bounded set of DataRows + CommandComplete) without a
+// realloc; a larger reply still grows via `<<` and the grown buffer is written
+// back to its pool slot, so growth is kept and never re-allocated per query.
+const frame_buf_cap = 16 * 1024
+
 // PendingQuery is one pipelined query's reply accumulator: its framed backend
 // messages (ParseComplete..ReadyForQuery), the rows-affected count, and any
 // server error. It lives on the connection's in-flight FIFO until ReadyForQuery
 // completes it, at which point async_on_readable pops it and yields its Result.
+// `frames` is BORROWED from the connection's frame_pool (reused round-robin), not
+// allocated per query; `frame_slot` is the pool index it borrows so the buffer
+// can be returned (and any growth captured) on completion.
 struct PendingQuery {
 mut:
 	frames        []u8
 	error         string
 	sqlstate      string
 	rows_affected u64
+	frame_slot    int
 }
 
 // set_nonblocking flips the connection socket to non-blocking. Call once, after
@@ -94,8 +105,27 @@ pub fn (mut c PgConn) async_submit(query_text string, params []?[]u8) bool {
 	if !c.append_send(frame) {
 		return false
 	}
+	// Borrow a reply accumulator from the per-connection pool instead of allocating
+	// one per query (which would leak under `-gc none`). The pool holds max_inflight
+	// buffers reused round-robin; a slot is only reused after a full ring cycle, by
+	// which time the query that last used it has been drained AND rendered (at most
+	// max_inflight queries are in flight, enforced by the guard above), so the borrow
+	// can never alias a still-in-use reply.
+	if c.frame_pool.len < max_inflight {
+		c.frame_pool = [][]u8{cap: max_inflight}
+		for _ in 0 .. max_inflight {
+			c.frame_pool << []u8{cap: frame_buf_cap}
+		}
+	}
+	slot := c.frame_ring
+	c.frame_ring = (c.frame_ring + 1) % max_inflight
+	mut fbuf := c.frame_pool[slot]
+	unsafe {
+		fbuf.len = 0
+	}
 	c.inflight << PendingQuery{
-		frames: []u8{cap: 8 * 1024}
+		frames:     fbuf
+		frame_slot: slot
 	}
 	return true
 }
@@ -186,7 +216,9 @@ pub fn (mut c PgConn) async_on_readable() !QueryPoll {
 	// recv_buf doesn't ratchet upward (the common between-edges state).
 	if c.recv_pos > 0 && c.recv_pos >= c.recv_buf.len {
 		c.recv_pos = 0
-		unsafe { c.recv_buf.len = 0 }
+		unsafe {
+			c.recv_buf.len = 0
+		}
 	}
 	// Drain the socket to EAGAIN, recv-ing STRAIGHT into recv_buf's spare tail — no
 	// per-iteration 16 KiB scratch alloc + copy. recv_buf is persistent + reused; only
@@ -196,22 +228,34 @@ pub fn (mut c PgConn) async_on_readable() !QueryPoll {
 			if c.recv_pos > 0 {
 				rem := c.recv_buf.len - c.recv_pos
 				if rem > 0 {
-					unsafe { C.memmove(c.recv_buf.data, &u8(c.recv_buf.data) + c.recv_pos, usize(rem)) }
+					unsafe {
+						C.memmove(c.recv_buf.data, &u8(c.recv_buf.data) + c.recv_pos, usize(rem))
+					}
 				}
-				unsafe { c.recv_buf.len = rem }
+				unsafe {
+					c.recv_buf.len = rem
+				}
 				c.recv_pos = 0
 			}
 			if c.recv_buf.len == c.recv_buf.cap {
 				// Grow by the current cap (doubling), or a 16 KiB floor when cap is 0
 				// (recv_buf comes back cap-0 after the blocking handshake — grow_cap(0)
 				// would be a no-op, leaving spare=0 and recv reading nothing forever).
-				unsafe { c.recv_buf.grow_cap(if c.recv_buf.cap > 0 { c.recv_buf.cap } else { 16 * 1024 }) }
+				unsafe {
+					c.recv_buf.grow_cap(if c.recv_buf.cap > 0 {
+						c.recv_buf.cap
+					} else {
+						16 * 1024
+					})
+				}
 			}
 		}
 		spare := c.recv_buf.cap - c.recv_buf.len
 		n := C.recv(c.fd, unsafe { &u8(c.recv_buf.data) + c.recv_buf.len }, usize(spare), 0)
 		if n > 0 {
-			unsafe { c.recv_buf.len += n }
+			unsafe {
+				c.recv_buf.len += n
+			}
 			continue
 		}
 		if n == 0 {
@@ -246,6 +290,13 @@ pub fn (mut c PgConn) async_on_readable() !QueryPoll {
 			// solely by `done`, so it is handed off without cloning.
 			done := c.inflight[0]
 			c.inflight.delete(0)
+			// Return the (possibly grown) accumulator to its pool slot so any growth
+			// is kept and the slot is reused next ring cycle — no per-query alloc. The
+			// Result borrows the same backing; it is consumed by the resume callback
+			// before the slot can be reused (a full ring cycle away).
+			if done.frame_slot >= 0 && done.frame_slot < c.frame_pool.len {
+				c.frame_pool[done.frame_slot] = done.frames
+			}
 			if done.error != '' {
 				return error('pg: query failed: ${done.error} (SQLSTATE ${done.sqlstate})')
 			}

--- a/pg_async/conn_async.v
+++ b/pg_async/conn_async.v
@@ -93,16 +93,23 @@ pub fn (mut c PgConn) async_submit(query_text string, params []?[]u8) bool {
 	if c.inflight.len >= max_inflight {
 		return false
 	}
-	// Serialize into a small scratch frame, then copy it into the fixed buffer.
-	// (The write_* helpers append via `<<`, which would reallocate the fixed
-	// buffer; the scratch keeps the buffer's backing store pinned.)
-	mut frame := []u8{cap: 256}
-	write_parse(mut frame, '', query_text)
-	write_bind(mut frame, '', '', params)
-	write_describe_portal(mut frame, '')
-	write_execute(mut frame, '', 0)
-	write_sync(mut frame)
-	if !c.append_send(frame) {
+	// Serialize into the per-connection reusable scratch, then copy it into the fixed
+	// send buffer. The scratch (1) keeps send_buf's backing pinned (write_* append via
+	// `<<`, which would reallocate send_buf) and (2) is reused across submits — a fresh
+	// `[]u8{cap: 256}` per submit would leak under -gc none. Reset to len 0 each submit;
+	// grows to a high-water mark if a query frame ever exceeds 512 bytes.
+	if c.submit_scratch.cap == 0 {
+		c.submit_scratch = []u8{cap: 512}
+	}
+	unsafe {
+		c.submit_scratch.len = 0
+	}
+	write_parse(mut c.submit_scratch, '', query_text)
+	write_bind(mut c.submit_scratch, '', '', params)
+	write_describe_portal(mut c.submit_scratch, '')
+	write_execute(mut c.submit_scratch, '', 0)
+	write_sync(mut c.submit_scratch)
+	if !c.append_send(c.submit_scratch) {
 		return false
 	}
 	// Borrow a reply accumulator from the per-connection pool instead of allocating

--- a/pg_async/protocol.v
+++ b/pg_async/protocol.v
@@ -386,8 +386,14 @@ fn put_u32(mut buf []u8, v u32) {
 	buf << u8(v)
 }
 
-fn put_cstr(mut buf []u8, s []u8) {
-	buf << s
+// put_cstr_s appends a NUL-terminated C string by copying the string's bytes
+// DIRECTLY (push_many from s.str/s.len), never `s.bytes()` — `.bytes()` allocates a
+// throwaway []u8 copy on every call, which leaks under `-gc none` (the SQL text + the
+// empty portal/stmt names are serialized on every async_submit). Wire output is
+// byte-identical: the same bytes followed by a NUL.
+@[direct_array_access]
+fn put_cstr_s(mut buf []u8, s string) {
+	unsafe { buf.push_many(s.str, s.len) }
 	buf << u8(0)
 }
 
@@ -398,11 +404,11 @@ pub fn write_startup(mut buf []u8, user string, database string) {
 	lenpos := buf.len
 	buf << [u8(0), 0, 0, 0]
 	put_u32(mut buf, 0x0003_0000)
-	put_cstr(mut buf, 'user'.bytes())
-	put_cstr(mut buf, user.bytes())
+	put_cstr_s(mut buf, 'user')
+	put_cstr_s(mut buf, user)
 	if database.len > 0 {
-		put_cstr(mut buf, 'database'.bytes())
-		put_cstr(mut buf, database.bytes())
+		put_cstr_s(mut buf, 'database')
+		put_cstr_s(mut buf, database)
 	}
 	buf << u8(0) // end of parameters
 	msg_len := u32(buf.len - lenpos)
@@ -416,8 +422,8 @@ pub fn write_startup(mut buf []u8, user string, database string) {
 // oids (let the server infer all parameter types).
 pub fn write_parse(mut buf []u8, stmt_name string, query_text string) {
 	lp := begin_msg(mut buf, `P`)
-	put_cstr(mut buf, stmt_name.bytes())
-	put_cstr(mut buf, query_text.bytes())
+	put_cstr_s(mut buf, stmt_name)
+	put_cstr_s(mut buf, query_text)
 	put_u16(mut buf, 0)
 	finish_msg(mut buf, lp)
 }
@@ -426,8 +432,8 @@ pub fn write_parse(mut buf []u8, stmt_name string, query_text string) {
 // binary-format results out (one result-format-code 1 applied to all columns).
 pub fn write_bind(mut buf []u8, portal string, stmt_name string, params []?[]u8) {
 	lp := begin_msg(mut buf, `B`)
-	put_cstr(mut buf, portal.bytes())
-	put_cstr(mut buf, stmt_name.bytes())
+	put_cstr_s(mut buf, portal)
+	put_cstr_s(mut buf, stmt_name)
 	put_u16(mut buf, 0) // 0 parameter format codes ⇒ all params are text
 	put_u16(mut buf, u16(params.len))
 	for p in params {
@@ -448,14 +454,14 @@ pub fn write_bind(mut buf []u8, portal string, stmt_name string, params []?[]u8)
 pub fn write_describe_portal(mut buf []u8, portal string) {
 	lp := begin_msg(mut buf, `D`)
 	buf << u8(`P`)
-	put_cstr(mut buf, portal.bytes())
+	put_cstr_s(mut buf, portal)
 	finish_msg(mut buf, lp)
 }
 
 // write_execute appends an Execute ('E'): portal and a max-rows cap (0 = all).
 pub fn write_execute(mut buf []u8, portal string, max_rows int) {
 	lp := begin_msg(mut buf, `E`)
-	put_cstr(mut buf, portal.bytes())
+	put_cstr_s(mut buf, portal)
 	put_u32(mut buf, u32(max_rows))
 	finish_msg(mut buf, lp)
 }
@@ -477,7 +483,7 @@ pub fn write_terminate(mut buf []u8) {
 // the Int32-length-prefixed client-first message.
 pub fn write_sasl_initial(mut buf []u8, mechanism string, client_first []u8) {
 	lp := begin_msg(mut buf, `p`)
-	put_cstr(mut buf, mechanism.bytes())
+	put_cstr_s(mut buf, mechanism)
 	put_u32(mut buf, u32(client_first.len))
 	buf << client_first
 	finish_msg(mut buf, lp)


### PR DESCRIPTION
## Why

A consumer that builds with `v -prod -gc none` (no garbage collector) leaks **every** heap allocation that isn't reused or freed. The async-DB request path allocated several buffers **per query/request**, so under `-gc none` a DB workload leaked ~12 KB/request — tens of GiB of RSS under load (and the ever-growing heap *also* degraded throughput via allocator thrash). This PR makes the driver's hot path allocation-free so a `-gc none` server's RSS stays flat.

(The truly zero-alloc paths — plaintext/pipelined — already stayed tiny; only the allocating DB path leaked. Keeping `-gc none` + making the DB path zero-alloc preserves the no-GC win without the leak.)

## Changes

- **`pg_async` per-connection frames-buffer pool** (`conn.v`, `conn_async.v`): `async_submit` allocated an 8 KiB reply accumulator per query. Now a per-conn ring of `max_inflight` buffers, reused round-robin; a slot is only re-taken after a full ring cycle (≤ `max_inflight` in flight, FIFO reply order), by which time its previous query was drained **and** rendered — so a borrow never aliases a live reply. The possibly-grown buffer is written back to its slot so growth is kept, never re-allocated. `PendingQuery.frame_slot` tracks the slot.
- **`pg_async` reusable submit scratch** (`conn_async.v`, `conn.v`): the per-submit `[]u8{cap: 256}` wire-frame scratch becomes a per-connection `submit_scratch` (lazy, reset `len=0`, grows to a high-water mark). `append_send` copies it into `send_buf` synchronously, so reuse across submits is safe.
- **`pg_async` wire builders** (`protocol.v`): the builders called `s.bytes()` on every submit — `write_parse` copied the **whole SQL** (~130–180 B/query), the others copied the (empty) portal/stmt names. Replace `put_cstr([]u8)` with `put_cstr_s(string)` that appends the string's bytes directly (`push_many(s.str, s.len)`). **Byte-identical** wire output; nothing copied per submit.
- **`request_parser.get_query_slice`** (`request_parser.v`): used `find_byte` (`!int`), whose not-found path calls `error()` and **allocates a `MessageError`** — several times per request (query parsing runs on every request). Switch to the existing no-Result `find_byte_idx` (returns `-1`). Behaviorally identical; a **library-wide** win, not just `-gc none`.

## Result (local, async-db, 16-core)

Combined with the framework-side reuse (separate repo), async-db under `-gc none` drops **11,971 → 159 bytes/request (−98.7%)**; the Boehm build is dead flat. Projected arena async-db RSS: ~44 GiB → <1 GiB.

## Validation

- `pg_async` suite (incl. pipelining + error-isolation integration tests) green vs PostgreSQL 18.
- `request_parser` unit tests green (covers `get_query_slice` edge cases).
- Adversarial review (8 independent passes) of the frames-pool ring aliasing, `submit_scratch` reuse, and `put_cstr_s` byte-identity (empty/UTF-8/overflow) — all confirmed safe; `-prod -gc none` build clean.
- All framework DB routes functionally correct vs PG18.