### PR TITLE
perf(io_uring): reuse per-connection buffers instead of free+remalloc (lock-free)

### DIFF
--- a/http_server/io_uring/io_uring_linux.c.v
+++ b/http_server/io_uring/io_uring_linux.c.v
@@ -297,10 +297,25 @@ pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	c.read_deadline = 0
 	c.write_deadline = 0
 	c.body_drain = 0
-	// Fresh persistent buffers for this connection's lifetime. Uninitialised
-	// (noscan) capacity — recv fills read_buf, the handler fills response_buffer.
-	c.read_buf = []u8{len: 0, cap: read_buf_cap}
-	c.response_buffer = []u8{len: 0, cap: write_buf_cap}
+	// Lock-free buffer REUSE: the per-worker pool is single-issuer (only this
+	// worker thread ever touches w.conns/free_stack), so a slot's buffers persist
+	// across connections with zero atomics. Reuse the pooled buffer (reset len,
+	// keep capacity); allocate only on a slot's first-ever use or after a release
+	// dropped an oversized buffer. This removes the per-connection 8K+16K
+	// malloc/free that showed up as 2 malloc + 2 free per connection under churn
+	// (the limited-conn tax), mirroring the epoll backend's free_conns pooling.
+	// Lazy (not pre-allocated in pool_init): pooled memory tracks the per-worker
+	// high-water concurrency, not max_conn_per_worker (which would be 768 MiB).
+	if unsafe { c.read_buf.data == nil } {
+		c.read_buf = []u8{len: 0, cap: read_buf_cap}
+	} else {
+		unsafe { c.read_buf.len = 0 }
+	}
+	if unsafe { c.response_buffer.data == nil } {
+		c.response_buffer = []u8{len: 0, cap: write_buf_cap}
+	} else {
+		unsafe { c.response_buffer.len = 0 }
+	}
 	// No manual `.noscan_data` here, on purpose. read_buf/response_buffer are `[]u8`
 	// (pointer-free), so under the default GC the compiler picks the no-scan array
 	// constructor (`__new_array_with_default_noscan`, gated on `gcboehm_opt`, which
@@ -326,12 +341,23 @@ pub fn pool_release(mut w Worker, mut c Connection) {
 		return
 	}
 	C.close(c.fd)
-	unsafe {
-		c.read_buf.free()
-		c.response_buffer.free()
+	// Keep base-sized buffers attached to the slot for lock-free reuse by the next
+	// connection that lands on it (see pool_acquire). Only release a buffer that
+	// GREW past its base capacity (a large upload/response grew it via grow_cap) so
+	// a one-off big request can't pin multi-MB on an otherwise idle pooled slot —
+	// pooled idle memory stays bounded at base (8K+16K) per high-water slot.
+	if c.read_buf.cap > read_buf_cap {
+		unsafe { c.read_buf.free() }
+		c.read_buf = []u8{}
+	} else {
+		unsafe { c.read_buf.len = 0 }
 	}
-	c.read_buf = []u8{}
-	c.response_buffer = []u8{}
+	if c.response_buffer.cap > write_buf_cap {
+		unsafe { c.response_buffer.free() }
+		c.response_buffer = []u8{}
+	} else {
+		unsafe { c.response_buffer.len = 0 }
+	}
 	c.bytes_sent = 0
 	c.close_after_send = false
 	c.read_deadline = 0


### PR DESCRIPTION
## What

The io_uring backend frees and re-allocates both per-connection buffers
(`read_buf` 8K + `response_buffer` 16K) on **every** connection: `pool_acquire`
mallocs them, `pool_release` `.free()`s them. Under connection churn (the
`limited-conn` profile — 10 requests then close) that is **2 malloc + 2 free per
connection**. The epoll backend doesn't: it keeps the buffers attached to its
pooled `ConnState` (`free_conns`) and reconnects at ~zero allocation.

This PR makes io_uring do the same: keep the buffers on the pooled `Connection`
slot, reset `len` and reuse on the next connection.

## Why it's lock-free

The connection pool is already per-worker and single-issuer
(`IORING_SETUP_SINGLE_ISSUER`; only the worker thread touches `w.conns` /
`free_stack`). Reusing the buffers adds **no shared state and no atomics** — the
lock-free property is preserved for free. Only the slot was being reused before;
now its buffers are too.

## Details

- **Lazy**, not pre-allocated: a slot allocates its buffers on first use only.
  Pre-allocating all `max_conn_per_worker` (32768) slots would be ~768 MiB/worker;
  lazy means pooled memory tracks per-worker high-water concurrency.
- **Bounded**: `pool_release` frees a buffer only if it GREW past its base cap
  (a large upload/response grew it via `grow_cap`), so a one-off big request can't
  pin multi-MB on an otherwise idle pooled slot.

## Measurements (local, AMD Ryzen 5800H, 16 logical cores)

Minimal server isolating the connection machinery (fixed response, no DB);
io_uring built `-prod` (Boehm GC, matching the entry) unless noted; custom churn
load generator; server and client pinned to disjoint physical cores.

**Per-connection allocation (gc-none, LD_PRELOAD malloc counter):**

| | malloc/conn | free/conn |
|---|---|---|
| before | 2.00 | 2.00 |
| after  | **0.00** | 0.00 |

**Throughput, interleaved A/B (3 rounds, kills CPU-freq drift):**

| profile | after / before |
|---|---|
| limited-conn (small-request churn) | **+8–9%** (reaches epoll parity) |
| keep-alive | unchanged |
| 256 KB response churn | parity (0.98 / 0.99 / 1.05) |
| 500 KB buffered upload churn | parity (1.02 / 1.04 / 0.93) |
| pipeline p=16 keep-alive | parity (798k vs 795k rps) |

The gain is isolated to the no-growth churn path (`limited-conn`); profiles where
buffers grow are freed by the guard on release, so they behave exactly as before.

**Correctness + memory (peak RSS):** `errors=0` across baseline / 256 KB response
/ 500 KB buffered upload / 2 MB streamed upload / pipeline p=16, hundreds of
thousands of connections each. Peak RSS bounded and never worse than before
(get-churn 124 → 67 MB; upload-2M 99 → 72 MB; big/upload-500K ~150 MB both —
RSS tracks concurrency, not total connections, confirming the grow-guard).

## Caveats / asks for review

- Measured on 16 cores; relative gain on the 64-core bench host may differ.
- Exercised at the library level (the patch is in the connection pool, which is
  handler-agnostic) via an extended harness for the upload/big/pipeline buffer-
  growth paths. Worth a run of the full real-profile suite (incl. DB profiles,
  which don't touch the buffer pool) in CI as the final gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
