### PR TITLE
docs: reflect the native async DB driver + -gc none zero-alloc model

### DIFF
--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -155,37 +155,72 @@ sb.write_string('Content-Length: ${body.len}\r\n')
 
 ---
 
-## 4. Allocate on the hot path with intent
+## 4. Allocate on the hot path with intent — under `-gc none`, not at all
 
-See [V_PERF_TOOLBOX.md](V_PERF_TOOLBOX.md) and the memory notes for detail. Key
-points:
+The production build is **`-prod -gc none`**: there is no garbage collector and
+**nothing is ever freed**. A per-request allocation is not "GC pressure" — it is
+a permanent **leak** that grows RSS linearly with traffic. So the hot paths must
+be *literally allocation-free*. See [V_PERF_TOOLBOX.md](V_PERF_TOOLBOX.md) and the
+[wiki](https://github.com/enghitalo/vanilla/wiki/Memory-Management-under-gc-none).
 
-- `[]u8{len: n}` is **zeroed**; `[]u8{cap: n}` is **uninitialized (noscan)** —
-  use the `cap` form and append/read into the spare capacity when you'll
-  overwrite the bytes anyway.
-- A large `cap` is not free: it adds GC pressure. Size to the realistic case,
-  not the worst case.
-- Reuse buffers per-connection instead of allocating per-request where the
-  lifetime allows it.
+The recurring zero-allocation patterns:
+
+- **Reuse a per-worker buffer** — reset `len=0`, grow to a high-water mark, keep
+  it. The worker is single-threaded, so one buffer is safe across requests (this
+  is what the per-worker render scratch does). This is the single most important
+  pattern.
+- **Borrow, don't copy** — return `tos`/slice views into the read buffer; defer
+  `.clone()`/`.bytes()` until bytes must outlive the buffer (they rarely do —
+  responses are built synchronously before the buffer is recycled).
+- **Append bytes directly** — `unsafe { out.push_many(s.str, s.len) }`; never
+  build an intermediate `string`/`[]u8` just to append it.
+- **Pool structs on a free-list** — reuse a heap object across requests, resetting
+  its fields on release (the per-worker `ConnState` and per-request `Stash` pools
+  do this), instead of `&T{}` per request.
+- **No error-boxing on the hot path** — `error()` allocates a `MessageError` even
+  when discarded by `or {}`; use a `-1`-returning "not found" (`find_byte_idx`).
+- **No empty/transient array literals** — `buf << [u8(0),0,0,0]` (and even `[]T{}`)
+  heap-allocate a temporary array; append the elements, or use a module `const`.
+- **Sizing (default-GC builds only):** `[]u8{cap: n}` is uninitialized/noscan,
+  `{len: n}` is zeroed, and a large `cap` is GC pressure. Under `-gc none` it is
+  the *reuse* that matters, not the flag — a fresh buffer of any size leaks.
 
 ---
 
-## 5. Side effects go through pools, off the hot path
+## 5. Side effects go through the async runtime + pools, off the hot path
 
 Databases, upstreams, and other blocking resources must not stall the event
-loop.
+loop. The async runtime exists exactly for this: a handler that must wait calls
+`ac.watch(ext_fd, interest, continuation, udata)` and returns `.suspend`; the
+worker parks the connection, serves others, and runs the continuation when
+`ext_fd` is ready. The DB driver (`pg_async`), upstream calls, and timers are all
+consumers of this one primitive — see the
+[wiki](https://github.com/enghitalo/vanilla/wiki/Async-Postgres-and-Pipelining).
+
+For Postgres specifically, `pg_async` is a native (no-libpq) wire client with a
+per-worker pool and **cross-request pipelining** (`max_inflight` queries per
+connection). Pool connections are **persistent** (`watch_persistent`): a client
+disconnecting mid-query tombstones the parked request rather than closing the
+connection, so the pooled conn (and its SCRAM handshake) survives client churn.
 
 **Do**
 
-- Use a **connection pool** (see [examples/database](../examples/database)).
-- Keep the pool sized to the worker/thread model; don't open a connection per
-  request.
-- Return a clean `503` / `504` when a resource is exhausted rather than blocking
-  indefinitely.
+- Use the **pool**, not a connection per request; build params/queries into
+  reused per-worker buffers (the DB path is allocation-free under `-gc none`).
+- Under saturation, **shed with the honest status**: `503 Service Unavailable`
+  when the pool is momentarily full, not `400`/`404`. A backpressure shed is not
+  a client error — misreporting it as `4xx` showed up as spurious failures in the
+  benchmark (see the wiki's *Gotchas* page). Genuine `400` (bad body) / `404`
+  (missing row) stay as they are.
+- Keep the pool sized to the worker/thread model.
 
 **Don't**
 
-- Open and close a socket/connection inside every handler invocation.
+- Open/close a socket or connection inside every handler invocation.
+- Block the worker on a DB/upstream call — `watch` + `.suspend` instead.
+- Return `200` with empty data for a *write* that was shed (it's a lie about a
+  mutation) — `503` is the honest answer. (The backpressure policy is tracked in
+  [vanilla#51](https://github.com/enghitalo/vanilla/issues/51).)
 - Log synchronously to disk on the hot path — batch or hand off (see
   [examples/middleware](../examples/middleware) access log).
 
@@ -278,20 +313,30 @@ Performance claims must be measured, not assumed.
 
 **Do**
 
-- Wipe caches and free the port between runs; sandboxed `wrk` is noisy — prefer
-  A/B comparisons or a micro-benchmark.
-- Build with `-prod` for any timing run.
+- Wipe caches (`v wipe-cache`) and free the port between runs; sandboxed `wrk` is
+  noisy — prefer A/B comparisons or a micro-benchmark.
+- Build with `-prod` for any timing run; build `-prod -gc none` to match
+  production.
 
   ```sh
-  v -prod .
+  v -prod -gc none .
   wrk -H 'Connection: keep-alive' --connections 512 --threads 16 \
       --duration 10s http://localhost:3000
   ```
+
+- For any change that touches allocation, **also check the RSS slope under `-gc
+  none`** (it must be flat) — measure the growth *in excess of a Boehm build's*,
+  and use callgrind to attribute any residual per-request allocation by call
+  site. See [V_PERF_TOOLBOX.md](V_PERF_TOOLBOX.md) ("Profiling allocations").
+- Confirm perf changes on a **high-core** run, not just a laptop: a couple of
+  small per-request allocs look like noise at 4–16 cores but can be a multiple-x
+  swing at 64 (and under `-gc none`, a runaway leak at scale).
 
 **Don't**
 
 - Compare a `-prod` build against a debug build.
 - Report a single noisy run as a result.
+- Trust a flat RSS line alone — subtract the Boehm floor first (see above).
 
 ---
 

--- a/docs/PERF_GAP_ANALYSIS.md
+++ b/docs/PERF_GAP_ANALYSIS.md
@@ -6,6 +6,48 @@ Analysis of six reference implementations — HttpArena **tokio**, **minima-sync
 **liburing** library/examples (proxy.c, releases 2.9–2.14) — compared against
 vanilla's epoll and io_uring backends.
 
+## Update (2026-06, late) — native async DB + `-gc none` zero-alloc
+
+Two things changed the picture after the analysis below was written. The
+[project wiki](https://github.com/enghitalo/vanilla/wiki) carries the full
+narrative; the short version:
+
+1. **The arena build moved to `-prod -gc none` (no garbage collector).** A
+   per-thread allocation microbenchmark showed the default Boehm GC's aggregate
+   throughput *flat across cores* (16 cores ≈ 1 core; filed
+   [vlang/v#27488](https://github.com/vlang/v/issues/27488)), so a thread-per-core
+   server cannot let a shared GC gate allocation. The catch: under `-gc none`
+   **nothing is ever freed**, so a per-request allocation is no longer "GC
+   pressure" — it is a permanent **leak** that grows RSS without bound. The
+   metric that matters becomes RSS growth *in excess of a Boehm build's* (the GC
+   floor); see [V_PERF_TOOLBOX.md](V_PERF_TOOLBOX.md).
+
+2. **The DB gap is closed — vanilla has a native Postgres client.** `pg_async`
+   speaks the v3 wire protocol directly (no libpq): SCRAM-SHA-256 auth, the
+   extended query protocol, binary result rows decoded without copying, and
+   **cross-request pipelining** (`max_inflight = 8` queries per connection) over
+   a small park/resume **async reactor** with **persistent pooled connections**
+   (`watch_persistent` — a client disconnect tombstones the parked request and
+   keeps the pooled conn open). This replaces the stdlib `db.pg` text-protocol
+   driver the "Still open" note below was written against.
+
+A staged zero-allocation campaign then drove the DB request path to **~0
+allocations/request** under `-gc none` (verified by callgrind):
+
+| metric | before | after |
+|---|---|---|
+| async-db per-request DB leak (excess over the Boehm floor) | 11,971 B/req | **~0** |
+| arena async-db RSS | 27–44 GiB | **~1.2 GiB** |
+| per-reconnect allocations (ConnState free-list) | 3 | **~0** |
+
+The general/plaintext path got the same treatment (`emit_int` instead of
+`n.str()`), and a per-worker `ConnState` free-list eliminated the
+connection-churn allocations that load generators (which reconnect tens of
+thousands of times per run) provoke. Backpressure under pool saturation now
+sheds with an honest `503` on the crud write paths (was `400`/`404`). See the
+wiki's *Memory Management under gc none*, *Async Postgres and Pipelining*, and
+*Gotchas and Lessons Learned* pages.
+
 ## Status (2026-06) — what landed and what it measured
 
 Most of the gaps below are **closed**. Both backends now have persistent
@@ -47,13 +89,12 @@ contract (item #9) is the most important decision in this list, not the last.
   segfaults from cross-thread `epoll` fd close, `unable to join thread`). A clean
   multi-server shutdown lifecycle is needed first. Deprioritized: the arena showed
   accept was **not** the bottleneck (GC/allocation was, and that is fixed).
-- **DB profiles (async-db, crud, fortunes)** are bound by the stdlib `db.pg`
-  driver (text protocol, lazy pool, no persistent prepared statements/pipelining).
-  `veb` on the same stack is *slower* than vanilla, so vanilla already maxes the
-  driver. Prepared statements (`PQprepare`/`PQexecPrepared`, lazily prepared per
-  pooled connection) give a small win (~+9% async-db); single-pass `escape_html`
-  gives +27% fortunes — but the gap to the top (native binary-protocol drivers)
-  only closes with a faster pg driver, a separate project.
+- **DB profiles (async-db, crud, fortunes)** — **CLOSED.** This used to read
+  "bound by the stdlib `db.pg` driver … only closes with a faster pg driver, a
+  separate project." That project shipped: `pg_async` is a native v3
+  binary-protocol client with cross-request pipelining over the async reactor
+  (see the *Update* section at the top). The remaining DB cost is the database
+  itself (and, for writes, the DB ceiling), not the client.
 
 ## What ALL the fast servers have in common
 

--- a/docs/V_PERF_TOOLBOX.md
+++ b/docs/V_PERF_TOOLBOX.md
@@ -4,6 +4,30 @@ Notes verified against the installed V source (`vlib/builtin/`) and emitted C
 (`v -prod -o out.c`). The guiding rule: **settle codegen/perf questions by
 reading the generated C, not by guessing.**
 
+## The two build modes: default GC vs `-gc none`
+
+vanilla can run either way, and the rules flip between them:
+
+- **Default (`-prod`, Boehm GC).** Allocations are reclaimed, but the GC's
+  stop-the-world serializes all workers, so per-request allocation is **GC
+  pressure** that caps how many cores do useful work. The "Allocation facts"
+  below (noscan, scan-on-grow) are this mode.
+- **`-prod -gc none` (the arena/production build).** No GC, **nothing is ever
+  freed**. A per-request allocation is therefore a permanent **leak** — RSS grows
+  linearly with requests served. Allocations are plain libc `malloc`/`calloc`
+  (so tools like callgrind/heaptrack see them, unlike Boehm's `GC_malloc`). This
+  is the build to optimize for; the hot paths must be **literally allocation-free**.
+
+Why `-gc none` at all: on a thread-per-core server the shared GC doesn't scale —
+a microbenchmark showed default-GC aggregate allocation throughput flat from 1→16
+threads (16 cores ≈ 1 core; [vlang/v#27488](https://github.com/vlang/v/issues/27488)).
+
+> **Measuring a leak under `-gc none`:** a rising RSS line is *not* proof — a
+> Boehm build of the same server also grows (glibc arena, connection buffers,
+> thread stacks). Build both, drive identical load, and report
+> **`gc_none_growth − boehm_growth`**. That difference is the genuinely
+> collectable per-request allocation; everything else is the unavoidable floor.
+
 ## Inspecting what V actually emits
 
 - `v -prod -o out.c ./examples/<name>` — write the C without compiling; `grep` it.
@@ -78,3 +102,60 @@ Arrays aren't the only structure. Consider: `map`, fixed `[N]T` (stack), channel
 and custom layouts — ring buffers, arenas, `@[packed]` structs over raw C memory
 — when array alloc/grow semantics don't fit. The request read path's target is a
 **per-worker arena / reusable buffer** so the hot path allocates nothing.
+
+## Profiling allocations (under `-gc none`)
+
+Two harnesses, one rule. (Both spin a throwaway, seeded Postgres and clean up;
+recipes are reproducible.)
+
+**callgrind — allocations per request, by call site.** The scalpel: it answers
+*which function allocates and how many times per request*. The recipe that makes
+it usable:
+
+- **Build with `-cc gcc`, not the default tcc** — callgrind can't resolve V app
+  symbols from tcc's debug info (everything shows as a hex address); gcc emits
+  DWARF, so `main__*` / `pg_async__*` are named.
+- **`--instr-atstart=no`, then `callgrind_control -i on` *after* a hard warmup** —
+  so pool bring-up + SCRAM + buffers reaching high-water run uninstrumented and
+  only steady-state per-request work is counted.
+- **Don't dump with a live `callgrind_control -d`** — it hangs when every worker
+  is parked in `epoll_wait`. **`SIGTERM`** the valgrind process: the signal
+  interrupts the syscall and callgrind flushes its dump on `fini`.
+- **Parse the raw dump for allocator call counts** — build the id→name map, sum
+  `calls=` to each V allocator entry (`vcalloc`, `malloc_uninit`, `memdup`, …)
+  by immediate caller, divide by measured requests. (The self-cost table doesn't
+  show call counts, and allocators are cheap-but-frequent, so they never surface
+  there.)
+- **Drive the load shape that exposes the bug:** per-request allocs show under
+  any load; **pipeline-queue** allocs need *concurrent* load with `clients > pool
+  conns`; **per-connection** allocs need *connection churn* (many short-lived
+  connections — what real load generators do, reconnecting tens of thousands of
+  times per run).
+
+**RSS slope — the leak in bytes/request.** Build `-gc none` **and** Boehm, run
+each under load for a fixed window sampling `VmRSS`, report bytes/request + the
+trajectory (linear climb = real leak; jump-then-flat = one-time setup). Subtract
+the Boehm floor. A **hard RSS cap** kills a runaway so it's safe unattended.
+
+**heaptrack caveat:** it sees `-gc none` allocations, but attributes from process
+start, so one-time bring-up (SCRAM/PBKDF2, lazy init) blurs the per-request
+signal. callgrind with post-warmup instrumentation is the disambiguator.
+
+## V allocation gotchas (filed upstream)
+
+- **Empty/zero-length array literals allocate.** `[]T{}` (and a default-init `[]T`
+  struct field) call `alloc_array_data(0)` → `vcalloc(header)` even at `len == 0,
+  cap == 0`. Under `-gc none` each is a permanent leak. Append elements or use a
+  module `const` instead. ([vlang/v#27487](https://github.com/vlang/v/issues/27487))
+- **Allocation does not scale across cores** under the default GC (the reason for
+  `-gc none`). ([vlang/v#27488](https://github.com/vlang/v/issues/27488))
+- **`error()` boxes a `MessageError`** — even when the caller discards it with
+  `or {}`. So a `!int` "not found" allocates per call; prefer a `-1`-returning
+  variant (`find_byte_idx`, not `find_byte`) on hot paths.
+- **`int.str()` / `${}` allocate** — format integers into a reused buffer with an
+  itoa helper (`wi`/`emit_int`), never `.str()` on the response hot path.
+- **`runtime.nr_cpus()` ignores CPU affinity** (`sched_getaffinity`) — `taskset
+  -c 0` still reports every core; keep in mind when pinning for profiling.
+- **`&Struct{}` as an `if`-*expression* branch** has miscompiled to invalid C in
+  some build modes — use the statement form
+  (`mut x := &T(unsafe{nil}); if … { x = … } else { x = &T{…} }`).


### PR DESCRIPTION
The `docs/` predated the async-runtime / `pg_async` / `-gc none` work and were partly stale — most visibly **PERF_GAP_ANALYSIS** still said the DB profiles were *"bound by the stdlib `db.pg` driver … a faster pg driver, a separate project."* That project shipped.

## Changes

- **PERF_GAP_ANALYSIS.md** — new top section: the move to `-prod -gc none` (allocations *leak* rather than pressure the GC; measure RSS growth *in excess of the Boehm floor*) and the native `pg_async` client (binary v3 protocol, SCRAM‑SHA‑256, cross‑request pipelining `max_inflight=8`, persistent pooled connections). Campaign results table (async‑db 27–44 GiB → ~1.2 GiB; per‑request DB leak 11,971 B/req → ~0; `ConnState` pool 3 → ~0 allocs/reconnect). The "Still open" DB bullet is marked **CLOSED**.
- **V_PERF_TOOLBOX.md** — a *two build modes* section (default GC vs `-gc none`), the allocation‑profiling harnesses (callgrind recipe: `-cc gcc` for DWARF, instrument *after* warmup, `SIGTERM`‑dump, parse the raw dump for alloc call counts; RSS‑slope vs the Boehm floor), and the upstream V gotchas ([#27487](https://github.com/vlang/v/issues/27487) empty‑array alloc, [#27488](https://github.com/vlang/v/issues/27488) allocator scaling, error‑boxing, `nr_cpus` affinity, `&Struct{}` if‑expr).
- **BEST_PRACTICES.md** — §4 reframed for `-gc none` (per‑request alloc = permanent leak) with the zero‑alloc patterns (reuse buffers, borrow, pool structs, no error‑boxing, no empty literals); §5 documents the `watch`/`.suspend` async runtime, `pg_async` pipelining + persistent pooled connections, and **shed‑with‑`503`** (not `4xx`) backpressure; §10 adds the under‑load RSS‑slope leak check.

Docs‑only. Full narrative on the [project wiki](https://github.com/enghitalo/vanilla/wiki).

🤖 Generated with [Claude Code](https://claude.com/claude-code)