### PR TITLE
perf(pg_async,backend_epoll): zero per-request alloc on the pipelined DB path under -gc none (Stage C)

### DIFF
--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -109,11 +109,19 @@ fn (mut r AsyncReactor) reactor_watch(ext_fd int, client_fd int, cont core.WakeF
 	}
 	if !r.watches[ext_fd].active {
 		// Fresh watch — the single-watch fast path (timerfd / SSE / one query).
-		r.watches[ext_fd] = WatchEntry{
-			active:    true
-			client_fd: client_fd
-			cont:      cont
-			udata:     udata
+		// Reset the fields in place and REUSE the slot's (already-empty) queue
+		// rather than assigning a `WatchEntry{}` literal: the literal default-inits
+		// the omitted `queue []ParkSlot` to a fresh empty array — one heap
+		// allocation per park, which leaks under `-gc none`. Semantics are
+		// identical to the literal (persistent reset to false; async_register
+		// re-stamps it right after when the fd is pool-owned).
+		r.watches[ext_fd].active = true
+		r.watches[ext_fd].client_fd = client_fd
+		r.watches[ext_fd].cont = cont
+		r.watches[ext_fd].udata = udata
+		r.watches[ext_fd].persistent = false
+		unsafe {
+			r.watches[ext_fd].queue.len = 0
 		}
 		return
 	}
@@ -128,14 +136,17 @@ fn (mut r AsyncReactor) reactor_watch(ext_fd int, client_fd int, cont core.WakeF
 			r.watches[ext_fd].udata = udata
 			return
 		}
-		// Promote: move the existing head into the queue, then append the newcomer.
-		r.watches[ext_fd].queue = [
-			ParkSlot{
-				client_fd: r.watches[ext_fd].client_fd
-				cont:      r.watches[ext_fd].cont
-				udata:     r.watches[ext_fd].udata
-			},
-		]
+		// Promote: move the existing head into the queue (len is 0 here), then the
+		// dedup loop below appends the newcomer. Push into the slot's RETAINED
+		// buffer rather than assigning a `[ParkSlot{...}]` literal: the literal
+		// reallocates the queue every promote cycle, which leaks under -gc none.
+		// The buffer grows once to the max pipeline depth and is reused thereafter
+		// (drain resets len to 0 without freeing).
+		r.watches[ext_fd].queue << ParkSlot{
+			client_fd: r.watches[ext_fd].client_fd
+			cont:      r.watches[ext_fd].cont
+			udata:     r.watches[ext_fd].udata
+		}
 	}
 	for i in 0 .. r.watches[ext_fd].queue.len {
 		if r.watches[ext_fd].queue[i].client_fd == client_fd {
@@ -198,14 +209,16 @@ fn (mut r AsyncReactor) reactor_orphan_single(ext_fd int, client_fd int) bool {
 	if e.queue.len != 0 || !e.persistent || !e.active {
 		return false
 	}
-	r.watches[ext_fd].queue = [
-		ParkSlot{
-			client_fd: client_fd
-			cont:      e.cont
-			udata:     e.udata
-			dead:      true
-		},
-	]
+	// Tombstone the orphaned single watch as a one-slot queue. Push into the
+	// slot's retained buffer (len is 0 here) rather than assigning a literal, so
+	// the pool-owned fd's queue is never reallocated — a per-disconnect leak under
+	// -gc none.
+	r.watches[ext_fd].queue << ParkSlot{
+		client_fd: client_fd
+		cont:      e.cont
+		udata:     e.udata
+		dead:      true
+	}
 	return true
 }
 
@@ -676,9 +689,12 @@ fn drain_pipelined(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, 
 	}
 	// Queue emptied: revert the fd to the inactive single-watch state. The fd itself
 	// stays in this worker's epoll (pool-owned); the next park re-activates it.
+	// KEEP the drained queue's buffer (len is already 0 from the delete(0)s) — do
+	// NOT reassign []ParkSlot{}: the next pipeline cycle on this pool-owned fd
+	// refills it without reallocating. A fresh empty array per drain leaks under
+	// -gc none (this is the dominant pipelined-load residual).
 	if reactor.watches[ext_fd].queue.len == 0 {
 		reactor.watches[ext_fd].active = false
-		reactor.watches[ext_fd].queue = []ParkSlot{}
 	}
 }
 

--- a/pg_async/protocol.v
+++ b/pg_async/protocol.v
@@ -362,7 +362,13 @@ pub fn parse_command_complete(payload []u8) u64 {
 fn begin_msg(mut buf []u8, typ u8) int {
 	buf << typ
 	lenpos := buf.len
-	buf << [u8(0), 0, 0, 0] // length placeholder, backpatched by finish_msg
+	// 4-byte length placeholder, backpatched by finish_msg. Appended a byte at a
+	// time on purpose: the literal `[u8(0), 0, 0, 0]` heap-allocates a temporary
+	// array on every call (4 per query — P/B/D/E), which leaks under `-gc none`.
+	buf << u8(0)
+	buf << u8(0)
+	buf << u8(0)
+	buf << u8(0)
 	return lenpos
 }
 


### PR DESCRIPTION
## What

Eliminates the last per-request heap allocations on the async-db / pipelined DB path under `-gc none` (the arena build, where every heap allocation leaks for the process lifetime). Follow-up to #48 (Stage A/B). Two library internals, pinned by callgrind:

1. **`pg_async/begin_msg`** wrote the 4-byte length placeholder as `buf << [u8(0), 0, 0, 0]` — a heap-allocated temporary array on **every** call, **4× per query** (Parse/Bind/Describe/Execute). Now appends the four bytes directly. **Byte-identical wire** (same offset, `finish_msg` backpatches by index).

2. **`backend_epoll` reactor queue churn** — the per-fd `WatchEntry.queue []ParkSlot` was reallocated every pipeline cycle (fresh-watch `WatchEntry{}` literal default-init, promote literal, FIX 3 orphan-tombstone literal, drain-empty `[]ParkSlot{}` reset). All four now **reuse the slot's retained buffer** (`len=0` reset + `<<` refill); it grows once to the connection's max pipeline depth and never reallocates.

## Why it's safe (semantics unchanged)

- Every `<<` is gated to `queue.len == 0`, so it lands at index 0 exactly as the old 1-element literal did; the dedup loop + tail append reproduce `[head, newcomer]`.
- The fresh-watch in-place reset reproduces the `WatchEntry{}` literal's field values (incl. `persistent = false`, re-stamped by `async_register`).
- All queue readers are `len`-bounded; physically-retained slots beyond `len` are unreachable. The queue is never a slice, so `delete(0)` stays on V's in-place memmove path.
- **Verified:** reactor pipelining + FIX 3 tombstone suite green; a 5-lens adversarial review (FIFO ordering, FIX 3 lifecycle, buffer-reuse aliasing/dangling, fresh-watch semantics, wire byte-identity) returned **GO / 0 bugs**, each lens running empirical reuse tests under `-gc none`.

## Measured (local, async-db `?min=1&max=500&limit=20`, RSS slope: `-gc none` vs Boehm)

The right metric is the **excess over the Boehm GC floor** (Boehm itself grows ~10 B/req here from allocator-arena / connection buffers, which is not a heap leak):

| | `-gc none` B/req | Boehm B/req | excess (the real per-request DB leak) |
|---|---|---|---|
| after #48 (Stage A/B) | 191 | 10 | **181** |
| **after this PR** | **21** | 10 | **11** |

callgrind confirms the DB request path (pg wire P/B/D/E, reactor queue, render) is now **allocation-free**; the ~11 B/req residual traces entirely to per-*connection* `state_for`, which amortizes to ~0 with the arena's persistent pooled connections. Net vs the pre-campaign baseline: **11,971 → 21 B/req (≈570×; ~1088× on the excess-over-Boehm leak).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)