### PR TITLE
feat(static_assets): borrowed send for small assets via core.queue_buf

### DIFF
--- a/http_server/static_assets/static_assets.v
+++ b/http_server/static_assets/static_assets.v
@@ -431,10 +431,18 @@ fn (s &AssetServer) emit_into(asset &Asset, req request_parser.HttpRequest, head
 		out << v.response[..v.header_len]
 		return
 	}
-	out << v.response // small: full response; large: headers only
 	if !v.is_large() {
+		// Small (preloaded): the precomputed response (headers + body) is immutable
+		// for the server's lifetime, so hand it to the worker to send DIRECTLY
+		// (borrowed) when the backend can (io_uring core.queue_buf) — no copy through
+		// the per-connection write buffer. queue_buf returns false on any backend that
+		// can't borrow-send (epoll, TLS, non-Linux), where the copy stays the path.
+		if !core.queue_buf(v.response.data, v.response.len) {
+			out << v.response
+		}
 		return
 	}
+	out << v.response // large: headers only; body streamed below
 	// Large body: stream it from the page cache with sendfile(2); if the backend
 	// can't (TLS / non-epoll / non-Linux), read it into `out` as a fallback.
 	if !(v.file_fd >= 0 && core.queue_file(v.file_fd, i64(0), v.body_len)) {


### PR DESCRIPTION
Follow-up to #80 (this commit was pushed just after #80 merged, so it missed the merge).

`emit_into` hands a preloaded (small) asset's precomputed, immutable response to the worker to send **directly (borrowed)** when the backend supports it (io_uring `core.queue_buf`), instead of always copying it through the per-connection write buffer. `queue_buf` returns false on any backend that can't borrow-send (epoll, TLS, non-Linux), where `out << response` stays the path — so epoll/TLS behavior is unchanged (verified: epoll still serves the `.br` body identically).

This folds the per-entry borrowed send from **MDA2AV/HttpArena#951** into the one audited static path, so both backends serve `/static` through `static_assets`: precompressed `.br`/`.gz` negotiation + ETag/`Vary` + **sendfile(2)** for large bodies (epoll) + **queue_buf borrowed send** for small bodies (io_uring). Consumer: the #951 update (vanilla-io_uring → static_assets).

`static_assets` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)