### PR TITLE
bench: measurement harness + same-runner A/B CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,90 @@
+name: (Linux) Benchmark hot-path
+
+# Same-runner A/B of the hot-path micro-benchmarks. Two ways in:
+#
+#   * push to main (hot-path or bench files changed): measures the landed commit
+#     vs its parent on ONE runner and comments the delta on the PR that landed it.
+#   * manual: `gh workflow run bench.yml` — runs on demand even with no open PR
+#     (results go to the run's Job Summary). Optional inputs let you pin the V
+#     toolchain, so you can check whether a new V version shifts the numbers:
+#       gh workflow run bench.yml -f v_version=0.4.8
+#       gh workflow run bench.yml -f base_ref=main~5
+#     NOTE: a workflow is only dispatchable once this file is on the DEFAULT
+#     branch (GitHub requirement), i.e. after this PR merges.
+#
+# Why A/B and not absolute numbers: hosted runners are noisy and change hardware
+# every run, so an absolute time is not comparable across runs. Building both
+# sides in one job cancels the machine; the leftover is the change itself. See
+# bench/ci_bench.sh and docs/BEST_PRACTICES.md section 10.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'http_server/**'
+      - 'bench/**'
+      - '.github/workflows/bench.yml'
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Ref to A/B the current checkout against'
+        required: false
+        default: 'HEAD~1'
+      v_version:
+        description: 'V version for setup-v (blank = latest). Set to compare toolchains.'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  pull-requests: write   # to comment the delta on the merged PR
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: false   # let each landed commit finish its measurement
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: the A/B checks out a baseline ref (HEAD~1 by default, or
+          # an arbitrary ref on manual dispatch) in a worktree.
+          fetch-depth: 0
+      - name: Set up V
+        uses: vlang/setup-v@v1.4
+        with:
+          version: ${{ github.event.inputs.v_version }}   # empty on push -> latest
+      - name: Remove Vlang folder to avoid conflicts
+        shell: bash
+        run: |
+          rm -rf -v ./vlang || true
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev liburing-dev linux-libc-dev
+      - name: Same-runner A/B benchmark
+        shell: bash
+        env:
+          BENCH_RUNS: '5'
+          BASE_REF: ${{ github.event.inputs.base_ref || 'HEAD~1' }}
+        run: |
+          # Writes the Markdown report to the Job Summary (via ci_bench.sh) and to
+          # this file for the PR comment below.
+          bench/ci_bench.sh | tee /tmp/bench_comment.md
+      - name: Comment the delta on the PR that landed this commit
+        if: github.event_name == 'push'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+                 --jq '.[0].number' 2>/dev/null || true)
+          if [ -z "$pr" ] || [ "$pr" = "null" ]; then
+            echo "No PR is associated with ${{ github.sha }} (direct push?) — see the Job Summary."
+            exit 0
+          fi
+          gh pr comment "$pr" --body-file /tmp/bench_comment.md
+          echo "Commented benchmark delta on PR #$pr"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,18 @@ curl -X GET -v http://localhost:3000/user/1
 wrk  -H 'Connection: "keep-alive"' --connection 512 --threads 16 --duration 10s http://localhost:3000
 ```
 
+## Telling a real change from noise
+
+For hot-path functions, a controlled micro-benchmark beats a noisy `wrk` run.
+Build the bench with `-prod`, then drive it through `bench/measure.sh`, which pins
+a core, reports the environment, and reports the **minimum** across runs (see
+[docs/BEST_PRACTICES.md](docs/BEST_PRACTICES.md) §10):
+
+```sh
+v -prod -gc none -o /tmp/bench bench/request_parser/request_parser_bench.v
+bench/measure.sh /tmp/bench
+```
+
 ### Valgrind
 
 ```sh

