### PR TITLE
pg_async: zero-alloc async_on_readable not-ready return

### DIFF
--- a/pg_async/conn_async.v
+++ b/pg_async/conn_async.v
@@ -209,6 +209,13 @@ pub:
 	result Result
 }
 
+// not_ready is the singleton returned on the (very common) not-ready path. A fresh
+// `QueryPoll{}` literal default-inits its `Result.frames` to `[]u8{}`, which under
+// `-gc none` allocates a (never-freed) array header EVERY call — ~1 per request on
+// the drain loop's terminating not-ready return (vlang/v#27487). The const allocates
+// that header once; returning it by value just copies the (ready=false) struct.
+const not_ready = QueryPoll{}
+
 // async_on_readable drains the socket to EAGAIN and frames complete backend
 // messages into the FRONT in-flight query. When that query's ReadyForQuery
 // arrives it is popped and returned as a ready QueryPoll; replies arrive in
@@ -316,5 +323,5 @@ pub fn (mut c PgConn) async_on_readable() !QueryPoll {
 			}
 		}
 	}
-	return QueryPoll{} // not ready — front query needs more bytes (or none in flight)
+	return not_ready // front query needs more bytes (or none in flight) — see `not_ready`
 }


### PR DESCRIPTION
## What

The pipelined drain loop in `PgConn.async_on_readable` ends each readable edge with `return QueryPoll{}` (the not-ready terminator). That literal default-inits `Result.frames` to `[]u8{}`, and **an empty array literal allocates a header** (vlang/v#27487) — so under `-gc none` it leaks a never-freed array descriptor on **every** not-ready return, ~1 per request on the drain.

Fix: a module `const not_ready = QueryPoll{}` returned by value. The header is allocated once at const-init; each return just copies the `ready=false` struct (no per-call allocation).

## Why it was invisible before

callgrind can't surface it — valgrind serializes execution, suppressing the native pipelining depth that drives the drain loop (a 1:1000 run showed only 0.007 allocs/req). A **30s heaptrack on a PUT-only workload** pinned it: 899,709 allocs (~1/PUT) at `__new_array ← async_on_readable` (conn_async.v), above the one-time SCRAM/PBKDF2 bring-up.

## Measured (`-gc none`, RSS slope, gc_none − Boehm = collectable leak)

| Workload | Before | After |
|---|---|---|
| PUT-only | 24 B/req (linear) | **0 B/req (flat)** |
| crud GET+PUT mix | residual | gc_none ≤ Boehm floor (leak-free) |

## Verification

- `v test pg_async/` — 4/4 pass
- `reactor_pipelining_test` + `backend_behaviors_test` — pass
- 10/10 live crud functional checks (MISS→HIT, PUT-invalidation, TTL expiry) against PG18

🤖 Generated with [Claude Code](https://claude.com/claude-code)