### PR TITLE
bench: standardize iteration count (BENCH_ITERS) + improve static_assets + load harness

### DIFF
--- a/bench/ci_bench.sh
+++ b/bench/ci_bench.sh
@@ -34,13 +34,20 @@ ISSUE_THRESHOLD="${BENCH_ISSUE_THRESHOLD:-10}" # a regression must clear THIS to
                                              # 5-10%) does not file issues on its own
 export BENCH_RUNS="${BENCH_RUNS:-5}"         # passed through to measure.sh
 
-# Hot-path micro-benches to A/B. name|path — each built with -prod -gc none.
+# Hot-path micro-benches to A/B. name | source — each built with -prod -gc none.
+# All run on every invocation; BENCH_ITERS (below) keeps the full set to a few
+# minutes in CI.
 BENCHES=(
 	"request_parser|bench/request_parser/request_parser_bench.v"
-	"static_assets|bench/static_assets/static_assets_bench.v"
 	"middleware|bench/middleware/middleware_bench.v"
 	"etag_hash|bench/etag_hash/etag_hash.v"
+	"static_assets|bench/static_assets/static_assets_bench.v"
 )
+# Standardize the loop count for the A/B: the benches read BENCH_ITERS. 2M keeps
+# even the cheapest bench (request_parser, ~0.3s) comfortably above the runner's
+# noise floor while a full run stays a few minutes; raise it if a bench's spread
+# is high on the runner. Unset (or run a bench directly) to use the 5M default.
+export BENCH_ITERS="${BENCH_ITERS:-2000000}"
 
 # Always measure with HEAD's measure.sh (one methodology for both sides), even
 # when the baseline ref predates it.
@@ -91,7 +98,7 @@ if [ "$worktree_ok" -ne 1 ]; then
 	emit "⚠️ Could not check out baseline \`${BASE_REF}\` (shallow clone? need \`fetch-depth: 2\`). No comparison."
 	exit 0
 fi
-emit "Same-runner A/B on \`${RUNNER_OS:-local}\`, toolchain \`$(v version 2>/dev/null || echo 'V unknown')\`. Hosted runners are noisy — treat **|Δ| < ${THRESHOLD}%** as noise. Each side is the **minimum of ${BENCH_RUNS} runs** (\`bench/measure.sh\`)."
+emit "Same-runner A/B on \`${RUNNER_OS:-local}\`, toolchain \`$(v version 2>/dev/null || echo 'V unknown')\`. Hosted runners are noisy — treat **|Δ| < ${THRESHOLD}%** as noise. Each side is the **minimum of ${BENCH_RUNS} runs** of ${BENCH_ITERS} iterations (\`bench/measure.sh\`)."
 emit ''
 emit '| bench | baseline | this commit | Δ | |'
 emit '|---|--:|--:|--:|:--|'

--- a/bench/etag_hash/etag_hash.v
+++ b/bench/etag_hash/etag_hash.v
@@ -1,8 +1,7 @@
 import benchmark
 import hash as wyhash
 import crypto.md5
-
-const intentions = 1_000_000
+import os
 
 // Precomputed u16 LUT: Each entry contains two ASCII hex characters.
 // Example: hex_lut_u16[0x0A] = u16(0x6130) which is '0a' in little-endian.
