### PR TITLE
io_uring: no-scan per-connection buffers by default (fix static/upload high-conn cliff)

### DIFF
--- a/http_server/io_uring/io_uring_linux.c.v
+++ b/http_server/io_uring/io_uring_linux.c.v
@@ -292,19 +292,27 @@ pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	// (noscan) capacity — recv fills read_buf, the handler fills response_buffer.
 	c.read_buf = []u8{len: 0, cap: read_buf_cap}
 	c.response_buffer = []u8{len: 0, cap: write_buf_cap}
-	// Keep both buffers in a no-scan GC block ACROSS growth. A large response
-	// (e.g. a 300 KiB static asset) grows response_buffer past write_buf_cap, and
-	// without this flag grow_cap reallocates as a *scanned* block — thousands of
-	// such multi-hundred-KB buffers at high keep-alive conn counts make GC
-	// scanning + stop-the-world dominate (the "static cliff"). The flag is
-	// preserved across resize, so the buffer stays atomic however large it grows.
+	// Keep both buffers in a no-scan GC block ACROSS growth — ON BY DEFAULT. A large
+	// response (e.g. a 300 KiB static asset) or a large upload body grows the buffer
+	// past its base cap, and without this flag grow_cap reallocates as a *scanned*
+	// block. At high keep-alive connection counts, thousands of such multi-hundred-KB
+	// buffers make GC scanning + stop-the-world dominate (the "static cliff"): the
+	// io_uring `static` profile collapsed from ~245K to ~8K RPS at 4096 conns (and
+	// `upload` similarly) with the CPU going idle, while the epoll backend — which
+	// sendfile()s static and never holds a big per-conn body buffer — stayed flat.
+	// The flag is preserved across resize, so the buffer stays atomic however large
+	// it grows; the buffer itself is NOT shrunk, so there is no realloc churn on the
+	// hot path (unlike a per-request shrink).
 	//
-	// Gated behind `-d vanilla_noscan`: `.noscan_data` only exists on V after the
-	// 0.5.1 release, and `$if flag ? {}` is comptime-eliminated (and not
-	// type-checked) when the flag is unset, so the library still builds on 0.5.1.
-	// Enable once a V release ships `.noscan_data` without the post-0.5.1 codegen
-	// slowdown (vlang/v#27468).
-	$if vanilla_noscan ? {
+	// `.noscan_data` only exists on V after the 0.5.1 release (it also needs the
+	// vlang/v#27468 codegen fix, shipped in #27470). The default branch below
+	// references it, so the library now requires a post-0.5.1 toolchain by default —
+	// the pinned/recommended V already satisfies this. To build on an older V, pass
+	// `-d vanilla_legacy_gc` (the `$if` branch is comptime-eliminated and not
+	// type-checked when the flag is set, so 0.5.1 still compiles).
+	$if vanilla_legacy_gc ? {
+		// legacy toolchain: leave the buffers scanned (no `.noscan_data`).
+	} $else {
 		unsafe {
 			c.read_buf.flags.set(.noscan_data)
 			c.response_buffer.flags.set(.noscan_data)


### PR DESCRIPTION
## Problem: io_uring backend collapses on large-transfer profiles at high connection counts

On the HttpArena benchmark, the io_uring backend craters on exactly the two profiles that move large payloads, while CPU goes **idle** (a stall, not a CPU ceiling):

| profile | conns | RPS | CPU | note |
|---|---|---|---|---|
| `static` | 1024 | 245,192 | 5700% | healthy |
| `static` | 4096 | **8,080** | **216%** | collapse, CPU idle |
| `static` | 6800 | **3,889** | **142%** | worse |
| `upload` | 32 | 948 | 929% | |
| `upload` | 256 | **220** | **267%** | collapse, 3.4 GiB RSS |
| `static` (epoll, **same app**) | 4096 | **1,139,124** | 5754% | flat ✅ |

`baseline`/`pipelined` (tiny buffers) at the same 4096 conns are fine (3.5M / 37M RPS) — so it scales with **buffer size × connection count**, not connection count alone.

## Cause: the "static cliff" (already named in the code)

`pool_acquire` grows each connection's `read_buf`/`response_buffer` past its base cap to hold a large response (e.g. a 300 KiB static asset) or upload body, and pins it for the connection's lifetime. Without `.noscan_data` that grown buffer is a GC-**scanned** block; with thousands live at high keep-alive conn counts, GC mark + stop-the-world dominates. The epoll backend never hits this — it `sendfile()`s static and doesn't hold a big per-connection body buffer.

## Fix: flip the existing `.noscan_data` mitigation to ON BY DEFAULT

The mitigation was already written, gated behind `-d vanilla_noscan` *pending V support*. The pinned/recommended V (master `6c4d26f1f`) now ships `.noscan_data` **and** the vlang/v#27468 codegen fix (#27470) — the precondition the comment was waiting on. So:

- Default → buffers are no-scan (the GC stops walking them; the cliff goes away).
- `-d vanilla_legacy_gc` → opt-out for a pre-0.5.1 toolchain (the `$if` branch is comptime-eliminated, so 0.5.1 still builds).

Marking a `[]u8` buffer no-scan is **correctness-neutral** (byte buffers hold no GC pointers) and adds **no realloc churn** on the hot path — deliberately *not* shrinking the buffer per request, which would realloc the 300 KiB buffer on every high-RPS static hit.

## Verification & notes
- Build-verified with V `6c4d26f1f`; a 16-core keep-alive `static` run shows no regression (scanned vs noscan both ~13.4K RPS — warm keep-alive serving allocates nothing, so the GC-scan cost only bites under the arena's high-conn/collection pattern).
- The high-conn collapse is a 64-core/GC-collection phenomenon I could not reproduce locally; **best confirmed on the HttpArena benchmark**, where it was observed.
- **Policy note:** this makes a post-0.5.1 toolchain the default. If you'd rather keep 0.5.1 building without a flag, the alternative is to keep this opt-in and instead pass `-d vanilla_noscan` from the consumer (e.g. the HttpArena io_uring Dockerfile). Happy to flip the polarity if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
