### PR TITLE
feat(http_server): per-server workers config (ServerConfig.workers)

### DIFF
--- a/.github/workflows/build_test_examples_on_linux.yml
+++ b/.github/workflows/build_test_examples_on_linux.yml
@@ -19,6 +19,7 @@ jobs:
           - examples/etag/src
           - examples/hexagonal/src
           - examples/io_uring_demo/src
+          - examples/per_server_workers/src
           - examples/simple/src
           - examples/simple2/src
           - examples/sse/src

--- a/examples/per_server_workers/src/main.v
+++ b/examples/per_server_workers/src/main.v
@@ -1,0 +1,63 @@
+module main
+
+// Per-server worker pools — `ServerConfig.workers`.
+//
+// By default EVERY server in a process runs `nr_cpus` worker threads (or
+// `$VANILLA_WORKERS`). When you co-host more than one server in a single process
+// that double-subscribes the cores (2 servers × nr_cpus threads). `workers` lets
+// you size each server's pool independently so the total stays ≈ nr_cpus: here a
+// main API server keeps most of the cores and a small secondary (admin/metrics)
+// server gets a couple. `workers: 0` (the default) keeps the nr_cpus behavior.
+//
+// The field's meaning is uniform across backends (count of worker threads); the
+// topology differs — epoll runs one central acceptor + `workers` epoll loops,
+// io_uring runs `workers` shared-nothing rings (one SO_REUSEPORT listener each).
+import http_server
+import runtime
+
+fn api_handler(req_buffer []u8, _ int, mut out []u8) ! {
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 4\r\nConnection: keep-alive\r\n\r\nmain'.bytes()
+}
+
+fn admin_handler(req_buffer []u8, _ int, mut out []u8) ! {
+	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nadmin'.bytes()
+}
+
+fn main() {
+	// Backend chosen per-OS; this example targets the Linux epoll backend.
+	mut backend := unsafe { http_server.IOBackend(0) }
+	$if linux {
+		backend = http_server.IOBackend.epoll
+	} $else {
+		eprintln('per_server_workers: this example targets the Linux epoll backend')
+		return
+	}
+
+	cpus := runtime.nr_cpus()
+	// Give the secondary server a small pool; the main server takes the rest, so
+	// the two pools together are ≈ nr_cpus instead of 2 × nr_cpus.
+	admin_workers := if cpus >= 4 { 2 } else { 1 }
+	main_workers := if cpus - admin_workers >= 1 { cpus - admin_workers } else { 1 }
+
+	// Secondary (admin) server on :8081 with a small pool, in its own thread.
+	mut admin := http_server.new_server(http_server.ServerConfig{
+		port:            8081
+		io_multiplexing: backend
+		workers:         admin_workers
+		request_handler: admin_handler
+	})!
+	spawn fn [admin] () {
+		mut s := admin
+		s.run()
+	}()
+
+	// Main API server on :8080 with the remaining cores.
+	mut api := http_server.new_server(http_server.ServerConfig{
+		port:            8080
+		io_multiplexing: backend
+		workers:         main_workers
+		request_handler: api_handler
+	})!
+	println('per-server workers: api :8080 = ${main_workers}, admin :8081 = ${admin_workers} (nr_cpus=${cpus})')
+	api.run()
+}