--- a/bench/ci_bench.sh
+++ b/bench/ci_bench.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Same-runner A/B benchmark, for CI to comment on the PR that landed on main.
+#
+# Absolute benchmark numbers published over time are misleading: a hosted CI
+# runner is noisy and uses different hardware on every run, so a "slower" number
+# may just be a slower machine. The honest measurement is a SAME-RUNNER A/B —
+# build and measure both HEAD and its parent in one job on one machine — and
+# report the DELTA the landed commit introduced. Cross-machine variance cancels;
+# what's left is the change itself (still floored by the runner's own noise, so
+# treat a small delta as noise — see BENCH_THRESHOLD).
+#
+# Per build it reports the MINIMUM of N runs via bench/measure.sh (the minimum
+# rejects upward noise — see that script and BEST_PRACTICES.md section 10).
+#
+#   bench/ci_bench.sh                  # HEAD vs HEAD~1, default bench set
+#   BASE_REF=main BENCH_RUNS=7 bench/ci_bench.sh
+#
+# Emits a Markdown report to stdout (capture it for the PR comment) and, when
+# running under Actions, also to $GITHUB_STEP_SUMMARY.
+
+set -uo pipefail
+
+# Match measure.sh: a C numeric locale so the dot-decimals it prints parse back
+# cleanly through printf/awk here (a comma locale otherwise rejects "0.764").
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 2
+
+BASE_REF="${BASE_REF:-HEAD~1}"
+THRESHOLD="${BENCH_THRESHOLD:-5}"      # |Δ%| below this is reported as noise, not a change
+export BENCH_RUNS="${BENCH_RUNS:-5}"   # passed through to measure.sh
+
+# Hot-path micro-benches to A/B. name|path — each built with -prod -gc none.
+BENCHES=(
+	"request_parser|bench/request_parser/request_parser_bench.v"
+	"static_assets|bench/static_assets/static_assets_bench.v"
+	"middleware|bench/middleware/middleware_bench.v"
+	"etag_hash|bench/etag_hash/etag_hash.v"
+)
+
+# Always measure with HEAD's measure.sh (one methodology for both sides), even
+# when the baseline ref predates it.
+MEASURE="$ROOT/bench/measure.sh"
+
+bins="$(mktemp -d)"
+wt="$(mktemp -d)"
+cleanup() {
+	git worktree remove --force "$wt" >/dev/null 2>&1 || true
+	rm -rf "$wt" "$bins"
+}
+trap cleanup EXIT
+
+head_sha="$(git rev-parse --short HEAD)"
+base_sha="$(git rev-parse --short "$BASE_REF" 2>/dev/null || echo 'unknown')"
+
+# Stale objects are the classic cause of an "absurd" delta — wipe once up front.
+v wipe-cache >/dev/null 2>&1 || true
+
+# Isolated checkout of the baseline; the main worktree is untouched.
+worktree_ok=1
+git worktree add --detach "$wt" "$BASE_REF" >/dev/null 2>&1 || worktree_ok=0
+
+# build_and_measure <checkout-dir> <bench-relpath> <out-bin> -> min seconds (or "")
+build_and_measure() {
+	local dir="$1" src="$2" bin="$3"
+	if ! ( cd "$dir" && v -prod -gc none -o "$bin" "$src" ) >/dev/null 2>&1; then
+		echo ""   # bench absent at this ref, or build failed
+		return
+	fi
+	BENCH_PERF=0 "$MEASURE" "$bin" 2>/dev/null | awk '/^min/{print $3; exit}'
+}
+
+emit() {
+	printf '%s\n' "$*"
+	if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+		printf '%s\n' "$*" >> "$GITHUB_STEP_SUMMARY"
+	fi
+	return 0   # never let the summary-append status leak (Actions runs steps with -e)
+}
+
+# Hidden marker so a future run could find-and-update this comment instead of
+# stacking a new one.
+emit '<!-- vanilla-bench-bot -->'
+emit "## 📊 Benchmark delta — \`${head_sha}\` vs \`${base_sha}\`"
+emit ''
+if [ "$worktree_ok" -ne 1 ]; then
+	emit "⚠️ Could not check out baseline \`${BASE_REF}\` (shallow clone? need \`fetch-depth: 2\`). No comparison."
+	exit 0
+fi
+emit "Same-runner A/B on \`${RUNNER_OS:-local}\`, toolchain \`$(v version 2>/dev/null || echo 'V unknown')\`. Hosted runners are noisy — treat **|Δ| < ${THRESHOLD}%** as noise. Each side is the **minimum of ${BENCH_RUNS} runs** (\`bench/measure.sh\`)."
+emit ''
+emit '| bench | baseline | this commit | Δ | |'
+emit '|---|--:|--:|--:|:--|'
+
+regressions=0
+for entry in "${BENCHES[@]}"; do
+	IFS='|' read -r name src <<< "$entry"
+	base_min="$(build_and_measure "$wt"   "$src" "$bins/base_$name")"
+	head_min="$(build_and_measure "$ROOT" "$src" "$bins/head_$name")"
+
+	if [ -z "$head_min" ] && [ -z "$base_min" ]; then
+		emit "| \`$name\` | — | — | — | ❌ build failed both sides |"
+		continue
+	elif [ -z "$base_min" ]; then
+		emit "| \`$name\` | — | $(printf '%.3f' "$head_min")s | — | 🆕 new bench |"
+		continue
+	elif [ -z "$head_min" ]; then
+		emit "| \`$name\` | $(printf '%.3f' "$base_min")s | — | — | ❌ build failed (HEAD) |"
+		continue
+	fi
+
+	delta="$(awk -v h="$head_min" -v b="$base_min" 'BEGIN{ printf "%+.1f", (b>0)?((h-b)/b*100):0 }')"
+	# Classify numerically (an awk word), then map to display text — never inspect
+	# the emoji byte-wise.
+	flag="$(awk -v d="$delta" -v t="$THRESHOLD" 'BEGIN{ if (d>t) print "slow"; else if (d<-t) print "fast"; else print "noise" }')"
+	case "$flag" in
+		slow) status='⚠️ slower'; regressions=$((regressions + 1)) ;;
+		fast) status='✅ faster' ;;
+		*)    status='≈ noise' ;;
+	esac
+	emit "| \`$name\` | $(printf '%.3f' "$base_min")s | $(printf '%.3f' "$head_min")s | ${delta}% | $status |"
+done
+
+emit ''
+if [ "$regressions" -gt 0 ]; then
+	emit "**${regressions} possible regression(s) > ${THRESHOLD}%.** Confirm locally on a quiesced machine (\`governor=performance\`, turbo off) before trusting — see BEST_PRACTICES.md §10."
+else
+	emit "_No change beyond the ${THRESHOLD}% noise floor._"
+fi
+emit ''
+emit "<sub>min of ${BENCH_RUNS} core-pinned runs per build · generated by \`.github/workflows/bench.yml\`</sub>"
+
+# Measurement succeeded — report via the comment/summary, not the exit code. A
+# regression is surfaced in the table, never as a failed CI step (this runs
+# post-merge; failing it would block nothing and only add red noise).
+exit 0

