### PR TITLE
perf(pg_async): read wire ints at offset, dropping the per-read slices

### DIFF
--- a/pg_async/protocol.v
+++ b/pg_async/protocol.v
@@ -48,7 +48,7 @@ pub fn auth_subtype(payload []u8) u32 {
 	if payload.len < 4 {
 		return 0xFFFF_FFFF
 	}
-	return binary.big_endian_u32(payload[0..4])
+	return binary.big_endian_u32_at(payload, 0)
 }
 
 // ── backend framing ─────────────────────────────────────────────────────────
@@ -68,7 +68,7 @@ pub fn next_message(buf []u8) ?MsgHeader {
 	if buf.len < 5 {
 		return none
 	}
-	msg_len := int(binary.big_endian_u32(buf[1..5]))
+	msg_len := int(binary.big_endian_u32_at(buf, 1))
 	if msg_len < 4 {
 		return none
 	}
@@ -90,7 +90,7 @@ pub fn next_message_at(buf []u8, pos int) ?MsgHeader {
 	if buf.len - pos < 5 {
 		return none
 	}
-	msg_len := int(binary.big_endian_u32(buf[pos + 1..pos + 5]))
+	msg_len := int(binary.big_endian_u32_at(buf, pos + 1))
 	if msg_len < 4 {
 		return none
 	}
@@ -131,7 +131,7 @@ pub fn (mut it FrameIter) next() ?Frame {
 	if it.pos + 5 > it.buf.len {
 		return none
 	}
-	msg_len := int(binary.big_endian_u32(it.buf[it.pos + 1..it.pos + 5]))
+	msg_len := int(binary.big_endian_u32_at(it.buf, it.pos + 1))
 	if msg_len < 4 {
 		return none
 	}


### PR DESCRIPTION
Completes the offset-read conversion the DataRow row-decode work started.

`Row.col` already reads column lengths with `binary.big_endian_u16_at` / `big_endian_u32_at` (`pg_async/protocol.v:207`, `:219`) specifically to drop the array descriptor + slice-marking bookkeeping that `big_endian_u32(payload[a..b])` incurs per read. The **message-framing** scalar reads were left on the old slicing form:

- `auth_subtype` (`:51`)
- `next_message` (`:71`)
- `next_message_at` (`:93`) — the advancing read cursor
- `FrameIter.next` (`:134`) — per backend message during result iteration

Each sliced a 4-byte window (`buf[a..b]`) only to read one big-endian `u32`. This converts them all to `binary.big_endian_u32_at(buf, off)`:

- Identical bounds-checked big-endian arithmetic — no behavior change.
- No `array.slice()` struct, no `mark_buffer_has_slices()` on the per-message framing hot path (`next_message_at`/`FrameIter.next` run once per backend message per query).
- The existing length guards (`buf.len < 5`, `it.pos + 5 > it.buf.len`, …) already guarantee `off + 4` is in range.

After this, `grep 'big_endian_u(16|32)\('` in `pg_async/` matches only `types.v`, which passes a whole `[]u8` (no slice — nothing to convert).

Found by an allocation audit of the lib hot paths (the same sweep behind the static-serving memory study). `protocol_test.v` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)