### PR TITLE
docs: static-serving memory study (sendfile + zero-copy lookup keys)

### DIFF
--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -68,11 +68,23 @@ Reach for the bytes you already have before allocating new ones.
   truly need a `string`.
 - Compare header names/values against the slice directly.
 - Defer `.clone()` / `.to_string()` until the byte data must outlive the buffer.
+- Build a map lookup key as a non-owning view — `unsafe { tos(ptr, len) }` —
+  when the map never retains it (it only hashes the key bytes). The
+  [static_assets module](../http_server/static_assets/static_assets.v#L273-L281)
+  is the canonical example: `key := tos(&buf[rs], rel_len)`, a view straight into
+  the request buffer, so routing costs no allocation.
 
 **Don't**
 
 - Copy the whole body to inspect a few bytes.
 - Build intermediate `string`s in a loop — concatenation reallocates.
+- Build a lookup key with a slice expression like `route[8..]` — V `string.substr`
+  does `malloc_noscan(len+1)` + `memcpy`, a fresh heap string **every request**
+  (a permanent leak under `-gc none`). Isolated proof (2026-06): 20M lookups into
+  the same `map[string]int`, `-prod -gc none` — `route[8..]` grows RSS +625 MiB,
+  monotonic (~31 B/request); `tos(route.str + 8, route.len - 8)` stays flat at
+  +28 KiB. The vanilla library already uses the `tos` view; an HttpArena benchmark
+  handler is what regressed here.
 
 ---
 

--- a/docs/PERF_GAP_ANALYSIS.md
+++ b/docs/PERF_GAP_ANALYSIS.md
@@ -196,6 +196,75 @@ round-robin ignores load. The 256-byte starting buffer guarantees ≥2 recv
 calls + reallocs for any normal request. Dropping pipelined bytes makes
 pipelined benchmarks (and clients) outright fail/slow.
 
+### Static serving: memory (2026-06)
+
+HttpArena `static` profile (`wrk`, `GET /static/<file>`, keep-alive, 200
+req/conn, at 1024 / 4096 / 6800 connections). rps / peak RSS:
+
+| server | 1024 | 4096 | 6800 | memory |
+|---|---|---|---|---|
+| zix (Zig, io_uring) | 2.03M / 140 MiB | 2.04M / 195 MiB | 1.99M / 241 MiB | flat |
+| iris (C++, epoll) | 1.77M / 111 MiB | 2.11M / 193 MiB | 1.88M / 281 MiB | flat |
+| vanilla-epoll (V, `-gc none`) | 1.10M / 262 MiB | 1.14M / 426 MiB | 1.18M / 912 MiB | balloons ~3.5× |
+| vanilla-io_uring (V, default Boehm) | — | — | — | collapses 231K→8K rps, 1.4–1.7 GiB |
+
+1. **The body is not the gap.** All three (iris, zix, vanilla) serve the file
+   with `sendfile(2)` — zero-copy straight from the page cache, body never
+   enters the heap. vanilla already does the right thing on the body: a cached
+   open fd + precomputed header + `queue_file`/sendfile. The differentiator is
+   the *non-body* allocation: per-request heap traffic on the routing/key path
+   and per-conn buffer footprint.
+
+2. **Root cause of the epoll balloon is in the HttpArena benchmark handler, NOT
+   the vanilla library.** The benchmark handler rolls its own asset map and
+   builds the lookup key with `route[8..]` — V's `string.substr` →
+   `malloc_noscan(len+1)` + `memcpy`, a fresh heap string **every request**.
+   The arena build ships `-gc none`, so that string is never freed → unbounded
+   leak. Sites (HttpArena repo, not this one):
+   `frameworks/vanilla-epoll/main.v:357` and
+   `frameworks/vanilla-io_uring/main.v:160`.
+
+   Empirical proof (isolated: identical `map[string]int` + 20,000,000 lookups,
+   `v -prod -gc none`, RSS from `/proc/self/status`; only the key construction
+   differs):
+   - `key = route[8..]` → **+625 MiB**, monotonic, never plateaus (~31 B/request).
+   - `key = tos(route.str + 8, route.len - 8)` → **+28 KiB**, flat (0 B/request).
+
+   A ~22,000× difference for the same work. A map lookup only hashes the key
+   bytes and never retains the key, so a non-owning view (`tos`) is safe as a
+   lookup key. The vanilla **library is already the reference for this**:
+   [`http_server/static_assets/static_assets.v:273-281`](../http_server/static_assets/static_assets.v)
+   builds the key as `key := tos(&buf[rs], rel_len)` — a zero-copy view into the
+   request buffer, documented as "never retained, so routing costs no
+   allocation." Never imply the lib leaks; the fix belongs in the arena handler.
+
+3. **io_uring is a separate problem, not this leak.** The default-Boehm
+   io_uring build *does* collect the substr (no hard leak), but it pays
+   per-request GC churn, and its static collapse (231K→8K rps, 1.4–1.7 GiB) is
+   the per-conn buffer-pool allocation problem, distinct from the `route[8..]`
+   substr above.
+
+4. **Secondary: the 24K/conn baseline floor (a deliberate tradeoff, not the
+   balloon).** vanilla's per-conn buffers are read_buf 8K + write_buf 16K = 24K
+   ([`http_server/backend_epoll/conn_state_linux.c.v:54-55`](../http_server/backend_epoll/conn_state_linux.c.v)),
+   pooled in `free_conns` (bounded to peak concurrent conns). On the sendfile
+   static path the 16K write_buf carries only a ~200 B header (the body goes
+   through the kernel), so it is ~163 MiB of mostly-idle buffer at 6800 conns vs
+   zix's ~27 MiB (zix uses a 4K fixed recv buffer and no write buffer for
+   static). Shrinking or lazily allocating write_buf would reintroduce
+   GC-scanned growth (the "static cliff") on the default-GC io_uring build, so
+   it is intentionally left as-is — **future work only, not a bug or planned
+   change**.
+
+5. **How the leaders stay flat (zero per-request heap):**
+   - **zix:** 4K fixed recv buffer, no write buffer for static, lock-free
+     append-only fd cache (one fd per variant), 192-byte precomputed header sent
+     with `MSG_MORE` then `sendfileAll`. Zero per-request heap allocation.
+   - **iris:** thread-per-core epoll + `SO_REUSEPORT`; a sealed `memfd` holding
+     pre-baked **complete frozen responses** (header+body together); per request
+     it just sendfiles an `(offset, len)` slice, so bodies never enter the heap;
+     fixed buffers pooled and reused across connections.
+
 ## Why they beat vanilla on io_uring
 
 Vanilla io_uring backend today (`http_server_io_uring_linux.c.v`,

--- a/docs/V_PERF_TOOLBOX.md
+++ b/docs/V_PERF_TOOLBOX.md
@@ -83,6 +83,19 @@ Already used here for the per-worker epoll fd arrays
   loses the atomic property.
 - A fixed-size stack array `[N]u8{}` **does** zero N bytes per call — don't make
   big ones on the hot path.
+- **`s[a..b]` / `string.substr` allocates a fresh heap string** every call
+  (`malloc_noscan(len+1)` + `memcpy`). Under `-gc none` a result used-and-discarded
+  on the hot path **leaks** (nothing frees it); under the default GC it is
+  per-request churn. For a **non-retained lookup key** (e.g. a map key) use a
+  zero-copy view: `unsafe { tos(ptr, len) }` — map lookup only hashes the key bytes
+  and never retains the key, so a view is safe. Empirical (isolated, same
+  `map[string]int` + 20M lookups, `-gc none`, only the key construction differs):
+  `route[8..]` → **+625 MiB** (monotonic, never plateaus) vs `tos(route.str+8,
+  route.len-8)` → **+28 KiB** flat — a ~22,000x gap for the same work. The vanilla
+  LIBRARY is already the reference (the substr leak lived in an HttpArena benchmark
+  handler, not here): [`http_server/static_assets/static_assets.v:273-281`](../http_server/static_assets/static_assets.v)
+  builds the key as `key := tos(&buf[rs], rel_len)`, a view straight into the
+  request buffer, "never retained, so routing costs no allocation."
 - `recv` into spare capacity to avoid a scratch buffer + second copy:
   `recv(fd, &u8(buf.data) + buf.len, buf.cap - buf.len)` then `unsafe { buf.len += n }`.
 - **Allocation cost is hidden at low core counts and explodes under GC at scale.**

--- a/examples/static_assets/README.md
+++ b/examples/static_assets/README.md
@@ -31,6 +31,28 @@ always correct. Smaller files stay preloaded in RAM and are sent from a single
 precomputed buffer. Range, conditional GET, and `Accept-Encoding` negotiation
 all work over the `sendfile` path.
 
+### Memory: flat RAM, no per-request allocation (2026-06)
+
+This module stays flat on RAM under load for two reasons:
+
+- **Body never hits the heap** — large files stream via `sendfile(2)` straight
+  from the page cache to the socket (above), so the response body costs zero
+  userspace allocation.
+- **Lookup key is a zero-copy view** — routing builds the asset key as a
+  non-owning `tos` view straight into the request buffer
+  (`key := tos(&buf[rs], rel_len)`, never retained — see
+  [`http_server/static_assets/static_assets.v:273`](../../http_server/static_assets/static_assets.v)),
+  not an allocating `substr`, so routing costs no per-request allocation.
+
+A hand-rolled handler that builds its key with `route[8..]` instead would
+allocate a fresh heap string every request (`string.substr` →
+`malloc_noscan(len+1)` + memcpy). Under `-gc none` that string is never freed —
+an unbounded leak. An isolated test (identical `map[string]int`, 20,000,000
+lookups, `-prod -gc none`) measured `route[8..]` at +625 MiB (monotonic,
+~31 B/request) vs the `tos` view at +28 KiB (flat) — same work, ~22,000x the
+RSS. A map lookup only hashes the key bytes and never retains them, so the
+non-owning view is safe as a lookup key.
+
 ## Running
 
 ```sh


### PR DESCRIPTION
Documents the static-serving memory study: why iris (C++) and zix (Zig) stay flat on RAM on the HttpArena `static` profile while a hand-rolled V handler balloons, and the zero-copy-key lesson behind it. **Documentation only — no code change.** The vanilla library is already correct (its `static_assets` module builds the lookup key as a zero-copy `tos` view).

### What motivated this

The `static` profile shows `vanilla-epoll` RSS climbing 262 → 426 → 912 MiB (1024 → 4096 → 6800 conns) while iris/zix stay flat (~140–280 MiB). Root cause, proven in isolation (identical `map[string]int` + 20M lookups, `v -prod -gc none`, RSS from `/proc/self/status`): a lookup key built with `route[8..]` (V `string.substr` → `malloc_noscan` + memcpy) leaks +625 MiB under `-gc none`, vs +28 KiB flat for a `tos()` view. That leak lives in the **HttpArena benchmark handler**, not this library — fixed separately in MDA2AV/HttpArena#943. These docs capture the lesson so it doesn't recur.

### Changes

- **docs/PERF_GAP_ANALYSIS.md** — new "Static serving: memory (2026-06)" section: the iris/zix/vanilla rps+RSS table, the `route[8..]` substr leak with the +625 MiB vs +28 KiB proof, the 24K/conn buffer floor framed as a deliberate noscan tradeoff (future work, not a bug), and how the leaders stay flat (zix: 4K recv + no write buf + lock-free fd cache; iris: sealed memfd of pre-baked frozen responses).
- **docs/V_PERF_TOOLBOX.md** — new allocation fact: `s[a..]`/`string.substr` allocates; use a `tos()` view for non-retained lookup keys.
- **docs/BEST_PRACTICES.md** — Do/Don't items for zero-copy map keys.
- **examples/static_assets/README.md** — a "Memory" note on the flat-RAM design.

All citations verified against the live source (`static_assets.v:273-281`, `conn_state_linux.c.v:54-55`, and V's `string.substr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)