### PR TITLE
docs: slice/buf_view + affinity workers + loopback-ceiling benchmarking

### DIFF
--- a/docs/PERF_GAP_ANALYSIS.md
+++ b/docs/PERF_GAP_ANALYSIS.md
@@ -96,6 +96,28 @@ contract (item #9) is the most important decision in this list, not the last.
   (see the *Update* section at the top). The remaining DB cost is the database
   itself (and, for writes, the DB ceiling), not the client.
 
+### Measuring locally: loopback is the ceiling, not the server
+
+A single-box `wrk`-over-loopback run does **not** measure server efficiency — the
+load generator and the loopback softirq path eat half the cores and cap throughput
+before the server does. On a 16-core box, `examples/tiny` (`-gc none`) tops out at
+**~340k req/s** with an 8-core-server / 8-core-`wrk` split, and the number is
+*identical with and without `-gc`* (the hello path barely allocates, so GC is
+irrelevant) and flat across `-c64…512` (a throughput ceiling, not latency). A
+hand-written 16-thread C epoll server (`benchmark-driven-webservers/c/epoll_simple.c`)
+hits the **same ~341k** on the same split — so vanilla is already at the
+bare-C/loopback ceiling here; local `wrk` has no more to give. Corollaries:
+  - Measure **server** efficiency by **instructions/request** (callgrind), which is
+    regime-independent, *or* on the multi-core arena with a real (non-loopback)
+    generator — not by a local loopback rps number.
+  - When you must use local rps, **balance the cores** (≈half to the generator) and
+    confirm the generator isn't the bottleneck (give it more cores; if rps rises, it
+    was generator-bound). A 12-server / 4-`wrk` split reads ~216k purely because
+    4 `wrk` cores can't push more.
+  - Worker count must track *usable* cores (`core.worker_count()` via
+    `sched_getaffinity`), or a pinned/containerized run oversubscribes and the
+    number drops — see V_PERF_TOOLBOX's `nr_cpus` note.
+
 ## What ALL the fast servers have in common
 
 Every one of these servers, regardless of language or backend, shares the same

--- a/docs/V_PERF_TOOLBOX.md
+++ b/docs/V_PERF_TOOLBOX.md
@@ -147,6 +147,16 @@ signal. callgrind with post-warmup instrumentation is the disambiguator.
   struct field) call `alloc_array_data(0)` → `vcalloc(header)` even at `len == 0,
   cap == 0`. Under `-gc none` each is a permanent leak. Append elements or use a
   module `const` instead. ([vlang/v#27487](https://github.com/vlang/v/issues/27487))
+- **`array.slice()` (`a[start..end]`) marks the source buffer on every call.**
+  It does an unconditional `mark_buffer_has_slices()` (a malloc data-header pointer
+  round-trip + flag write) plus bounds checks and the result-struct build — ~11% of
+  the plaintext request hot path's `-prod` instructions when slicing the read buffer
+  per request, yet pure waste for a transient read-only view (`has_slices` is only
+  consulted by `delete`/shrink, which a manually-managed reused buffer never does).
+  Fix: a non-owning window built by hand — copy the array header, repoint
+  `data`/`len`/`cap`, `unsafe { flags.clear(.managed) }` so it is never freed and a
+  sub-slice of it also skips marking (compiles to a struct copy + 3 stores, zero
+  alloc). See `backend_epoll`'s `buf_view`. ([vlang/v#27507](https://github.com/vlang/v/issues/27507))
 - **Allocation does not scale across cores** under the default GC (the reason for
   `-gc none`). ([vlang/v#27488](https://github.com/vlang/v/issues/27488))
 - **`error()` boxes a `MessageError`** — even when the caller discards it with
@@ -154,8 +164,13 @@ signal. callgrind with post-warmup instrumentation is the disambiguator.
   variant (`find_byte_idx`, not `find_byte`) on hot paths.
 - **`int.str()` / `${}` allocate** — format integers into a reused buffer with an
   itoa helper (`wi`/`emit_int`), never `.str()` on the response hot path.
-- **`runtime.nr_cpus()` ignores CPU affinity** (`sched_getaffinity`) — `taskset
-  -c 0` still reports every core; keep in mind when pinning for profiling.
+- **`runtime.nr_cpus()` ignores CPU affinity** — it is `sysconf(_SC_NPROCESSORS_ONLN)`
+  = every online *host* core, blind to `taskset`/cpuset and cgroup CPU pinning. A
+  server pinned to N cores (a profiling run, or a container capped at N CPUs on a
+  bigger host) that sizes its worker pool from `nr_cpus()` spawns host-many workers
+  and oversubscribes them N-ways. The worker count instead comes from
+  `core.worker_count()`: a `VANILLA_WORKERS` env override → else the
+  `sched_getaffinity` mask bit-count (`core/affinity_linux.c.v`) → else `nr_cpus()`.
 - **`&Struct{}` as an `if`-*expression* branch** has miscompiled to invalid C in
   some build modes — use the statement form
   (`mut x := &T(unsafe{nil}); if … { x = … } else { x = &T{…} }`).


### PR DESCRIPTION
Documents the techniques and findings from #55 (hot-path `array.slice()` elimination + affinity-aware worker count).

**`docs/V_PERF_TOOLBOX.md`**
- New gotcha: `array.slice()` calls `mark_buffer_has_slices()` on every slice (malloc-header round-trip + flag write) — ~11% of the plaintext request hot path — and the `buf_view` non-owning window that avoids it. Links [vlang/v#27507](https://github.com/vlang/v/issues/27507).
- Rewrote the `nr_cpus` note: it's `sysconf(_SC_NPROCESSORS_ONLN)` (host cores, blind to taskset/cpuset), so worker count now comes from `core.worker_count()` (`VANILLA_WORKERS` → `sched_getaffinity` → `nr_cpus`).

**`docs/PERF_GAP_ANALYSIS.md`** — new "Measuring locally: loopback is the ceiling, not the server":
- A single-box `wrk`-over-loopback run is generator/loopback-bound, not server-bound: `examples/tiny` tops out ~340k on a 16-core box (8 srv / 8 wrk), **identical with and without `-gc`**, and a hand-written 16-thread C epoll server hits the same ~341k — so vanilla is already at the bare-C/loopback ceiling locally.
- Measure server efficiency by **instructions/request** (callgrind) or on the multi-core arena with a real generator; balance generator cores; size workers from usable cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)