@@ -138,6 +137,11 @@ fn generate_md5_etag(content_ptr &u8, content_len int) []u8 {
 }
 
 fn main() {
+	// Loop count: BENCH_ITERS env if set (CI uses a smaller value for speed),
+	// else 5M for stable local numbers. See bench/ci_bench.sh.
+	env_iters := os.getenv('BENCH_ITERS').int()
+	iterations := if env_iters > 0 { env_iters } else { 5_000_000 }
+
 	buffer := 'The quick brown fox jumps over the lazy dog'.bytes()
 
 	// Verification
@@ -159,29 +163,29 @@ fn main() {
 
 	mut b_md5 := benchmark.start()
 
-	for _ in 0 .. intentions {
+	for _ in 0 .. iterations {
 		_ = generate_md5_etag(buffer.data, buffer.len)
 	}
 	b_md5.measure('generate_md5_etag (u16 chunked)')
-	for _ in 0 .. intentions {
+	for _ in 0 .. iterations {
 		_ = md5.sum(buffer).hex().bytes()
 	}
 	b_md5.measure('md5.sum().hex()')
 
 	mut b_wyhash := benchmark.start()
 
-	for _ in 0 .. intentions {
+	for _ in 0 .. iterations {
 		_ = generate_wyhash_etag(buffer.data, buffer.len)
 	}
 	b_wyhash.measure('generate_wyhash_etag (u16 chunked)')
 
-	for _ in 0 .. intentions {
+	for _ in 0 .. iterations {
 		_ = wyhash.wyhash_c(buffer.data, u64(buffer.len), 0).hex().bytes()
 	}
 	b_wyhash.measure('wyhash.wyhash_c().hex()')
 
 	mut b_validate := benchmark.start()
-	for _ in 0 .. intentions {
+	for _ in 0 .. iterations {
 		_ = validate_u64_to_hex(etag_wyhash_u64, etag_wyhash.data, etag_wyhash.len)
 	}
 	b_validate.measure('validate_u64_to_hex')

--- a/bench/load.sh
+++ b/bench/load.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Server-under-load memory + CPU harness — LOCAL only.
+#
+# Micro-benchmarks (measure.sh / ci_bench.sh) time a pure function's CPU cost.
+# They cannot see the two things that decide behaviour at scale:
+#   * how memory grows under sustained load — per-request allocation / GC
+#     pressure. BEST_PRACTICES.md section 10 wants the RSS slope FLAT under
+#     `-gc none`; a rising slope is a leak/retention.
+#   * how much CPU the server burns per request (its efficiency).
+# This boots a server, drives it with wrk, and samples /proc/<pid> throughout.
+#
+# When: after a change to allocation, buffering, or the concurrency model, or to
+# confirm RSS stays flat under -gc none — things the function-level micro-benches
+# (measure.sh / ci_bench.sh) can't see. NOT for hosted CI: a load test on a
+# shared, hardware-varying runner is too noisy to compare (the same reason
+# ci_bench.sh does a same-runner A/B instead). Run it on a quiesced machine.
+#
+#   bench/load.sh                                  # examples/simple, GET /, 15s
+#   DURATION=30 bench/load.sh examples/tiny/src / 3000
+#   GC=boehm bench/load.sh                         # compare default GC vs -gc none
+#
+# Reports req/s, peak RSS, RSS slope (start->end), CPU-seconds, CPU% (cores
+# busy), and CPU-ms per 1k requests.
+
+set -uo pipefail
+export LC_ALL=C
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 2
+
+SRC="${1:-examples/simple/src}"
+URL_PATH="${2:-/}"
+PORT="${3:-3000}"
+DURATION="${DURATION:-15}"
+THREADS="${THREADS:-8}"
+CONNS="${CONNS:-256}"
+GC="${GC:-none}"          # none = production (-gc none); boehm = default GC
+
+command -v wrk  >/dev/null || { echo "ERROR: wrk not installed";  exit 2; }
+command -v v    >/dev/null || { echo "ERROR: v not installed";    exit 2; }
+command -v curl >/dev/null || { echo "ERROR: curl not installed"; exit 2; }
+
+hz=$(getconf CLK_TCK)
+
+# /proc/<pid>/stat fields 14 (utime) + 15 (stime), summed over all threads of the
+# process. comm (field 2) may contain spaces, so strip up to ") " first; in the
+# remainder, state is $1, so utime is $12 and stime is $13.
+read_cpu_ticks() {
+	local stat rest
+	stat=$(cat "/proc/$1/stat" 2>/dev/null) || return 1
+	rest=${stat#*) }
+	# shellcheck disable=SC2086
+	set -- $rest
+	echo $(( ${12} + ${13} ))
+}
+
+gov=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo unknown)
+[ "$gov" = performance ] || echo "note: governor=$gov — set 'performance' for stable CPU% (RSS is robust regardless)."
+
+gcflag="-gc none"; [ "$GC" = boehm ] && gcflag=""
+bin=$(mktemp -u /tmp/loadsrv.XXXXXX)
+srvlog=$(mktemp)
+rssfile=$(mktemp)
+samplerpid=0
+srvpid=0
+cleanup() {
+	[ "$samplerpid" -ne 0 ] && kill "$samplerpid" 2>/dev/null
+	[ "$srvpid" -ne 0 ] && kill "$srvpid" 2>/dev/null
+	fuser -k "${PORT}/tcp" >/dev/null 2>&1
+	rm -f "$bin" "$srvlog" "$rssfile"
+}
+trap cleanup EXIT
+
+echo "=== load: ${SRC}  ${URL_PATH}  (v -prod ${gcflag:--gc=default}) ==="
+v wipe-cache >/dev/null 2>&1 || true
+# shellcheck disable=SC2086
+v -prod $gcflag -o "$bin" "$SRC" >/dev/null 2>&1 || { echo "ERROR: build failed"; exit 2; }
+
+fuser -k "${PORT}/tcp" >/dev/null 2>&1; sleep 0.3
+"$bin" >"$srvlog" 2>&1 &
+srvpid=$!
+
+ready=0
+for _ in $(seq 1 80); do
+	curl -s -o /dev/null --max-time 1 "http://localhost:${PORT}${URL_PATH}" && { ready=1; break; }
+	sleep 0.25
+done
+[ "$ready" = 1 ] || { echo "ERROR: server did not start:"; tail -5 "$srvlog"; exit 2; }
+
+# Background RSS sampler (kB), every 200 ms while the server lives.
+( while kill -0 "$srvpid" 2>/dev/null; do
+		awk '/^VmRSS:/{print $2}' "/proc/$srvpid/status" 2>/dev/null
+		sleep 0.2
+	done > "$rssfile" ) &
+samplerpid=$!
+
+cpu0=$(read_cpu_ticks "$srvpid")
+t0=$EPOCHREALTIME
+echo "running: wrk -t${THREADS} -c${CONNS} -d${DURATION}s ..."
+wrk_out=$(wrk -t"$THREADS" -c"$CONNS" -d"${DURATION}s" -H 'Connection: keep-alive' \
+	"http://localhost:${PORT}${URL_PATH}")
+t1=$EPOCHREALTIME
+cpu1=$(read_cpu_ticks "$srvpid")
+kill "$samplerpid" 2>/dev/null; samplerpid=0
+
+rps=$(echo "$wrk_out"   | awk '/Requests\/sec/{print $2}')
+total=$(echo "$wrk_out" | awk '/requests in/{print $1}')
+
+read -r rss_first rss_last rss_peak < <(awk '
+	NR==1{first=$1} {last=$1; if($1>peak)peak=$1} END{print first, last, peak}' "$rssfile")
+
+echo
+echo "=== summary ==="
+awk -v rps="${rps:-0}" -v total="${total:-0}" \
+	-v c0="$cpu0" -v c1="$cpu1" -v hz="$hz" -v t0="$t0" -v t1="$t1" \
+	-v rf="${rss_first:-0}" -v rl="${rss_last:-0}" -v rp="${rss_peak:-0}" 'BEGIN{
+	wall  = t1 - t0
+	cpus  = (c1 - c0) / hz
+	pct   = (wall>0) ? cpus/wall*100 : 0
+	cores = pct/100
+	effms = (total>0) ? cpus*1000.0/(total/1000.0) : 0
+	printf "throughput : %s req/s  (%s requests)\n", rps, total
+	printf "CPU        : %.2f cpu-s over %.2f s wall = %.0f%% (%.1f cores busy)\n", cpus, wall, pct, cores
+	printf "efficiency : %.3f cpu-ms / 1k req\n", effms
+	printf "memory RSS : start %.1f MB  peak %.1f MB  end %.1f MB  ->  slope %+.1f MB\n", \
+		rf/1024, rp/1024, rl/1024, (rl-rf)/1024
+}'
+if [ "$GC" = none ]; then
+	echo "             under -gc none the slope should be ~flat; growth = leak/retention (BEST_PRACTICES.md §10)."
+fi
+echo
+echo "$wrk_out" | sed 's/^/wrk | /'

--- a/bench/middleware/middleware_bench.v
+++ b/bench/middleware/middleware_bench.v
@@ -15,11 +15,10 @@ module main
 //
 // (Use -prod: the default debug build is not representative.)
 import benchmark
+import os
 import http_server.http1_1.request_parser
 
 fn C.memchr(buf voidptr, c int, n usize) voidptr
-
-const iterations = 5_000_000
 
 const raw_request = 'GET /users/42/posts?id=123&format=json HTTP/1.1\r\nHost: example.com\r\nUser-Agent: wrk/4.1\r\nAccept: application/json\r\nConnection: keep-alive\r\n\r\n'.bytes()
 
@@ -121,6 +120,11 @@ fn build_log_line(req_buffer []u8, resp []u8) int {
 }
 
 fn main() {
+	// Loop count: BENCH_ITERS env if set (CI uses a smaller value for speed),
+	// else 5M for stable local numbers. See bench/ci_bench.sh.
+	env_iters := os.getenv('BENCH_ITERS').int()
+	iterations := if env_iters > 0 { env_iters } else { 5_000_000 }
+
 	// Sanity-print once so we know both injectors produce the same result.
 	a := inject_headers(base_resp, headers).bytestr()
 	b := inject_headers_string(base_resp, headers_str).bytestr()

--- a/bench/request_parser/request_parser_bench.v
+++ b/bench/request_parser/request_parser_bench.v
@@ -11,9 +11,8 @@ module main
 //
 // (Use -prod: the default debug build is not representative.)
 import benchmark
+import os
 import http_server.http1_1.request_parser
-
-const iterations = 5_000_000
 
 // A realistic request: method + path with a query string + the headers a real
 // client sends. The Host header makes it valid HTTP/1.1.
@@ -22,6 +21,11 @@ const raw_request = ('GET /users/42/posts?id=123&format=json&page=2 HTTP/1.1\r\n
 	'Accept-Encoding: gzip, deflate\r\n' + 'Connection: keep-alive\r\n' + '\r\n').bytes()
 
 fn main() {
+	// Loop count: BENCH_ITERS env if set (CI uses a smaller value for speed),
+	// else 5M for stable local numbers. See bench/ci_bench.sh.
+	env_iters := os.getenv('BENCH_ITERS').int()
+	iterations := if env_iters > 0 { env_iters } else { 5_000_000 }
+
 	// Sanity-print once so we know we're measuring correct behavior.
 	req0 := request_parser.decode_http_request(raw_request) or { panic('decode: ${err}') }
 	println('path            = "${req0.path.to_string(req0.buffer)}"')

--- a/bench/static_assets/static_assets_bench.v
+++ b/bench/static_assets/static_assets_bench.v
@@ -15,8 +15,6 @@ import benchmark
 import os
 import http_server.static_assets
 
-const iterations = 5_000_000
-
 const bench_root = os.join_path(os.temp_dir(), 'vanilla_sa_bench')
 
 fn setup() static_assets.AssetServer {
@@ -50,6 +48,11 @@ fn r(line string) []u8 {
 
 fn main() {
 	s := setup()
+
+	// Loop count: BENCH_ITERS env if set (CI uses a smaller value for speed),
+	// else 5M for stable local numbers. See bench/ci_bench.sh.
+	env_iters := os.getenv('BENCH_ITERS').int()
+	iterations := if env_iters > 0 { env_iters } else { 5_000_000 }
 
 	// Realistic requests with the headers a browser actually sends.
 	req_wasm :=
@@ -98,13 +101,22 @@ fn main() {
 	// Full handler path: the server copies the response into the per-connection
 	// write buffer (`out << ...`). This is the body-copy cost a precomputed
 	// response can't avoid without sendfile(2). 256 KiB body.
+	//
+	// Generation (parse/route/encode) is already measured at the FULL count in the
+	// sections above; this section adds only the body copy on top. That copy is
+	// memcpy-bandwidth-bound (~40 GB/s) — a CPU/libc property, not vanilla's code,
+	// so it can't regress from a code change and needs few samples. Scale it to
+	// iters/50 (e.g. 1M -> 20k ~0.1s, 5M -> 100k) so it neither dominates the
+	// bench's wall time (it was ~90% at full count) nor reports a misleading
+	// memcpy figure. The label prints the actual count used.
+	copy_iters := if iterations > 100_000 { iterations / 50 } else { iterations }
 	mut out := []u8{cap: 300 * 1024}
-	for _ in 0 .. iterations {
+	for _ in 0 .. copy_iters {
 		out.clear()
 		out << (s.respond(req_wasm) or { panic(err) })
 		acc += out.len
 	}
-	b.measure('handler  200 wasm + copy into out (256 KiB)')
+	b.measure('handler  200 wasm + copy into out (256 KiB, ${copy_iters} iters)')
 
 	os.rmdir_all(bench_root) or {}
 	println('\nchecksum=${acc} (ignore; keeps the optimizer honest)')


### PR DESCRIPTION
Reworked from the earlier "tier/skip static_assets" approach (per review): instead of skipping the heavy bench, **standardize the loop count via an env var** so every bench stays in CI, and **fix `static_assets` so its number is meaningful**.

## 1. Standardized iteration count (`BENCH_ITERS`)

All four micro-benches now read the loop count from `$BENCH_ITERS` (default `5_000_000` for stable local runs):

```v
env_iters := os.getenv('BENCH_ITERS').int()
iterations := if env_iters > 0 { env_iters } else { 5_000_000 }
```

`ci_bench.sh` sets `BENCH_ITERS=2_000_000` for the A/B (overridable) — fast, while keeping even the cheapest bench (`request_parser`, ~0.3s) above the runner's noise floor.

**Fixes a real typo**: `etag_hash.v` had `const intentions` (misnamed) **silently stuck at 1M** while the others ran 5M. It now uses a proper `iterations` variable. (Local etag wall time rises ~5×; per-op cost is unchanged.)

## 2. `static_assets` made meaningful (not skipped)

It was ~38s because its final section copied a **256 KiB body into the write buffer every iteration (~90% of the bench)**. That copy is **memcpy-bandwidth-bound (~40 GB/s) — a CPU/libc property, not vanilla's code**, so it can't regress from a code change. Generation (parse/route/encode) is already measured at the full count in the sections above; this section only adds the copy. Scaling it to `iters/50` drops the section from ~35s to ~0.2s, so the bench's time now reflects the **generation hot path that can actually regress**. The bench runs every time again.

## 3. `bench/load.sh` — memory + CPU under load (local)

Boots a server, drives it with `wrk`, samples `/proc/<pid>`: peak RSS, **RSS slope** (flat under `-gc none` per BEST_PRACTICES.md §10), CPU% (cores busy), CPU-ms/1k req. Local only (hosted load tests are too noisy).

## Net effect
CI bench job: **~10 min → ~3-4 min**, all benches included, `static_assets` now a peer (~0.9s at 2M) rather than a 6-min hog.

## Validation
- All four build & run; `BENCH_ITERS` honored (200k/2M/5M); default falls back to 5M; `intentions` typo gone; `static_assets` copy section 222ms at 2M (was 34.6s).
- `ci_bench.sh` end-to-end (BASE_REF=HEAD): all four present, exit 0, header shows the count.
- Adversarial 3-lens review (V-correctness / measurement-soundness / CI-comparability); findings folded in (2M default, comment clarifications, this note).

## Known one-time artifact
The **first** post-merge A/B comment will show spurious ~80% "improvements": the baseline commit predates `BENCH_ITERS` and runs 5M while HEAD runs 2M. It self-heals on the next commit (both sides then honor the env), and a false *improvement* never opens a regression issue.

Tooling only; no hot-path or runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)