### PR TITLE
docs: refresh perf docs, roadmap, and the http_server module README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,18 +264,18 @@ See [BENCHMARK_RESULTS_MACOS.md](BENCHMARK_RESULTS_MACOS.md) for full benchmark 
 
 ### vanilla — future improvements
 
-- [ ] Per-worker `SO_REUSEPORT` accept on epoll (eliminate the single shared accept thread; blocked by clean multi-server shutdown lifecycle)
+- [ ] Per-worker `SO_REUSEPORT` accept on epoll — eliminate the single central accept thread (the io_uring backend already does per-worker accept; epoll still round-robins fds from one acceptor). Blocked by clean multi-server shutdown lifecycle.
 - [ ] Dynamic route matching (`/user/:id`) with a trie or radix tree
 - [ ] Query-string parser (`?key=value&…`) as a zero-copy slice view
 - [ ] Case-insensitive header lookup (IANA registry compliance)
 - [ ] `Host` header validation (RFC 9112 §7.2)
-- [ ] Request timeouts (idle read / total request deadline)
-- [ ] Chunked transfer-encoding in the request parser
+- [x] Request timeouts — `Limits.read_timeout_ms` (408) / `write_timeout_ms`, enforced by the per-worker deadline sweep
+- [x] Chunked transfer-encoding in the request parser (`frame_chunked_total`)
 - [ ] HTTP/2 support (multiplexing, HPACK, server push)
 - [ ] WebSocket upgrade (framing, ping/pong, close handshake)
-- [ ] TLS/HTTPS — complete V TLS bindings and integrate into the backends
+- [x] TLS/HTTPS — epoll backend via `ServerConfig.tls_config` (e.g. `tls.new_self_signed()`); other backends are plaintext
 - [ ] HTTPS example (`examples/https/`)
-- [ ] Per-connection request-count limit and body-size cap exposed via `ServerConfig`
+- [x] Body-size cap + max-connections via `Limits` (`max_body_bytes` → 413, `max_request_bytes`, `max_connections`); a per-connection request-count limit is still open
 - [ ] Response caching layer (ETag + `Last-Modified` auto-generation)
 - [ ] Logging middleware example (`examples/logging/`)
 - [ ] API documentation (godoc-style, inline)

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -137,7 +137,8 @@ sb.write_string('Content-Length: ${body.len}\r\n')
 
 - Precompute fixed responses as `const`; reuse them.
 - Keep literal header text in plain string literals, not interpolated ones.
-- Use `write_decimal` (ints), `write_u8` (single bytes), `write_string` (literals).
+- Format ints with `strconv.write_dec`/`write_dec_u` (zero-alloc, into your `[]u8`)
+  or `Builder.write_decimal`; `write_u8` (single bytes), `write_string` (literals).
 - Seed the builder with `header_overhead + body.len`.
 - Always send an accurate `Content-Length` (or `Transfer-Encoding: chunked`).
 - Set `Connection: keep-alive` unless you intend to close.
@@ -145,7 +146,7 @@ sb.write_string('Content-Length: ${body.len}\r\n')
 **Don't**
 
 - Use `${}` to assemble response lines on the hot path.
-- Call `.str()` / `int.str()` just to concatenate — `write_decimal` avoids it.
+- Call `.str()` / `int.str()` just to concatenate — `strconv.write_dec` avoids it.
 - Forget the blank line (`\r\n\r\n`) between headers and body.
 - Compute the body twice (once for the length, once for the payload).
 
@@ -155,12 +156,17 @@ sb.write_string('Content-Length: ${body.len}\r\n')
 
 ---
 
-## 4. Allocate on the hot path with intent — under `-gc none`, not at all
+## 4. Allocate on the hot path with intent
 
