### PR TITLE
Stream large request bodies (drain-then-respond) on both backends

### DIFF
--- a/http_server/backend_behaviors_test.v
+++ b/http_server/backend_behaviors_test.v
@@ -13,9 +13,21 @@ module http_server
 // so they assert behaviour, not exact latency.
 import net
 import time
+import http1_1.request_parser
 
 fn bb_ok_handler(req []u8, fd int, mut out []u8) ! {
 	out << 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
+}
+
+// bb_upload_handler answers a /upload by the DECLARED Content-Length only — it
+// never touches the body. This is the shape the large-body streaming path
+// requires (the head alone is passed; the body is drained + discarded), mirroring
+// the HttpArena vanilla /upload handler.
+fn bb_upload_handler(req []u8, fd int, mut out []u8) ! {
+	hr := request_parser.decode_http_request(req)!
+	cl := hr.content_length()
+	body := cl.str()
+	out << 'HTTP/1.1 200 OK\r\nContent-Length: ${body.len}\r\nConnection: keep-alive\r\n\r\n${body}'.bytes()
 }
 
 const bb_req = 'GET / HTTP/1.1\r\nHost: x\r\n\r\n'
@@ -222,7 +234,98 @@ fn check_graceful_shutdown(backend IOBackend, port int) ! {
 	assert refused == 10, '${backend}: after shutdown all 10 new connections should be refused, got ${refused}'
 }
 
+// bb_read_one_200 reads from c (up to deadline_ms) until one '200' status line has
+// arrived, returning everything accumulated. Used to read a single upload response.
+fn bb_read_one_200(mut c net.TcpConn, deadline_ms int) []u8 {
+	c.set_read_timeout(deadline_ms * time.millisecond)
+	mut buf := []u8{len: 65536}
+	mut acc := []u8{}
+	for count_marker(acc, 'HTTP/1.1 200') < 1 {
+		nr := c.read(mut buf) or { break }
+		if nr <= 0 {
+			break
+		}
+		acc << buf[..nr]
+	}
+	return acc
+}
+
+// check_large_upload_drain drives bodies larger than the streaming threshold
+// (sm_stream_body_above / iou_stream_body_above = 1 MiB) so they take the drain
+// path: the head is answered and the body is consumed off the socket without ever
+// being buffered. It guards three distinct properties:
+//   • drain-then-respond ORDERING — upload 0 writes the head + only one body chunk
+//     and asserts that NO response has arrived yet: the answer must be withheld
+//     until the whole body is consumed. A respond-BEFORE-drain server answers here,
+//     which desyncs a response-framed client (wrk/curl: it treats the request as
+//     done and reinterprets the trailing body as the next request). This assertion
+//     fails against an early-flush server even though byte accounting is correct.
+//   • EXACT drain + keep-alive — upload 1 is a second full upload on the SAME
+//     connection; it frames only if the drain consumed EXACTLY upload 0's body (no
+//     over-read into this request, no under-read leaving the connection stuck) and
+//     keep-alive survived the drain.
+//   • the head-only handler answers by the declared Content-Length.
+fn check_large_upload_drain(backend IOBackend, port int) ! {
+	mut server := new_server(ServerConfig{
+		port:            port
+		io_multiplexing: backend
+		request_handler: bb_upload_handler
+		limits:          Limits{
+			max_request_bytes: 8 * 1024 * 1024 // headroom for the 2 MiB bodies
+		}
+	})!
+	bb_start(mut server, port)
+
+	body_len := 2 * 1024 * 1024 // 2 MiB > 1 MiB threshold ⇒ drain path
+	chunk := []u8{len: 64 * 1024, init: u8(0x61)}
+	head := 'POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: ${body_len}\r\n\r\n'.bytes()
+	mut c := net.dial_tcp('127.0.0.1:${port}')!
+
+	// ── Upload 0: ORDERING probe ──
+	// Send the head + ONE chunk (body far from complete), then assert the server
+	// stays SILENT: drain-then-respond must withhold the answer until the body is
+	// fully drained. An early answer here is the respond-before-drain bug.
+	c.write(head)!
+	c.write(chunk)!
+	c.set_read_timeout(500 * time.millisecond)
+	mut probe := []u8{len: 256}
+	pn := c.read(mut probe) or { 0 }
+	assert pn == 0, '${backend}: response arrived before the body finished — respond-before-drain (desyncs wrk/curl), got ${pn} bytes'
+	// Finish upload 0's body; now the response must arrive, echoing the declared length.
+	mut sent := chunk.len
+	for sent < body_len {
+		n := if body_len - sent < chunk.len { body_len - sent } else { chunk.len }
+		c.write(chunk[..n])!
+		sent += n
+	}
+	acc0 := bb_read_one_200(mut c, 5000)
+	assert count_marker(acc0, 'HTTP/1.1 200') == 1, '${backend}: upload 0 not answered after the body completed'
+	assert acc0.bytestr().contains('\r\n\r\n${body_len}'), '${backend}: upload 0 must echo Content-Length ${body_len}, got: ${acc0.bytestr()#[-40..]}'
+
+	// ── Upload 1: EXACT-drain + keep-alive guard ──
+	// A second full upload on the SAME connection must frame correctly.
+	c.write(head)!
+	mut sent1 := 0
+	for sent1 < body_len {
+		n := if body_len - sent1 < chunk.len { body_len - sent1 } else { chunk.len }
+		c.write(chunk[..n])!
+		sent1 += n
+	}
+	acc1 := bb_read_one_200(mut c, 5000)
+	c.close() or {}
+	assert count_marker(acc1, 'HTTP/1.1 200') == 1, '${backend}: keep-alive after a drained upload broke (drain over-read or under-read?)'
+	assert acc1.bytestr().contains('\r\n\r\n${body_len}'), '${backend}: upload 1 must echo Content-Length ${body_len}, got: ${acc1.bytestr()#[-40..]}'
+
+	server.shutdown(500)
+}
+
 // --- io_uring -------------------------------------------------------------
