### PR TITLE
io_uring: remove the dead per-connection noscan flag (corrects #59)

### DIFF
--- a/http_server/io_uring/io_uring_linux.c.v
+++ b/http_server/io_uring/io_uring_linux.c.v
@@ -292,32 +292,18 @@ pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	// (noscan) capacity — recv fills read_buf, the handler fills response_buffer.
 	c.read_buf = []u8{len: 0, cap: read_buf_cap}
 	c.response_buffer = []u8{len: 0, cap: write_buf_cap}
-	// Keep both buffers in a no-scan GC block ACROSS growth — ON BY DEFAULT. A large
-	// response (e.g. a 300 KiB static asset) or a large upload body grows the buffer
-	// past its base cap, and without this flag grow_cap reallocates as a *scanned*
-	// block. At high keep-alive connection counts, thousands of such multi-hundred-KB
-	// buffers make GC scanning + stop-the-world dominate (the "static cliff"): the
-	// io_uring `static` profile collapsed from ~245K to ~8K RPS at 4096 conns (and
-	// `upload` similarly) with the CPU going idle, while the epoll backend — which
-	// sendfile()s static and never holds a big per-conn body buffer — stayed flat.
-	// The flag is preserved across resize, so the buffer stays atomic however large
-	// it grows; the buffer itself is NOT shrunk, so there is no realloc churn on the
-	// hot path (unlike a per-request shrink).
-	//
-	// `.noscan_data` only exists on V after the 0.5.1 release (it also needs the
-	// vlang/v#27468 codegen fix, shipped in #27470). The default branch below
-	// references it, so the library now requires a post-0.5.1 toolchain by default —
-	// the pinned/recommended V already satisfies this. To build on an older V, pass
-	// `-d vanilla_legacy_gc` (the `$if` branch is comptime-eliminated and not
-	// type-checked when the flag is set, so 0.5.1 still compiles).
-	$if vanilla_legacy_gc ? {
-		// legacy toolchain: leave the buffers scanned (no `.noscan_data`).
-	} $else {
-		unsafe {
-			c.read_buf.flags.set(.noscan_data)
-			c.response_buffer.flags.set(.noscan_data)
-		}
-	}
+	// No manual `.noscan_data` here, on purpose. read_buf/response_buffer are `[]u8`
+	// (pointer-free), so under the default GC the compiler picks the no-scan array
+	// constructor (`__new_array_with_default_noscan`, gated on `gcboehm_opt`, which
+	// `-prod`/`-gc boehm` enable by default), which sets `.noscan_data`; the flag is
+	// preserved across `grow_cap`, so the buffers are no-scan automatically and stay
+	// no-scan as they grow to hold a large response/upload (since vlang/v 23d47695e,
+	// 2026-04). A manual `flags.set(.noscan_data)` would be a no-op in EVERY mode: with
+	// `gcboehm_opt` on the constructor already set it; with it off `alloc_array_data_like`
+	// gates its no-scan branch behind `$if gcboehm_opt ?` and ignores the flag entirely;
+	// under `-gc none` there is no GC. (PR #59's default-on flag — supposedly fixing the
+	// io_uring static/upload high-conn collapse — was therefore inert; that collapse is
+	// not GC scanning and is still under investigation. PR #60 removed it.)
 	return c
 }
 


### PR DESCRIPTION
## Corrects #59 (which I got wrong) — removes a dead flag

#59 flipped the per-connection-buffer `.noscan_data` flag to **default-on**, claiming it fixes the io_uring `static`/`upload` high-connection-count collapse. That flag is actually a **no-op in every build mode**, so this PR removes it.

### Why the flag does nothing
`read_buf`/`response_buffer` are `[]u8` (pointer-free). With the default GC the compiler already selects the no-scan array constructor `__new_array_with_default_noscan` (gated on `gcboehm_opt`, which `-prod`/`-gc boehm` enable by default); it sets `.noscan_data`, and the flag is **preserved across `grow_cap`**. So the buffers are no-scan automatically — and stay no-scan as they grow to a 300 KiB static asset or an upload body — since vlang/v `23d47695e` (2026-04).

A manual `flags.set(.noscan_data)` is therefore inert in all modes:
- **gcboehm_opt ON** → the constructor already set it (redundant).
- **gcboehm_opt OFF** → `alloc_array_data_like` gates its no-scan branch behind `$if gcboehm_opt ?` and ignores the flag entirely.
- **`-gc none`** → no GC at all.

Verified on a plain `v -prod`: `[]u8{cap:8192}` → `builtin____new_array_with_default_noscan(0, 8192, …)`.

### Consequences
1. **The `static`/`upload` collapse is NOT GC scanning** of these buffers (they were never scanned) — #59's diagnosis was wrong and its flag changed nothing. The collapse is still unexplained and needs profiling on the 64-core target (more likely the one-op-per-connection I/O model + large per-connection transfers than the GC).
2. Removing the flag also drops #59's accidental "post-0.5.1 V by default" requirement — no `.noscan_data` reference remains, so 0.5.1 builds again without a flag.

A comment is left in `pool_acquire` documenting *why* there is no manual noscan handling, so the no-op isn't re-introduced. Build-verified `-prod` on V `80e76cdad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