--- a/bench/measure.sh
+++ b/bench/measure.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Controlled measurement harness — the discipline for telling a real change from
+# noise (MIT 6.172 Lecture 10, "Measurement and Timing").
+#
+# wrk.sh gates END-TO-END throughput. THIS script answers a different question:
+# "is the delta I just measured real, or is it the machine?" It does three things
+# wrk.sh does not:
+#
+#   1. Reports the ENVIRONMENT that shaped the numbers (governor, turbo, the
+#      pinned core's SMT sibling) so a pasted result is attributable — and warns,
+#      with the exact fix, when the environment is not quiesced.
+#   2. PINS the work to one core (taskset). A migrating process pays cold caches
+#      and cross-core scheduling jitter; a fixed core removes that variable.
+#   3. Runs the command N times and reports the MINIMUM (plus spread). The minimum
+#      is the right estimator: every source of noise on a real machine — an
+#      interrupt, a scheduler migration, a turbo step-down, a noisy neighbour —
+#      only ever makes a run SLOWER, never faster. So the fastest run is the one
+#      closest to the true cost; the mean just drags toward the noise. The spread
+#      is your noise floor: a delta smaller than the spread is not measurable here.
+#
+# Wrap a *prebuilt* micro-bench binary (NOT `v run`, which recompiles every call):
+#
+#   v -prod -gc none -o /tmp/rp bench/request_parser/request_parser_bench.v
+#   bench/measure.sh /tmp/rp                  # 7 runs -> min / median / spread
+#   BENCH_PERF=1 bench/measure.sh /tmp/rp     # + perf stat (cycles, IPC, misses)
+#   BENCH_RUNS=15 BENCH_CORE=7 bench/measure.sh /tmp/rp
+#
+# A/B a change: build the binary on `main`, measure; build on your branch,
+# measure; compare the MINIMUMS. If the delta is smaller than the spread%, the
+# environment is too noisy to trust it — quiesce further (the warnings tell you how).
+
+set -uo pipefail
+
+# Force a C numeric locale so EPOCHREALTIME, awk, and sort all agree on '.' as the
+# radix char. Without this, a comma-decimal locale + a non-locale-aware awk (mawk,
+# Ubuntu's default) silently truncates timings at the comma and the math is wrong.
+export LC_ALL=C
+
+RUNS="${BENCH_RUNS:-7}"
+CORE="${BENCH_CORE:-}"
+MAX_SPREAD="${BENCH_MAX_SPREAD:-3}"   # % over which a measured delta is untrustworthy
+
+[ "$#" -ge 1 ] || {
+	echo "usage: [BENCH_RUNS=N] [BENCH_CORE=n] [BENCH_PERF=1] $0 <command> [args...]" >&2
+	exit 2
+}
+
+# Default to the highest-numbered CPU — core 0 fields the most IRQs.
+[ -n "$CORE" ] || CORE=$(( $(nproc) - 1 ))
+
+read_sys() { [ -r "$1" ] && tr -d '\n' < "$1" 2>/dev/null; }
+
+# High-resolution wall clock. bash 5 has EPOCHREALTIME (microseconds); fall back
+# to date for older shells.
+if [ -n "${EPOCHREALTIME:-}" ]; then
+	now() { echo "$EPOCHREALTIME"; }
+else
+	now() { date +%s.%N; }
+fi
+
+echo "=== environment ==="
+printf 'cpu        : %s\n' "$(lscpu 2>/dev/null | awk -F: '/Model name/{gsub(/^ +/,"",$2);print $2;exit}')"
+printf 'kernel     : %s\n' "$(uname -r)"
+printf 'pinned core: %s\n'  "$CORE"
+
+gov=$(read_sys "/sys/devices/system/cpu/cpu${CORE}/cpufreq/scaling_governor")
+printf 'governor   : %s\n' "${gov:-unknown}"
+if [ -n "$gov" ] && [ "$gov" != performance ]; then
+	echo '             ^ WARN: not "performance" — frequency will drift between runs.'
+	echo '               fix: sudo cpupower frequency-set -g performance'
+fi
+
+if [ -r /sys/devices/system/cpu/intel_pstate/no_turbo ]; then
+	if [ "$(read_sys /sys/devices/system/cpu/intel_pstate/no_turbo)" = 1 ]; then
+		echo 'turbo      : off'
+	else
+		echo 'turbo      : ON'
+		echo '             ^ WARN: turbo makes early (cool) runs faster than later ones.'
+		echo '               fix: echo 1 | sudo tee /sys/devices/system/cpu/intel_pstate/no_turbo'
+	fi
+elif [ -r /sys/devices/system/cpu/cpufreq/boost ]; then
+	if [ "$(read_sys /sys/devices/system/cpu/cpufreq/boost)" = 0 ]; then
+		echo 'turbo      : off'
+	else
+		echo 'turbo      : ON'
+		echo '             ^ WARN: boost makes early (cool) runs faster than later ones.'
+		echo '               fix: echo 0 | sudo tee /sys/devices/system/cpu/cpufreq/boost'
+	fi
+else
+	echo 'turbo      : unknown'
+fi
+
+sib=$(read_sys "/sys/devices/system/cpu/cpu${CORE}/topology/thread_siblings_list")
+if [ -n "$sib" ] && [ "$sib" != "$CORE" ]; then
+	printf 'smt sibling: %s\n' "$sib"
+	echo '             ^ keep it idle, or pin to a core whose sibling is isolated.'
+fi
+
+# `v run` recompiles on every invocation — that compile time would land in the
+# measurement. Catch the common mistake.
+if [ "$1" = v ]; then
+	case " $* " in
+		*" run "*) echo 'WARN: "v run" recompiles each call — build once with "-o BIN" and pass BIN.' ;;
+	esac
+fi
+
+if command -v taskset >/dev/null; then
+	PIN=(taskset -c "$CORE")
+else
+	PIN=()
+	echo 'WARN: taskset not found — runs are NOT core-pinned (install util-linux).'
+fi
+
+echo
+echo "=== ${RUNS} runs (seconds, lower is better) ==="
+samples=$(mktemp)
+for i in $(seq 1 "$RUNS"); do
+	t0=$(now)
+	"${PIN[@]}" "$@" >/dev/null 2>&1
+	t1=$(now)
+	awk -v a="$t0" -v b="$t1" 'BEGIN{ printf "%.6f\n", b-a }' >> "$samples"
+	printf '  run %2d: %s\n' "$i" "$(tail -1 "$samples")"
+done
+
+sort -g "$samples" -o "$samples"
+min=$(head -1 "$samples")
+max=$(tail -1 "$samples")
+med=$(sed -n "$(( (RUNS + 1) / 2 ))p" "$samples")
+spread=$(awk -v mn="$min" -v mx="$max" 'BEGIN{ printf "%.1f", (mn>0)?((mx-mn)/mn*100):0 }')
+rm -f "$samples"
+
+echo
+echo "=== summary ==="
+printf 'min    : %s s   <-- report THIS for A/B comparisons\n' "$min"
+printf 'median : %s s\n' "$med"
+printf 'max    : %s s\n' "$max"
+printf 'spread : %s%%  (max-min)/min — your noise floor\n' "$spread"
+if awk -v s="$spread" -v m="$MAX_SPREAD" 'BEGIN{ exit !(s > m) }'; then
+	echo "WARN: spread > ${MAX_SPREAD}% — too noisy to trust a delta smaller than this."
+	echo "      quiesce: close apps, governor=performance, turbo off, pin to an isolated core."
+fi
+
+if [ "${BENCH_PERF:-0}" = 1 ]; then
+	echo
+	echo "=== perf stat -d (one extra pinned run) ==="
+	if command -v perf >/dev/null; then
+		# perf writes BOTH its counter table and any error to stderr; capture it so
+		# the user sees the reason on failure instead of an empty header.
+		perflog=$(mktemp)
+		"${PIN[@]}" perf stat -d "$@" >/dev/null 2>"$perflog" || true
+		cat "$perflog"
+		if grep -q perf_event_paranoid "$perflog"; then
+			echo
+			echo '      ^ counters blocked. fix: sudo sysctl kernel.perf_event_paranoid=1'
+			echo '        (or =-1 for full access; persist in /etc/sysctl.conf)'
+		fi
+		rm -f "$perflog"
+	else
+		echo 'perf not installed — sudo apt install linux-tools-$(uname -r)'
+	fi
+fi

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -325,6 +325,20 @@ Performance claims must be measured, not assumed.
   noisy — prefer A/B comparisons or a micro-benchmark.
 - Build with `-prod` for any timing run; build `-prod -gc none` to match
   production.