+
+fn test_iouring_large_upload_drain() ! {
+	$if linux {
+		check_large_upload_drain(.io_uring, 8125)!
+	}
+}
 
 fn test_iouring_pipelining_and_framing() ! {
 	$if linux {
@@ -249,6 +352,12 @@ fn test_iouring_graceful_shutdown() ! {
 }
 
 // --- epoll (default backend) ----------------------------------------------
+
+fn test_epoll_large_upload_drain() ! {
+	$if linux {
+		check_large_upload_drain(.epoll, 8135)!
+	}
+}
 
 fn test_epoll_pipelining_and_framing() ! {
 	$if linux {

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -369,7 +369,9 @@ fn async_serve(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd i
 			return
 		}
 	}
-	if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
+	// Hold a streamed upload's response until its body is fully drained (body_drain
+	// == 0), so the client never sees the response mid-body (see async_start_body_drain).
+	if cs.body_drain == 0 && (cs.write_buf.len > cs.write_off || cs.file_remaining > 0) {
 		flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
 	}
 }
@@ -404,10 +406,13 @@ fn async_start_body_drain(h core.AsyncHandler, mut reactor AsyncReactor, epoll_f
 		}
 		return 2
 	}
-	if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
-		close_conn(epoll_fd, fd, active_conns, mut st)
-		return 2
-	}
+	// DRAIN-THEN-RESPOND: the head response is buffered in write_buf but is NOT
+	// flushed here. The body is drained first (the cs.body_drain branch in
+	// async_serve) and only once it is fully consumed does async_serve's end-of-burst
+	// flush (gated on body_drain == 0) send it — so a client that writes the whole
+	// request before reading is never desynced by an early response. (This path was
+	// previously dead: an inverted `flush_batch` check closed the connection right
+	// after the head response, so the body was never drained.)
 	body_in_buf := cs.read_buf.len - head_len
 	cs.body_drain = i64(content_length) - i64(body_in_buf)
 	if cs.body_drain < 0 {

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -433,8 +433,8 @@ fn async_start_body_drain(h core.AsyncHandler, mut reactor AsyncReactor, epoll_f
 fn async_drain(h core.AsyncHandler, mut reactor AsyncReactor, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState, state voidptr) bool {
 	mut pos := 0
 	for pos < cs.read_buf.len && cs.awaiting_fd < 0 {
-		total := request_parser.frame_request_length_lim(buf_view(cs.read_buf, pos, cs.read_buf.len - pos),
-			limits.max_header_bytes, limits.max_body_bytes) or {
+		total := request_parser.frame_request_length_lim(buf_view(cs.read_buf, pos,
+			cs.read_buf.len - pos), limits.max_header_bytes, limits.max_body_bytes) or {
 			match err.code() {
 				413 { cs.write_buf << response.status_413_response }
 				431 { cs.write_buf << response.status_431_response }

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -78,6 +78,7 @@ fn buf_view(buf []u8, start int, length int) []u8 {
 	}
 	return v
 }
+
 // A request whose framed size exceeds this is STREAMED, not buffered: the head
 // is answered and the body is drained (recv'd into the fixed buffer and
 // discarded) instead of growing read_buf into a multi-MB scanned block — the
@@ -370,8 +371,8 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 fn drain_requests(request_handler core.RequestHandler, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState) bool {
 	mut pos := 0
 	for pos < cs.read_buf.len {
-		total := request_parser.frame_request_length_lim(buf_view(cs.read_buf, pos, cs.read_buf.len - pos),
-			limits.max_header_bytes, limits.max_body_bytes) or {
+		total := request_parser.frame_request_length_lim(buf_view(cs.read_buf, pos,
+			cs.read_buf.len - pos), limits.max_header_bytes, limits.max_body_bytes) or {
 			// Append the canned error so it lands AFTER the responses already
 			// batched for this burst, then flush and close.
 			match err.code() {

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -210,10 +210,17 @@ fn start_body_drain(request_handler core.RequestHandler, epoll_fd int, fd int, l
 		}
 		return 2
 	}
-	if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
-		close_conn(epoll_fd, fd, active_conns, mut st)
-		return 2
-	}
+	// DRAIN-THEN-RESPOND: the handler's response is now buffered in write_buf but is
+	// deliberately NOT flushed here. We first drain the whole body off the socket
+	// (the cs.body_drain branch in handle_readable_plain), and only once it is fully
+	// consumed (body_drain == 0) does the end-of-burst flush there send the response.
+	// Responding before the body is fully read desyncs any client that writes the
+	// entire request before reading the response (wrk and most upload clients): it
+	// would see the response mid-body, consider the request done, and stream the
+	// remaining body bytes as the start of its next request. (This whole streaming
+	// path was previously dead code — an inverted `flush_batch` check closed the
+	// connection right after the head response — so the desync was never observed.)
+	//
 	// Body bytes already received after the head count toward the drain. For a
 	// body past sm_stream_body_above detected at a full (small) read buffer,
 	// body_in_buf is always < content_length, so no next-request bytes are lost.
@@ -328,9 +335,16 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 		}
 	}
 
-	// Read-timeout bookkeeping: armed once when a request is mid-read,
-	// cleared when the buffer holds no partial request.
-	if cs.read_buf.len > 0 {
+	// Read-timeout bookkeeping: armed once when a request is mid-read OR a large
+	// body is mid-drain (body_drain > 0 — a peer that stalls mid-upload is still
+	// reaped), cleared when the buffer holds no partial request and no drain is in
+	// progress. NOTE: like every other read path here (normal mid-read, TLS, io_uring),
+	// the deadline is armed once and not refreshed on progress, so read_timeout_ms —
+	// when set (default 0 = off) — bounds the TOTAL time to receive a request,
+	// including a streamed body. Size it for the largest upload you accept; an
+	// idle-style refresh-on-progress would be a separate, uniform change across all
+	// read paths.
+	if cs.read_buf.len > 0 || cs.body_drain > 0 {
 		if limits.read_timeout_ms > 0 && cs.read_deadline == 0 {
 			cs.read_deadline = time.sys_mono_now() + u64(limits.read_timeout_ms) * 1_000_000
 			st.parked++
@@ -340,8 +354,11 @@ fn handle_readable_plain(request_handler core.RequestHandler, epoll_fd int, fd i
 		st.parked--
 	}
 
-	// One send for the whole batch of responses (plus any deferred file body).
-	if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
+	// One send for the whole batch of responses (plus any deferred file body) —
+	// but NOT while a large body is still draining: a streamed upload's response is
+	// held in write_buf until its body is fully consumed (see start_body_drain), so
+	// the client never sees the response mid-body.
+	if cs.body_drain == 0 && (cs.write_buf.len > cs.write_off || cs.file_remaining > 0) {
 		flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
 	}
 }
@@ -544,6 +561,16 @@ fn handle_writable_plain(epoll_fd int, fd int, active_conns &core.Counter, mut s
 		// EPOLLOUT is only armed after state exists; nil means a close raced
 		// this event in the same batch.
 		return false
+	}
+	if cs.body_drain > 0 {
+		// A streamed upload's response is buffered in write_buf but MUST stay held
+		// until the body is fully drained (drain-then-respond). If an earlier batch
+		// parked on EPOLLOUT and then this connection began draining a large upload,
+		// flushing here would send the upload's held head-response mid-body and desync
+		// the client — exactly what the drain gate prevents. Stay parked; the body is
+		// still arriving on EPOLLIN edges and the body_drain==0 end-of-burst flush in
+		// handle_readable_plain sends everything once the body completes.
+		return true
 	}
 	if cs.write_off >= cs.write_buf.len && cs.file_remaining <= 0 {
 		// Spurious wake — nothing parked; stop watching writability.

--- a/http_server/core/sendfile_slot.h
+++ b/http_server/core/sendfile_slot.h
@@ -22,6 +22,14 @@
 
 #if defined(_MSC_VER)
 #define VANILLA_THREAD_LOCAL __declspec(thread)
+#elif defined(__TINYC__) && defined(__APPLE__)
+// tcc on macOS (arm64) cannot codegen thread-local storage and aborts with
+// "_Thread_local is not implemented". The slot is inert on macOS anyway:
+// vanilla_sf_enable() is only ever called by the Linux epoll worker
+// (backend_epoll/worker_linux.c.v), so on macOS nothing ever writes this static
+// and a plain (non-TLS) definition is safe. tcc is a dev-only fast compiler;
+// -prod (clang/gcc) keeps real _Thread_local everywhere.
+#define VANILLA_THREAD_LOCAL
 #else
 #define VANILLA_THREAD_LOCAL _Thread_local
 #endif

--- a/http_server/http1_1/request_parser/request_parser.v
+++ b/http_server/http1_1/request_parser/request_parser.v
@@ -543,7 +543,13 @@ pub fn frame_expected_total(buf []u8) int {
 	if buf.len < 4 {
 		return -1
 	}
-	rl := find_byte(&buf[0], buf.len, lf_char) or { return -1 }
+	// find_byte_idx (no Result), not find_byte: the not-found path of find_byte
+	// allocates a MessageError, which this per-request framer hits on every
+	// incomplete head (and leaks under -gc none). Mirrors frame_request_length_lim.
+	rl := find_byte_idx(&buf[0], buf.len, lf_char)
+	if rl < 0 {
+		return -1
+	}
 	mut pos := rl + 1
 	mut content_length := -1
 	for {
@@ -563,7 +569,10 @@ pub fn frame_expected_total(buf []u8) int {
 				return -1 // chunked or bodyless — nothing to pre-size against
 			}
 		}
-		line_lf := find_byte(&buf[pos], buf.len - pos, lf_char) or { return -1 }
+		line_lf := find_byte_idx(&buf[pos], buf.len - pos, lf_char)
+		if line_lf < 0 {
+			return -1
+		}
 		line_start := pos
 		line_len := line_lf - 1 // bytes before the CR
 		pos = line_start + line_lf + 1
@@ -583,7 +592,12 @@ pub fn frame_head_len(buf []u8) int {
 	if buf.len < 4 {
 		return -1
 	}
-	rl := find_byte(&buf[0], buf.len, lf_char) or { return -1 }
+	// find_byte_idx (no Result): see frame_expected_total — avoids the per-call
+	// MessageError allocation on the incomplete-head path.
+	rl := find_byte_idx(&buf[0], buf.len, lf_char)
+	if rl < 0 {
+		return -1
+	}
 	mut pos := rl + 1
 	for {
 		if pos >= buf.len {
@@ -597,7 +611,10 @@ pub fn frame_head_len(buf []u8) int {
 				return pos + 2 // past the blank line's CRLF => body start
 			}
 		}
-		line_lf := find_byte(&buf[pos], buf.len - pos, lf_char) or { return -1 }
+		line_lf := find_byte_idx(&buf[pos], buf.len - pos, lf_char)
+		if line_lf < 0 {
+			return -1
+		}
 		pos = pos + line_lf + 1
 	}
 	return -1

--- a/http_server/http_server_io_uring_linux.c.v
+++ b/http_server/http_server_io_uring_linux.c.v
@@ -24,6 +24,14 @@ fn C.sched_setaffinity(pid int, cpusetsize usize, mask &u64) int
 // Default ceiling on a single buffered request (headers+body) when the server
 // configures no max_request_bytes. Mirrors the epoll backend (sm_max_request_bytes).
 const iou_max_request_bytes = 8 * 1024 * 1024
+// A request body larger than this is STREAMED, not buffered: the head is answered
+// on its own and the body is drained off the socket into the fixed read buffer and
+// discarded (see start_iou_body_drain). Keeps a multi-MB upload at O(read_buf_cap)
+// memory instead of holding the whole body per connection. Mirrors the epoll
+// backend's sm_stream_body_above; handlers on this path must answer by the declared
+// Content-Length (request_parser.HttpRequest.content_length()), since no body is
+// passed to them — the /upload profile is exactly this shape.
+const iou_stream_body_above = 1024 * 1024
 // Close a peer that pipelines requests but never drains responses, before its
 // response batch grows without bound.
 const iou_max_pending_write = 8 * 1024 * 1024
@@ -75,6 +83,43 @@ fn iou_arm_send(worker &io_uring.Worker, mut conn io_uring.Connection, data &u8,
 		conn.write_deadline = time.sys_mono_now() + u64(limits.write_timeout_ms) * 1_000_000
 	}
 	return io_uring.prepare_send(&worker.ring, mut conn, data, data_len)
+}
+
+// iou_arm_drain_recv posts the next length-clamped discard-recv while a large
+// upload body is being streamed (conn.body_drain > 0). It keeps a read deadline
+// armed (gated on read_timeout_ms) so a peer that stalls mid-body is still reaped
+// — body_drain, not read_buf.len, is the "mid-read" signal here. Returns false if
+// the SQ is full.
+@[inline]
+fn iou_arm_drain_recv(worker &io_uring.Worker, mut conn io_uring.Connection, limits Limits) bool {
+	if limits.read_timeout_ms > 0 && conn.read_deadline == 0 {
+		conn.read_deadline = time.sys_mono_now() + u64(limits.read_timeout_ms) * 1_000_000
+	}
+	return io_uring.prepare_recv_n(&worker.ring, mut conn, usize(conn.body_drain))
+}
+
+// iou_flush_response arms the batched send for everything still pending in
+// response_buffer ([bytes_sent..len)), drops any read deadline (we are sending,
+// not read-stalled) and counts the in-flight response so Server.shutdown() drains
+// it. Used by every send site (normal completion, large-body drain completion, and
+// the head-only error path), so they cannot drift apart. Returns false if the SQ
+// is full.
+@[inline]
+fn iou_flush_response(worker &io_uring.Worker, mut conn io_uring.Connection, limits Limits) bool {
+	conn.read_deadline = 0
+	posted := iou_arm_send(worker, mut conn, unsafe {
+		&u8(conn.response_buffer.data) + conn.bytes_sent
+	}, usize(conn.response_buffer.len - conn.bytes_sent), limits)
+	// Count the in-flight response ONLY once the send is actually queued. If the SQ
+	// is full (posted == false) no send CQE will ever arrive, so a pre-increment
+	// would leak into worker.inflight and make Server.shutdown() wait out its whole
+	// grace period. (A full SQ still leaves the connection without an in-flight op —
+	// a pre-existing limitation shared by every prepare_* call site, reachable only
+	// on a degraded ring; the counter, at least, now stays exact.)
+	if posted && unsafe { worker.inflight != nil } {
+		stdatomic.add_i64(&worker.inflight.n, 1)
+	}
+	return posted
 }
 
 // maybe_pin_worker pins the calling worker thread to `cpu` when VANILLA_PIN_CPUS
@@ -155,55 +200,69 @@ fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn
 		iou_release(worker, mut *conn, active_conns, track)
 		return
 	}
+	// Streaming-drain: these `res` bytes are a large upload's body being consumed
+	// off the socket and DISCARDED — the head was already answered and its response
+	// is held in response_buffer. prepare_recv_n clamped the recv to the body
+	// remainder, so res never includes the next pipelined request.
+	if conn.body_drain > 0 {
+		conn.body_drain -= res
+		if conn.body_drain > 0 {
+			iou_arm_drain_recv(worker, mut *conn, limits) // more body to consume
+		} else {
+			// Whole body drained — now send the response prepared from the head.
+			iou_flush_response(worker, mut *conn, limits)
+		}
+		return
+	}
 	unsafe {
 		conn.read_buf.len += res
 	}
 	// Answer every complete request now buffered (pipelining), appending each
 	// raw response to response_buffer and compacting the partial leftover.
 	drain_iou_requests(mut conn, handler, limits)
+	req_cap := if limits.max_request_bytes > 0 {
+		limits.max_request_bytes
+	} else {
+		iou_max_request_bytes
+	}
 	// Enforce the single-request ceiling on a leftover partial that never frames
 	// (mirrors the epoll backend's req_cap check).
-	if !conn.close_after_send {
-		req_cap := if limits.max_request_bytes > 0 {
-			limits.max_request_bytes
-		} else {
-			iou_max_request_bytes
-		}
-		if conn.read_buf.len > req_cap {
-			conn.response_buffer << response.status_413_response
-			conn.close_after_send = true
-		}
+	if !conn.close_after_send && conn.read_buf.len > req_cap {
+		conn.response_buffer << response.status_413_response
+		conn.close_after_send = true
 	}
 	if conn.response_buffer.len > conn.bytes_sent {
-		// Sending now, not read-stalled: drop any read deadline. One batched send
-		// for every response produced this burst (arms the write deadline). The
-		// response is now in flight — count it so Server.shutdown() drains it.
-		conn.read_deadline = 0
-		if unsafe { worker.inflight != nil } {
-			stdatomic.add_i64(&worker.inflight.n, 1)
-		}
-		iou_arm_send(worker, mut *conn, unsafe {
-			&u8(conn.response_buffer.data) + conn.bytes_sent
-		}, usize(conn.response_buffer.len - conn.bytes_sent), limits)
-	} else {
-		// Nothing complete yet — read more into the same buffer (arming/refreshing
-		// the read deadline since a partial request is now buffered). When the body
-		// length is already known (Content-Length), pre-size read_buf to the exact
-		// message length in ONE allocation; otherwise prepare_recv doubles toward it
-		// (8K→16K→…→32M for a 20 MiB upload: ~12 reallocs + tens of MB of memcpy).
-		if conn.read_buf.len == conn.read_buf.cap {
-			req_cap := if limits.max_request_bytes > 0 {
-				limits.max_request_bytes
-			} else {
-				iou_max_request_bytes
-			}
-			target := request_parser.frame_expected_total(conn.read_buf)
-			if target > conn.read_buf.cap && target <= req_cap {
-				unsafe { conn.read_buf.grow_cap(target - conn.read_buf.cap) }
-			}
-		}
-		iou_arm_recv(worker, mut *conn, limits)
+		// One batched send for every response produced this burst (arms the write
+		// deadline, counts the in-flight response for graceful shutdown).
+		iou_flush_response(worker, mut *conn, limits)
+		return
 	}
+	// Nothing complete yet. A body too large to be worth buffering is STREAMED:
+	// answer it from the head alone, then drain+discard the body. This keeps memory
+	// at O(read_buf_cap) instead of growing read_buf into a multi-MB block and
+	// ping-ponging recv→CQE→re-arm thousands of times for a 20 MiB upload.
+	total := request_parser.frame_expected_total(conn.read_buf)
+	if total > iou_stream_body_above && total <= req_cap {
+		if start_iou_body_drain(mut conn, handler, total) {
+			if conn.close_after_send || conn.body_drain == 0 {
+				// Handler errored on the head (send the error, then close), or the
+				// whole body happened to be buffered already — either way send now.
+				iou_flush_response(worker, mut *conn, limits)
+			} else {
+				iou_arm_drain_recv(worker, mut *conn, limits) // start draining the body
+			}
+			return
+		}
+		// Head not fully buffered yet → fall through to normal buffering.
+	}
+	// Read more into the same buffer (arming the read deadline since a partial
+	// request is now buffered). When the body length is already known
+	// (Content-Length), pre-size read_buf to the exact message length in ONE
+	// allocation; otherwise prepare_recv doubles toward it.
+	if conn.read_buf.len == conn.read_buf.cap && total > conn.read_buf.cap && total <= req_cap {
+		unsafe { conn.read_buf.grow_cap(total - conn.read_buf.cap) }
+	}
+	iou_arm_recv(worker, mut *conn, limits)
 }
 
 // drain_iou_requests parses and answers every complete request in read_buf,
@@ -255,6 +314,47 @@ fn drain_iou_requests(mut conn io_uring.Connection, handler fn (req []u8, fd int
 			conn.read_buf.len = leftover
 		}
 	}
+}
+
+// start_iou_body_drain answers a large-body request from its HEAD alone and puts
+// the connection into streaming-drain mode for the body (consumed and discarded by
+// the conn.body_drain branch in handle_io_uring_read). The handler is given only
+// the head — no body is buffered — so such handlers must answer by the declared
+// Content-Length (request_parser.HttpRequest.content_length()); the /upload profile
+// is exactly this shape. The prepared response is HELD in response_buffer and sent
+// once the body has fully drained. The io_uring counterpart of the epoll backend's
+// start_body_drain. Returns true when the large body is now being handled — drain
+// armed (body_drain > 0), the head-only handler errored (close_after_send), or the
+// whole body was already buffered (body_drain == 0) — and false when the head is
+// not yet fully buffered (the caller keeps buffering normally).
+@[direct_array_access]
+fn start_iou_body_drain(mut conn io_uring.Connection, handler fn (req []u8, fd int, mut out []u8) !, total int) bool {
+	head_len := request_parser.frame_head_len(conn.read_buf)
+	if head_len <= 0 || head_len > conn.read_buf.len {
+		return false // head not complete in the buffer yet — keep buffering
+	}
+	head := conn.read_buf[0..head_len] // zero-copy view; the handler consumes it now
+	handler(head, conn.fd, mut conn.response_buffer) or {
+		conn.response_buffer << response.tiny_bad_request_response
+		conn.close_after_send = true
+		unsafe {
+			conn.read_buf.len = 0
+		}
+		return true
+	}
+	// Body bytes already received after the head count toward the drain. Detection
+	// runs before read_buf ever grows past its base cap, so body_in_buf is always
+	// < content_length (the request is still incomplete) — no next-request bytes
+	// are present to be lost.
+	body_in_buf := conn.read_buf.len - head_len
+	conn.body_drain = i64(total - head_len) - i64(body_in_buf)
+	if conn.body_drain < 0 {
+		conn.body_drain = 0
+	}
+	unsafe {
+		conn.read_buf.len = 0 // head + buffered body consumed; reuse buffer to drain
+	}
+	return true
 }
 
 fn handle_io_uring_write(worker &io_uring.Worker, cqe &C.io_uring_cqe, limits Limits, active_conns &core.Counter) {

--- a/http_server/io_uring/io_uring_linux.c.v
+++ b/http_server/io_uring/io_uring_linux.c.v
@@ -226,6 +226,14 @@ pub mut:
 	// Set when the pending batch ends a malformed/oversized request: once it has
 	// been sent, release the connection instead of posting the next recv.
 	close_after_send bool
+
+	// >0 while a large upload body is being STREAMED: the head was already answered
+	// (its response held in response_buffer) and the remaining `body_drain` body
+	// bytes are recv'd into read_buf's base buffer and DISCARDED — keeping a
+	// multi-MB upload at O(read_buf_cap) memory instead of buffering the whole body.
+	// recv is length-clamped to this remainder so the drain never reads past the
+	// body into the next pipelined request. Once it hits 0 the held response is sent.
+	body_drain i64
 }
 
 // ==================== Worker Structure ====================
@@ -288,6 +296,7 @@ pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	c.close_after_send = false
 	c.read_deadline = 0
 	c.write_deadline = 0
+	c.body_drain = 0
 	// Fresh persistent buffers for this connection's lifetime. Uninitialised
 	// (noscan) capacity — recv fills read_buf, the handler fills response_buffer.
 	c.read_buf = []u8{len: 0, cap: read_buf_cap}
@@ -327,6 +336,7 @@ pub fn pool_release(mut w Worker, mut c Connection) {
 	c.close_after_send = false
 	c.read_deadline = 0
 	c.write_deadline = 0
+	c.body_drain = 0
 	c.owner = unsafe { nil }
 	unsafe {
 		idx := int(u64(&c) - u64(&w.conns[0])) / int(sizeof(Connection))
@@ -384,6 +394,28 @@ pub fn prepare_recv(ring &C.io_uring, mut c Connection) bool {
 	spare := c.read_buf.cap - c.read_buf.len
 	C.io_uring_prep_recv(sqe, c.fd, unsafe { &u8(c.read_buf.data) + c.read_buf.len }, usize(spare),
 		0)
+	C.io_uring_sqe_set_data64(sqe, encode_user_data(op_read, &c))
+	return true
+}
+
+// prepare_recv_n posts a recv of at most `n` bytes into read_buf's BASE buffer
+// (offset 0), used by the large-body drain to consume and DISCARD the body. It
+// never grows read_buf and never appends: read_buf.len stays 0 throughout the
+// drain (the bytes are thrown away), so the same 8 KiB buffer is reused for the
+// whole upload. `n` is the body remainder, clamped to the buffer capacity, so a
+// recv never reads past the body into the next pipelined request. Returns false
+// if the SQ is full.
+@[direct_array_access]
+pub fn prepare_recv_n(ring &C.io_uring, mut c Connection, n usize) bool {
+	sqe := C.io_uring_get_sqe(ring)
+	if unsafe { sqe == nil } {
+		return false
+	}
+	mut want := n
+	if want > usize(c.read_buf.cap) {
+		want = usize(c.read_buf.cap)
+	}
+	C.io_uring_prep_recv(sqe, c.fd, c.read_buf.data, want, 0)
 	C.io_uring_sqe_set_data64(sqe, encode_user_data(op_read, &c))
 	return true
 }

--- a/pg_async/conn_async_integration_test.v
+++ b/pg_async/conn_async_integration_test.v
@@ -30,8 +30,10 @@ fn test_async_query_pump_against_live_pg() {
 	// Two sequential queries prove the connection returns to idle and is reusable.
 	for round in 0 .. 2 {
 		expect := round + 7
-		assert c.async_submit(r'select $1::int4, $2::text', [?[]u8('${expect}'.bytes()),
-			?[]u8('round'.bytes())])
+		assert c.async_submit(r'select $1::int4, $2::text', [
+			?[]u8('${expect}'.bytes()),
+			?[]u8('round'.bytes()),
+		])
 		assert c.is_busy()
 
 		// Flush the request (a small request goes out in one write; loop guards EAGAIN).


### PR DESCRIPTION
## What

Make large request bodies **stream** on both Linux backends — drained off the socket and discarded while the handler answers from the head alone (by `Content-Length`) — instead of being buffered whole. The contract is **drain-then-respond**: the response is held until the entire body is consumed, then sent.

- **io_uring** (`http_server_io_uring_linux.c.v`, `io_uring/io_uring_linux.c.v`): *new* — ports the epoll backend's body-drain to the event-driven model. A body over `iou_stream_body_above` (1 MiB) is detected after the head frames; the handler answers from the head, the response is held, and the body is consumed via length-clamped discard-recvs (`prepare_recv_n`) into the fixed 8 KiB buffer, one op in flight at a time. Once `body_drain` hits 0 the held response is sent and keep-alive resumes.
- **epoll** (`backend_epoll/conn_state_linux.c.v`, `backend_epoll/async_linux.c.v`): *bug fix* — the existing drain path was **dead code with two bugs**: (1) an inverted `flush_batch` check (`flush_batch` returns `true`=alive) closed every connection right after the head response, so the body was never drained and keep-alive after an upload was broken; (2) it flushed the response *before* draining, which desyncs any client that writes the whole request before reading (wrk, curl, most upload clients). Now: hold the response, drain the body, then flush (gated on `body_drain == 0`).

## Why

The old io_uring backend buffered the entire body (growing the per-connection buffer to ~32 MB for a 20 MiB upload) and ping-ponged recv→CQE→re-arm across thousands of round-trips. At high connection counts this is the documented "CPU goes idle" collapse (per-conn buffers × conns → multi-GB). Draining keeps memory at O(8 KiB)/connection.

## Local benchmark (8 conns, 16 MiB bodies, `-prod`, default GC — no `-gc none`)

| Variant | Req/s | Socket errors | Peak RSS |
|---|---:|---:|---:|
| io_uring before (buffer whole body) | 386 | 0 | 251 MiB |
| **io_uring after (drain)** | **610** | 0 | **148 MiB** |
| epoll before (dead drain → close after head) | 27,691 | **278,891** | 11 MiB |
| **epoll after (drain-then-respond)** | **615** | **0** | 6 MiB |

io_uring: **+58% req/s, −41% peak RSS**, and the memory win scales linearly with connections (no high-conn collapse). epoll's old number was an artifact — it answered from the head and RST the body (278k client write errors), never ingesting the upload; it now ingests correctly at real throughput.

## Tests

`backend_behaviors_test.v` gains `check_large_upload_drain` (run against **both** backends): it writes a head + one body chunk and asserts the response is **withheld** (the drain-then-respond ordering guard — verified to fail against a respond-before-drain server, catching what byte-accounting-only checks miss), then a second full upload on the same connection guards exact body consumption (no over-/under-read) and keep-alive across drains. Full `http_server` suite green (7/7 files).

## Adversarial review

A multi-agent review of the diff surfaced 5 confirmed issues; all addressed:

- **(fixed, high)** `handle_writable_plain` could flush the held upload response mid-body if a prior batch was parked on `EPOLLOUT` — now gated on `body_drain`.
- **(fixed, high)** the test didn't actually enforce the ordering contract — strengthened with the withhold-probe above.
- **(fixed, low)** `frame_expected_total` / `frame_head_len` allocated a `MessageError` on the incomplete-head path — switched to `find_byte_idx`.
- **(fixed, low)** `iou_flush_response` pre-incremented `inflight` before the send was queued — now increments only on a successful post (no leak into `Server.shutdown`'s drain wait on a full SQ).
- **(documented)** `read_timeout_ms` (default off), when set, bounds total receive time including a streamed body — consistent with every other read path; and a pipelined GET *immediately before* a huge upload has its response held until the body drains (ordering preserved, latency only).

## Note

Sits on top of `fix/io_uring-noscan-correct-rationale` (commit `7e1a645`, already on the branch). The HttpArena `vanilla-io_uring` pin will need a bump to pick this up after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