-The production build is **`-prod -gc none`**: there is no garbage collector and
-**nothing is ever freed**. A per-request allocation is not "GC pressure" — it is
-a permanent **leak** that grows RSS linearly with traffic. So the hot paths must
-be *literally allocation-free*. See [V_PERF_TOOLBOX.md](V_PERF_TOOLBOX.md) and the
+The build mode differs by backend: **epoll ships `-prod -gc none`** — no garbage
+collector, **nothing is ever freed**, so a per-request allocation is not "GC
+pressure" but a permanent **leak** that grows RSS linearly with traffic; the hot
+path must be *literally allocation-free*. **io_uring ships `-prod`** with the
+default Boehm GC (per-request allocs are reclaimed). On the pinned V master the
+GC's allocation lock is gone (thread-local alloc), so default-GC allocation scales
+across cores — the alloc-free patterns below still matter (they cut GC
+**collection** pauses), and remain mandatory under `-gc none`. See
+[V_PERF_TOOLBOX.md](V_PERF_TOOLBOX.md) and the
 [wiki](https://github.com/enghitalo/vanilla/wiki/Memory-Management-under-gc-none).
 
 The recurring zero-allocation patterns:
@@ -177,10 +183,12 @@ The recurring zero-allocation patterns:
 - **Pool structs on a free-list** — reuse a heap object across requests, resetting
   its fields on release (the per-worker `ConnState` and per-request `Stash` pools
   do this), instead of `&T{}` per request.
-- **No error-boxing on the hot path** — `error()` allocates a `MessageError` even
-  when discarded by `or {}`; use a `-1`-returning "not found" (`find_byte_idx`).
-- **No empty/transient array literals** — `buf << [u8(0),0,0,0]` (and even `[]T{}`)
-  heap-allocate a temporary array; append the elements, or use a module `const`.
+- **No error-boxing on the hot path** — `error("msg")` allocates a `MessageError`;
+  on a hot `!T` "not found" return the cached `error_sentinel` (alloc-free, like
+  `none` for `?T`) or a plain-int twin (`find_byte_idx`, `frame_request_length_lim_idx`).
+- **No transient array literals** — `buf << [u8(0),0,0,0]` heap-allocates a
+  temporary array; append the elements or use a module `const`. (Empty `[]T{}` at
+  `len==0,cap==0` no longer allocates on the pinned V — that leak is fixed.)
 - **Sizing (default-GC builds only):** `[]u8{cap: n}` is uninitialized/noscan,
   `{len: n}` is zeroed, and a large `cap` is GC pressure. Under `-gc none` it is
   the *reuse* that matters, not the flag — a fresh buffer of any size leaks.

--- a/docs/PERF_GAP_ANALYSIS.md
+++ b/docs/PERF_GAP_ANALYSIS.md
@@ -15,8 +15,10 @@ narrative; the short version:
 1. **The arena build moved to `-prod -gc none` (no garbage collector).** A
    per-thread allocation microbenchmark showed the default Boehm GC's aggregate
    throughput *flat across cores* (16 cores ≈ 1 core; filed
-   [vlang/v#27488](https://github.com/vlang/v/issues/27488)), so a thread-per-core
-   server cannot let a shared GC gate allocation. The catch: under `-gc none`
+   [vlang/v#27488](https://github.com/vlang/v/issues/27488)) — that allocation
+   lock is **now fixed** by thread-local allocation (in the pinned V master), so
+   the default GC scales again. `-gc none`'s remaining edge is dodging
+   stop-the-world *collection* entirely + libc-visible `malloc`. The catch: under `-gc none`
    **nothing is ever freed**, so a per-request allocation is no longer "GC
    pressure" — it is a permanent **leak** that grows RSS without bound. The
    metric that matters becomes RSS growth *in excess of a Boehm build's* (the GC
@@ -64,8 +66,10 @@ profile's pathological realloc churn.
 
 The decisive lesson is **#5 (zero hot-path allocation)**. Per-request allocation
 is invisible on a laptop but **compounds catastrophically under V's Boehm GC at
-high core counts** — the GC's stop-the-world serializes all workers, so fewer
-cores do useful work. Removing per-request allocation let CPU utilisation (and
+high core counts** — the GC's stop-the-world *collection* pauses all workers, so
+fewer cores do useful work. (Allocation throughput itself now scales — thread-local
+alloc fixed the `GC_malloc` lock — but a high alloc rate still forces frequent
+collection.) Removing per-request allocation let CPU utilisation (and
 throughput) scale across all cores. Measured deltas (vanilla-epoll, the framework
 handler riding this lib):
 
@@ -114,9 +118,10 @@ bare-C/loopback ceiling here; local `wrk` has no more to give. Corollaries:
     confirm the generator isn't the bottleneck (give it more cores; if rps rises, it
     was generator-bound). A 12-server / 4-`wrk` split reads ~216k purely because
     4 `wrk` cores can't push more.
-  - Worker count must track *usable* cores (`core.worker_count()` via
-    `sched_getaffinity`), or a pinned/containerized run oversubscribes and the
-    number drops — see V_PERF_TOOLBOX's `nr_cpus` note.
+  - Worker count is `core.worker_count()` = `VANILLA_WORKERS` → `runtime.nr_cpus()`.
+    `nr_cpus()` is blind to `taskset`/cpuset, so set `VANILLA_WORKERS` on a pinned or
+    CPU-capped run (an affinity-aware auto-count was tried and reverted — it
+    under-sized the DB profiles).
 
 ## What ALL the fast servers have in common
 

--- a/docs/V_PERF_TOOLBOX.md
+++ b/docs/V_PERF_TOOLBOX.md
@@ -147,6 +147,14 @@ the Boehm floor. A **hard RSS cap** kills a runaway so it's safe unattended.
 start, so one-time bring-up (SCRAM/PBKDF2, lazy init) blurs the per-request
 signal. callgrind with post-warmup instrumentation is the disambiguator.
 
+**io_uring caveat:** valgrind/callgrind does **not** emulate io_uring — an
+io_uring server boots under callgrind but never serves (the ring delivers no
+completions, so `accept`/`recv` never fire and the client hangs). Profile the
+**epoll** backend under callgrind; the request-parsing / handler / response code is
+shared, so its per-request instruction counts carry over. For the io_uring-specific
+glue, read the source or use a tool that supports the ring. (perf works too but
+needs `perf_event_paranoid ≤ 2` / sudo.)
+
 ## V allocation gotchas (filed upstream — all fixed)
 
 Every gotcha below was filed upstream and is **fixed as of the pinned V master

--- a/http_server/README.md
+++ b/http_server/README.md
@@ -1,139 +1,97 @@
 # HTTP Server Module
 
-A high-performance, epoll-based HTTP server implementation for V.
+`http_server` is vanilla's core: a multi-threaded, non-blocking HTTP/1.1 server
+with pluggable I/O backends. Handlers are pure — `fn (req []u8, fd int, mut out
+[]u8) !` — they receive the raw request bytes and **append** the raw response to a
+server-owned buffer; the server batches everything appended during one readiness
+event into a single send and reuses the buffer across requests.
 
-## Architecture
+## Backends
 
-The module is organized into focused components:
+Selected via `ServerConfig.io_multiplexing` (`IOBackend`). One worker thread per
+core; per-connection read/response buffers are pooled, so the hot path does no
+per-request allocation.
 
-### Core Files
+| Platform | Backend | Accept model | Handlers supported |
+|---|---|---|---|
+| Linux | `.epoll` *(default)* | one central acceptor → round-robins fds to per-worker epolls | `request_handler`, `stateful_handler`, `async_handler`, TLS |
+| Linux | `.io_uring` | per-worker `SO_REUSEPORT` listener + multishot accept (kernel 5.19+) | `request_handler` (stateless) |
+| macOS | kqueue | per-worker | `request_handler`, `async_handler` |
+| Windows | IOCP | per-worker | `request_handler` |
 
-#### `http_server.c.v`
-Main orchestration and server lifecycle management.
+## Handler paths
 
-**Key Components:**
-- `Server` struct: Main server configuration and state
-- `run()`: Server initialization, thread pool setup, and accept loop
-- `handle_accept_loop()`: Non-blocking connection acceptance with round-robin load balancing
-- `process_events()`: Epoll event loop for client connections
-- `handle_readable_fd()`: Request reading, handler invocation, and response sending
+Provide **exactly one** of:
 
-**Threading Model:**
-- Main thread: Handles `accept()` via dedicated epoll instance
-- Worker threads: One per CPU core, each with its own epoll instance for client I/O
-- Round-robin distribution of accepted connections across worker threads
+- **`request_handler`** — `fn (req []u8, fd int, mut out []u8) !`, stateless. All backends.
+- **`stateful_handler` + `make_state`** — lock-free per-worker state (e.g. a DB
+  connection): `make_state` runs once per worker, then every request on that worker
+  is dispatched with it. Linux/epoll only.
+- **`async_handler` (+ optional `make_state`)** — may PARK a request on any fd via
+  `ac.watch(...)` and resume by a continuation in the worker loop (DB sockets,
+  upstreams, timers, `EPOLLOUT` backpressure). Linux/epoll + macOS/kqueue.
 
----
+`on_worker_start` arms clientless background watches (e.g. a periodic timerfd that
+refreshes per-worker state with no extra thread). Linux/epoll, plaintext only.
 
-#### `epoll.v`
-Low-level epoll abstractions for Linux I/O multiplexing.
-
-**Exports:**
-- `EpollEventCallbacks`: Callback interface for read/write events
-  - `on_read fn(fd int)`: Invoked when socket is readable
-  - `on_write fn(fd int)`: Invoked when socket is writable
-- `create_epoll_fd() int`: Creates new epoll instance
-- `add_fd_to_epoll(epoll_fd int, fd int, events u32) int`: Registers fd with events
-- `remove_fd_from_epoll(epoll_fd int, fd int)`: Unregisters fd
-
-**Event Flags:**
-- `C.EPOLLIN`: Socket readable
-- `C.EPOLLOUT`: Socket writable
-- `C.EPOLLET`: Edge-triggered mode
-- `C.EPOLLHUP | C.EPOLLERR`: Connection errors
-
----
-
-#### `socket.v`
-Socket creation, configuration, and lifecycle management.
-
-**Exports:**
-- `create_server_socket(port int) int`: Creates non-blocking TCP server socket
-  - Enables `SO_REUSEPORT` for multi-threaded accept
-  - Binds to `INADDR_ANY`
-  - Sets listen backlog to `max_connection_size`
-- `close_socket(fd int)`: Closes socket descriptor
-- `set_blocking(fd int, blocking bool)`: Configures socket blocking mode (internal)
-
-**Constants:**
-- `max_connection_size = 1024`: Listen queue size
-
----
-
-#### `request.v`
-HTTP request reading from client sockets.
-
-**Exports:**
-- `read_request(client_fd int) ![]u8`: Reads complete HTTP request
-  - Returns error if recv fails or client closes connection
-  - Handles partial reads in non-blocking mode
-  - 140-byte buffer chunks for efficient memory usage
-
-**Error Cases:**
-- `recv failed`: System error during read
-- `client closed connection`: EOF received
-- `empty request`: No data read
-
----
-
-#### `response.v`
-HTTP response transmission utilities.
-
-**Exports:**
-- `send_response(fd int, buffer_ptr &u8, buffer_len int) !`: Sends response buffer
-  - Uses `MSG_NOSIGNAL | MSG_ZEROCOPY` for performance
-  - Returns error on send failure
-- `send_bad_request_response(fd int)`: Sends HTTP 400 response
-- `send_status_444_response(fd int)`: Sends HTTP 444 (No Response)
-
-**Constants:**
-- `tiny_bad_request_response`: Minimal 400 response bytes
-- `status_444_response`: Nginx-style connection close signal
-
----
-
-## Usage Example
+## Minimal server
 
 ```v
-import http_server
+import vanilla.http_server
 
-fn my_handler(request []u8, client_fd int) ![]u8 {
-    // Parse request, generate response
-    return 'HTTP/1.1 200 OK\r\nContent-Length: 13\r\n\r\nHello, World!'.bytes()
+fn handle(req []u8, fd int, mut out []u8) ! {
+	out << 'HTTP/1.1 200 OK\r\nContent-Length: 13\r\nConnection: keep-alive\r\n\r\nHello, World!'.bytes()
 }
 
-mut server := http_server.Server{
-    port: 8080
-    request_handler: my_handler
+fn main() {
+	mut server := http_server.new_server(http_server.ServerConfig{
+		port:            8080
+		io_multiplexing: .epoll // or .io_uring on Linux
+		request_handler: handle
+	})!
+	server.run() // blocks
 }
-
-server.run() // Blocks until shutdown
 ```
 
-## Performance Characteristics
+`new_server(ServerConfig) !Server` validates the config (e.g. rejects more than one
+handler path, or a backend that doesn't support the chosen handler); `server.run()`
+spawns the workers and blocks; `server.shutdown(grace_ms int)` shuts the listeners
+and drains in-flight requests up to the grace period.
 
-- **Connection Handling**: O(1) epoll operations per event
-- **Memory**: 140-byte buffers per active read operation
-- **Concurrency**: N worker threads (N = CPU cores)
-- **Load Balancing**: Round-robin accept distribution
+## Request limits (`ServerConfig.limits`)
 
-## Platform Support
+`Limits` gates abusive requests at the framing/accept layer (0 = unlimited, zero-cost):
 
-- **Linux**: Full support via epoll
-- **Windows**: Not supported (use WSL)
-- **macOS**: Not supported (epoll unavailable)
+| field | effect |
+|---|---|
+| `max_header_bytes` | **431** once the header block exceeds it |
+| `max_body_bytes` | **413** from the declared `Content-Length`, before buffering the body |
+| `max_request_bytes` | ceiling on a single buffered request (headers + body) |
+| `max_connections` | refuse new connections past this many concurrent (checked at accept) |
+| `read_timeout_ms` | **408** + close a connection that can't finish its request in time |
+| `write_timeout_ms` | close a connection whose parked response can't drain in time |
 
-## Thread Safety
+## TLS
 
-- Each worker thread has isolated epoll instance
-- No shared mutable state between workers
-- Request handler must be thread-safe (receives immutable request slice)
+Set `ServerConfig.tls_config` (e.g. `tls.new_self_signed()`) and `certificates` for
+HTTPS on the **epoll** backend; the other backends are plaintext.
 
-## Error Handling
+## Internals (where to look)
 
-Connection errors trigger automatic cleanup:
-1. Remove fd from epoll
-2. Close socket
-3. Continue processing remaining events
+- `http_server.c.v` — `new_server`, `ServerConfig`, `Server`, `shutdown`.
+- `backend_epoll/` — epoll worker (`worker_linux.c.v`), connection state + buffer
+  pool (`conn_state_linux.c.v`), async reactor (`async_linux.c.v`), TLS
+  (`tls_conn_linux.c.v`).
+- `http_server_io_uring_linux.c.v` + `io_uring/` — the io_uring backend.
+- `http1_1/request_parser/` — request framing (`frame_request_length_lim`/`_idx`
+  with the non-marking `buf_view` window; chunked via `frame_chunked_total`).
+- `kqueue/`, `iocp/` — macOS / Windows backends.
 
-Request/response errors are logged but don't crash the server.
+## Performance
+
+Worker count = `VANILLA_WORKERS` env → `runtime.nr_cpus()` (set `VANILLA_WORKERS`
+inside a cpuset/CPU-capped container). The hot path is allocation-free (pooled
+per-connection buffers, zero-copy `buf_view` request windows, one batched send per
+readiness event). epoll ships `-prod -gc none`; io_uring ships `-prod` (default
+GC). See [../docs/V_PERF_TOOLBOX.md](../docs/V_PERF_TOOLBOX.md) and
+[../docs/BEST_PRACTICES.md](../docs/BEST_PRACTICES.md).


### PR DESCRIPTION
Second pass of the docs refresh (follow-up to #65). Corrects claims that the
recent work — #62/#63/#64, the V pin bump to `badd3466`, and the now-landed V
upstream fixes — made stale. Every change verified against the current code.

### `docs/PERF_GAP_ANALYSIS.md`
- The "default GC doesn't scale → that's why `-gc none`" rationale: the `GC_malloc`
  lock (#27488) is **fixed** by thread-local allocation, so the default GC scales.
  The zero-alloc lever still matters — but now via avoiding stop-the-world
  *collection*, not the alloc lock. Reframed, not deleted.
- `worker_count()` = `VANILLA_WORKERS → nr_cpus()` (the `sched_getaffinity`
  auto-count was reverted).
- **Kept** the single-acceptor / round-robin epoll gap — still open and accurate.

### `docs/BEST_PRACTICES.md`
- Build mode is **per-backend**: epoll `-gc none`, io_uring `-prod` (default GC).
- Int formatting → `strconv.write_dec` / `write_dec_u` (new stdlib, zero-alloc).
- Hot "not found" → `error_sentinel` (new, cached alloc-free `IError`).
- Empty `[]T{}` no longer allocates; GC-scaling note added.

### `docs/V_PERF_TOOLBOX.md`
- Added the **io_uring/valgrind caveat**: callgrind can't profile io_uring backends
  (the ring delivers no completions under valgrind) — profile epoll; the
  parse/handler/response code is shared.

### `README.md` roadmap
- Marked shipped: request timeouts (`Limits.read/write_timeout_ms` → 408), chunked
  TE (`frame_chunked_total`), TLS/HTTPS (epoll `tls_config`), body-size cap +
  max-connections (`Limits`). Clarified the per-worker `SO_REUSEPORT` epoll-accept
  item (io_uring already does it; epoll still has the single central acceptor).

### `http_server/README.md` — rewritten
It was from 2025-12 and described a single epoll-only server with **non-existent
modules** (`epoll.v`/`socket.v`/`request.v`/`response.v`), a **wrong handler
signature**, and direct `Server{}` construction. Now documents: both Linux backends
(epoll + io_uring) + kqueue/IOCP, the three handler paths and their per-backend
support, `new_server`/`run`/`shutdown`, `Limits`, TLS, and a correct minimal example.

Docs-only. Remaining `.md` not in scope here (mostly accurate or lower-traffic):
example READMEs, `CONTRIBUTING.md`, `CHECKLIST.md`, `pg_async/PIPELINING_DESIGN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
