### PR TITLE
core: name the AsyncCtx.register fn type (RegisterFn) — fix build on current V

### DIFF
--- a/http_server/core/core.v
+++ b/http_server/core/core.v
@@ -84,6 +84,13 @@ pub type WakeFn = fn (mut out []u8, mut ac AsyncCtx) AsyncStep
 // and SSE/WebSocket backpressure are all consumers of this one primitive.
 pub type AsyncHandler = fn (req []u8, mut out []u8, mut ac AsyncCtx) AsyncStep
 
+// RegisterFn is the backend-installed watch-registration hook (see AsyncCtx.register).
+// A NAMED fn type, not an inline one on the field: on recent V (c0624b274) calling an
+// inline-fn-typed struct field mis-resolves its parameter types and errors with
+// "cannot use WatchInterest as WatchInterest" — a named alias resolves the signature
+// canonically. (A vlang/v function-pointer-field checker quirk.)
+pub type RegisterFn = fn (mut ac AsyncCtx, ext_fd int, interest WatchInterest, cont WakeFn, udata voidptr)
+
 // AsyncCtx is the per-invocation handle a handler/continuation uses to await an
 // fd. The backend fills it in and installs `register`; handlers only call
 // watch()/ready_fd()/udata()/state(). It is the layering bridge: `core` owns the
@@ -107,7 +114,7 @@ pub mut:
 	// and resets it; a plain watch() leaves it false (the fd is request-owned and
 	// closed on disconnect, e.g. a per-request timerfd or pipe).
 	persistent bool
-	register   fn (mut ac AsyncCtx, ext_fd int, interest WatchInterest, cont WakeFn, udata voidptr) = unsafe { nil }
+	register   RegisterFn = unsafe { nil }
 }
 
 // watch parks the current request and asks the worker to call `cont` when


### PR DESCRIPTION
On recent V (master `c0624b274`), calling the **inline-fn-typed** `AsyncCtx.register` struct field fails the checker:
```
core.v:117: error: cannot use `core.WatchInterest` as `core.WatchInterest` in argument 3 to register
core.v:117: error: cannot use `fn (mut []u8, mut core.AsyncCtx) core.AsyncStep` as `fn (...) ...` in argument 4
```
i.e. it mis-resolves the inline fn type's parameter types as distinct-but-identically-named. This blocked building vanilla against current V (it surfaced in the HttpArena `vanilla-epoll` build once it moved off 0.5.1).

Fix: hoist the signature into a named `pub type RegisterFn = fn(...)` and use it for the field. Named fn types resolve canonically, so `watch()` / `watch_persistent()` compile again. No behavior change.

Verified: `reactor_pipelining` + `backend_behaviors` suites pass; vanilla-epoll builds `-prod -gc none` on c0624b274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)