--- a/examples/per_server_workers/src/main_test.v
+++ b/examples/per_server_workers/src/main_test.v
@@ -1,0 +1,65 @@
+module main
+
+import http_server
+import runtime
+
+// ServerConfig.workers sizes each server's worker pool independently. new_server
+// allocates the per-worker thread / in-flight-counter / io_uring-listener arrays
+// from it WITHOUT spawning any threads (run() later spawns exactly threads.len
+// workers, and each backend derives its count from threads.len). So asserting the
+// public array lengths verifies the knob end-to-end, deterministically — no
+// sleeps, no real server to start or stop, nothing that can hang CI.
+
+fn noop_handler(req_buffer []u8, _ int, mut out []u8) ! {}
+
+// workers:N is honored, and two co-hosted servers size their pools independently.
+fn test_workers_override_sizes_pools_independently() {
+	$if linux {
+		mut a := http_server.new_server(http_server.ServerConfig{
+			port:            18181
+			io_multiplexing: .epoll
+			workers:         5
+			request_handler: noop_handler
+		}) or { panic(err) }
+		assert a.threads.len == 5
+		assert a.inflight.len == 5
+
+		mut b := http_server.new_server(http_server.ServerConfig{
+			port:            18182
+			io_multiplexing: .epoll
+			workers:         9
+			request_handler: noop_handler
+		}) or { panic(err) }
+		assert b.threads.len == 9
+		assert b.inflight.len == 9
+	}
+}
+
+// workers unset (0) falls back to the process default (nr_cpus, unless
+// $VANILLA_WORKERS is set — CI does not set it).
+fn test_workers_zero_falls_back_to_default() {
+	$if linux {
+		mut s := http_server.new_server(http_server.ServerConfig{
+			port:            18183
+			io_multiplexing: .epoll
+			request_handler: noop_handler
+		}) or { panic(err) }
+		assert s.threads.len == runtime.nr_cpus()
+		assert s.inflight.len == runtime.nr_cpus()
+	}
+}
+
+// io_uring is shared-nothing: workers:N creates N SO_REUSEPORT listeners (one per
+// worker) in addition to sizing the thread array.
+fn test_workers_io_uring_one_listener_per_worker() {
+	$if linux {
+		mut s := http_server.new_server(http_server.ServerConfig{
+			port:            18184
+			io_multiplexing: .io_uring
+			workers:         6
+			request_handler: noop_handler
+		}) or { panic(err) }
+		assert s.threads.len == 6
+		assert s.listener_fds.len == 6
+	}
+}

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -98,7 +98,7 @@ fn handle_accept_loop(socket_fd int, main_epoll_fd int, epoll_fds []int, limits 
 				socket.set_tcp_nodelay(client_conn_fd)
 				// Distribute client connection to worker threads (round-robin)
 				epoll_fd := epoll_fds[next_worker]
-				next_worker = (next_worker + 1) % core.max_thread_pool_size
+				next_worker = (next_worker + 1) % epoll_fds.len
 				$if verbose ? {
 					eprintln('[epoll] Adding client fd ${client_conn_fd} to worker epoll fd ${epoll_fd}')
 				}
@@ -304,10 +304,12 @@ pub fn run_epoll_backend(socket_fd int, request_handler core.RequestHandler, sta
 
 	// the function of this epoll_fds array is to hold epoll fds for each worker thread
 	// they are used to distribute client connections among worker threads
-	mut epoll_fds := []int{len: core.max_thread_pool_size, cap: core.max_thread_pool_size}
+	// One worker epoll fd per worker thread. threads was sized by new_server from
+	// config.workers (default nr_cpus), so its length is this server's worker count.
+	mut epoll_fds := []int{len: threads.len, cap: threads.len}
 
 	unsafe { epoll_fds.flags.set(.noslices | .noshrink | .nogrow) }
-	for i in 0 .. core.max_thread_pool_size {
+	for i in 0 .. threads.len {
 		epoll_fds[i] = epoll.create_epoll_fd()
 		if epoll_fds[i] < 0 {
 			C.perror(c'epoll_create1')

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -251,6 +251,16 @@ pub:
 	certificates    Certificates
 	limits          Limits
 	tls_config      &tls.Config = unsafe { nil } // set for HTTPS (e.g. tls.new_self_signed())
+	// workers sets how many worker threads THIS server runs. 0 (default) =
+	// `VANILLA_WORKERS` env → `runtime.nr_cpus()` (the process-wide default). Set it
+	// PER server instance when co-hosting two servers in one process so their worker
+	// threads don't oversubscribe the cores: e.g. give the high-traffic plaintext
+	// server most cores and a co-hosted TLS/secondary server a small pool, keeping
+	// the total ≈ nr_cpus. The meaning is uniform across backends (count of worker
+	// threads); the topology differs — epoll runs a central acceptor + `workers`
+	// epoll loops, io_uring runs `workers` shared-nothing rings (one SO_REUSEPORT
+	// listener each).
+	workers int
 }
 
 pub fn new_server(config ServerConfig) !Server {
@@ -336,6 +346,13 @@ pub fn new_server(config ServerConfig) !Server {
 		}
 	}
 
+	// Per-server worker count: config.workers when set (>0), else the process-wide
+	// default (VANILLA_WORKERS → nr_cpus). This is the single source of truth for
+	// this server's worker fan-out — it sizes the thread / in-flight-counter /
+	// io_uring-listener arrays below, and every backend derives its worker count
+	// from threads.len, so two co-hosted servers can split the cores independently.
+	n_workers := if config.workers > 0 { config.workers } else { max_thread_pool_size }
+
 	// Listeners the server will accept on. The first is always socket_fd. The
 	// io_uring backend is shared-nothing with one SO_REUSEPORT listener PER worker,
 	// so create the rest up front (worker 0 reuses socket_fd): then shutdown() can
@@ -344,7 +361,7 @@ pub fn new_server(config ServerConfig) !Server {
 	mut listener_fds := [socket_fd]
 	$if linux {
 		if io_multiplexing == .io_uring {
-			for _ in 1 .. max_thread_pool_size {
+			for _ in 1 .. n_workers {
 				listener_fds << socket.create_server_socket(config.port)
 			}
 		}
@@ -361,7 +378,8 @@ pub fn new_server(config ServerConfig) !Server {
 		on_worker_start:  config.on_worker_start
 		limits:           config.limits
 		tls_config:       config.tls_config
-		threads:          []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
+		threads:          []thread{len: n_workers, cap: n_workers}
+		inflight:         []&core.Counter{len: n_workers, init: &core.Counter{}}
 		listener_fds:     listener_fds
 	}
 }

--- a/http_server/http_server_darwin.c.v
+++ b/http_server/http_server_darwin.c.v
@@ -115,7 +115,8 @@ pub fn run_kqueue_backend(socket_fd int, handler fn (req []u8, fd int, mut out [
 		return
 	}
 
-	n_workers := max_thread_pool_size
+	// Worker count = the thread array new_server sized from config.workers.
+	n_workers := threads.len
 	mut worker_kqs := []int{len: n_workers}
 
 	for i in 0 .. n_workers {

--- a/http_server/http_server_io_uring_linux.c.v
+++ b/http_server/http_server_io_uring_linux.c.v
@@ -701,7 +701,9 @@ pub fn run_io_uring_backend(server Server, mut threads []thread) {
 	if server.on_worker_start != unsafe { nil } {
 		panic('on_worker_start is not supported on the io_uring backend')
 	}
-	num_workers := max_thread_pool_size
+	// Worker count = the thread array new_server sized from config.workers (one
+	// SO_REUSEPORT listener was created per worker, so server.listener_fds.len matches).
+	num_workers := threads.len
 
 	for i in 0 .. num_workers {
 		// One SO_REUSEPORT listener per worker, all created in new_server so


### PR DESCRIPTION
## What

Add a `workers int` field to `ServerConfig` — the number of worker threads **this** server instance runs. `0` (default) keeps current behavior (`VANILLA_WORKERS` env → `runtime.nr_cpus()`).

Until now the worker count was the process-global const `core.max_thread_pool_size`, so **every** server in a process spawned `nr_cpus` workers — there was no way to size them per instance. This adds that knob, useful when co-hosting more than one server in a process, or capping workers on a constrained box per server.

## How

- `new_server` resolves a per-instance count (`config.workers` when `>0`, else the global default) and sizes the `threads`, per-worker `inflight` counters, and io_uring `listener_fds` arrays from it.
- Every backend now derives its worker count from the **passed-in `threads.len`** instead of the global const:
  - epoll: `epoll_fds` length + spawn loop from `threads.len`; the acceptor's round-robin from `epoll_fds.len`.
  - io_uring: `num_workers := threads.len` (one SO_REUSEPORT listener per worker is created in `new_server`).
  - kqueue (darwin): `n_workers := threads.len`.
- The global const stays as the default fallback; a single-server program with `workers` unset is **unchanged**.

Semantics are uniform (count of worker threads); topology differs per backend — epoll = 1 central acceptor + `workers` epoll loops; io_uring = `workers` shared-nothing rings.

## Verification

- Runtime (epoll, `-gc none`): `workers:3` → **4** OS threads (3 workers + 1 acceptor), `workers:8` → **9**, `workers:0` → **nr_cpus + 1**.
- Module builds clean under both `-gc none` and the default GC; all four touched files `vfmt`-clean.

## Note on the original motivation

This started as a candidate fix for the HttpArena `vanilla-io_uring` `json-comp@16384` collapse (enghitalo/vanilla#89), under the hypothesis that the co-hosted json-tls listener's worker threads oversubscribed the cores. **That hypothesis turned out to be wrong**: both backends *block* when idle (epoll `epoll_wait(-1)`; io_uring `io_uring_submit_and_wait`, SQPOLL never used), and the json-tls server is idle during the plaintext json-comp profile — so its threads burn zero CPU and don't oversubscribe. The collapse cause is still open. This field is therefore offered as a **general worker-control feature**, not as that fix. (It does make the collapse easier to *investigate* — you can now vary one server's worker count in isolation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