+- To tell a real change from machine noise, drive micro-benchmarks through
+  [`bench/measure.sh`](../bench/measure.sh). It pins the work to one core, prints
+  the environment that shaped the numbers (governor, turbo, SMT sibling) with the
+  exact fix when it isn't quiesced, and reports the **minimum** across N runs — not
+  the mean. The minimum is the right estimator: every source of noise (an
+  interrupt, a migration, a turbo step-down) only makes a run *slower*, so the
+  fastest run is closest to the true cost. The reported spread is your noise floor
+  — a delta smaller than the spread is not measurable on that machine.
+
+  ```sh
+  v -prod -gc none -o /tmp/bench bench/request_parser/request_parser_bench.v
+  bench/measure.sh /tmp/bench              # min / median / spread
+  BENCH_PERF=1 bench/measure.sh /tmp/bench # + perf stat (cycles, IPC, misses)
+  ```
 
   ```sh
   v -prod -gc none .


### PR DESCRIPTION
Closes the gap called out in `docs/BEST_PRACTICES.md` §10 ("don't report a single noisy run") with actual tooling — the discipline from MIT 6.172 Lecture 10, "Measurement and Timing".

## 1. `bench/measure.sh` — controlled local measurement

Tells a **real change from machine noise**. `wrk.sh` gates end-to-end throughput; this answers *"is the delta real or is it the machine?"*:

- **Reports the environment** (CPU governor, turbo/boost, the pinned core's SMT sibling) and prints the *exact fix* when it isn't quiesced.
- **Pins the work to one core** (`taskset`) — no migration/cold-cache jitter.
- **Runs N times, reports the MINIMUM** (plus spread), not the mean. Every source of noise only makes a run *slower*, so the fastest run is closest to the true cost. The spread is the noise floor — a delta smaller than it is not measurable on that machine.
- `BENCH_PERF=1` adds `perf stat -d`, with a clear hint when `perf_event_paranoid` blocks counters.

```sh
v -prod -gc none -o /tmp/bench bench/request_parser/request_parser_bench.v
bench/measure.sh /tmp/bench
BENCH_PERF=1 bench/measure.sh /tmp/bench
```

## 2. `bench/ci_bench.sh` + `.github/workflows/bench.yml` — same-runner A/B CI

Absolute benchmark numbers published over time are misleading: hosted runners are noisy and change hardware every run. So the CI does a **same-runner A/B** — builds and measures both `HEAD` and its parent in one job, reports the **delta the landed commit introduced** (cross-machine variance cancels). Each side is the minimum of N runs via `measure.sh`.

- **On push to `main`** (hot-path or bench files changed): measures and **comments the delta on the PR that landed the commit**.
- **Manual** (`gh workflow run bench.yml`): runs on demand with no open PR — results go to the run's **Job Summary**. Inputs `base_ref` and `v_version` let you pin the toolchain and check whether **a new V version shifts the numbers**.

The report records the V version, flags any bench moving more than the noise threshold, and never fails the step on a regression (post-merge, informational).

## Validation
- All four micro-benches A/B'd locally; deltas within noise (this PR touches no hot-path code).
- Caught and fixed: comma-locale number parsing, emoji byte-slice miscount, and a non-zero exit that would have failed the Actions step. `ci_bench.sh` exits 0 and writes the Job Summary correctly.
- Workflow YAML validated; `setup-v` empty-`version` confirmed equivalent to omitting it (latest).

## Files
- `bench/measure.sh`, `bench/ci_bench.sh` (new, executable)
- `.github/workflows/bench.yml` (new)
- `docs/BEST_PRACTICES.md` §10, `CONTRIBUTING.md` — pointers + rationale

No hot-path or runtime code touched; tooling + CI + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)