### PR TITLE
feat(http_server): io_uring backend supports make_state / stateful_handler (per-worker state) — closes #93

### DIFF
--- a/http_server/README.md
+++ b/http_server/README.md
@@ -15,7 +15,7 @@ per-request allocation.
 | Platform | Backend | Accept model | Handlers supported |
 |---|---|---|---|
 | Linux | `.epoll` *(default)* | one central acceptor → round-robins fds to per-worker epolls | `request_handler`, `stateful_handler`, `async_handler`, TLS |
-| Linux | `.io_uring` | per-worker `SO_REUSEPORT` listener + multishot accept (kernel 5.19+) | `request_handler` (stateless) |
+| Linux | `.io_uring` | per-worker `SO_REUSEPORT` listener + multishot accept (kernel 5.19+) | `request_handler`, `stateful_handler` |
 | macOS | kqueue | per-worker | `request_handler`, `async_handler` |
 | Windows | IOCP | per-worker | `request_handler` |
 
@@ -26,7 +26,7 @@ Provide **exactly one** of:
 - **`request_handler`** — `fn (req []u8, fd int, mut out []u8) !`, stateless. All backends.
 - **`stateful_handler` + `make_state`** — lock-free per-worker state (e.g. a DB
   connection): `make_state` runs once per worker, then every request on that worker
-  is dispatched with it. Linux/epoll only.
+  is dispatched with it. Linux epoll + io_uring (each ring worker builds its own state).
 - **`async_handler` (+ optional `make_state`)** — may PARK a request on any fd via
   `ac.watch(...)` and resume by a continuation in the worker loop (DB sockets,
   upstreams, timers, `EPOLLOUT` backpressure). Linux/epoll + macOS/kqueue.

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -23,7 +23,7 @@ pub:
 pub mut:
 	threads         []thread            = []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
 	request_handler core.RequestHandler = unsafe { nil }
-	// Per-thread state path (epoll only); see ServerConfig. make_state runs once
+	// Per-worker state path (epoll + io_uring); see ServerConfig. make_state runs once
 	// per worker thread, stateful_handler receives its result on every request.
 	stateful_handler core.StatefulHandler = unsafe { nil }
 	async_handler    core.AsyncHandler    = unsafe { nil }
@@ -230,11 +230,12 @@ pub:
 	// Provide EITHER request_handler (stateless) OR stateful_handler+make_state
 	// (per-thread state). new_server enforces exactly one is set.
 	request_handler core.RequestHandler = unsafe { nil }
-	// stateful_handler + make_state opt into lock-free per-thread state: each
-	// epoll worker calls make_state ONCE (so the value is thread-local), then every
-	// request on that worker is dispatched through stateful_handler with it. Used to
-	// give each worker its own DB connection — no shared pool, no mutex. Linux/epoll
-	// only; ignored by other backends. See core.StatefulHandler.
+	// stateful_handler + make_state opt into lock-free per-worker state: each worker
+	// calls make_state ONCE (so the value is thread-local), then every request on that
+	// worker is dispatched through stateful_handler with it. Used to give each worker
+	// its own DB connection / reused render scratch — no shared pool, no mutex. Linux
+	// epoll AND io_uring (each ring worker builds its own state); ignored by other
+	// backends. See core.StatefulHandler.
 	stateful_handler core.StatefulHandler = unsafe { nil }
 	make_state       fn () voidptr        = unsafe { nil }
 	// async_handler opts into the async runtime: the handler may PARK a request on
@@ -304,13 +305,15 @@ pub fn new_server(config ServerConfig) !Server {
 	// inside the matching `$if` — otherwise this all-platform file fails to
 	// compile on the other targets.
 	if has_stateful {
-		// stateful_handler (sync per-thread state) is Linux/epoll only for now.
+		// stateful_handler (sync per-worker state) runs on the Linux epoll AND io_uring
+		// backends: each worker calls make_state once, then dispatches every request
+		// through stateful_handler with that thread-local state (no sharing, no lock).
 		$if linux {
-			if config.io_multiplexing != .epoll {
-				return error('stateful_handler requires the epoll backend')
+			if config.io_multiplexing != .epoll && config.io_multiplexing != .io_uring {
+				return error('stateful_handler requires the epoll or io_uring backend')
 			}
 		} $else {
-			return error('stateful_handler is only supported on the Linux epoll backend')
+			return error('stateful_handler is only supported on the Linux epoll and io_uring backends')
 		}
 	}
 	if has_async {

--- a/http_server/http_server_io_uring_linux.c.v
+++ b/http_server/http_server_io_uring_linux.c.v
@@ -528,7 +528,7 @@ fn iou_sweep_timeouts(worker &io_uring.Worker) {
 // up on the main thread and driving it here would make every submit_and_wait
 // fail; doing it all here keeps the ring single-owner (and matches how every
 // thread-per-core io_uring server sets up).
-fn io_uring_worker_main(listener int, cpu_id int, handler fn (req []u8, fd int, mut out []u8) !, limits Limits, active_conns &core.Counter, inflight &core.Counter, draining &core.Counter) {
+fn io_uring_worker_main(listener int, cpu_id int, handler fn (req []u8, fd int, mut out []u8) !, stateful_handler core.StatefulHandler, make_state fn () voidptr, limits Limits, active_conns &core.Counter, inflight &core.Counter, draining &core.Counter) {
 	maybe_pin_worker(cpu_id)
 	mut worker := &io_uring.Worker{}
 	worker.cpu_id = cpu_id
@@ -562,7 +562,32 @@ fn io_uring_worker_main(listener int, cpu_id int, handler fn (req []u8, fd int, 
 	// Skip the per-enter fget/fput on the ring fd.
 	C.io_uring_register_ring_fd(&worker.ring)
 
-	io_uring_worker_loop(worker, handler, limits, active_conns)
+	// Per-worker state (issue #93): build THIS worker's thread-local state once (e.g.
+	// its own DB pool / reused render scratch), then fold it into a plain
+	// RequestHandler-shaped closure so the ring hot path stays a plain handler and the
+	// state needs no sharing and no lock. make_state runs HERE — on the worker thread,
+	// after CPU pinning — so its allocations are thread- and NUMA-local. Mirrors the
+	// epoll backend's process_events_plain + build_handler.
+	mut state := voidptr(unsafe { nil })
+	if make_state != unsafe { nil } {
+		state = make_state()
+	}
+	eff_handler := build_iou_handler(handler, stateful_handler, state)
+
+	io_uring_worker_loop(worker, eff_handler, limits, active_conns)
+}
+
+// build_iou_handler resolves the effective synchronous per-worker handler: with no
+// stateful_handler it is just the stateless request_handler; otherwise it binds this
+// worker's `state` into a plain RequestHandler-shaped closure so the ring hot path
+// stays a plain handler and the state is thread-local. Mirrors backend_epoll.build_handler.
+fn build_iou_handler(request_handler fn (req []u8, fd int, mut out []u8) !, stateful_handler core.StatefulHandler, state voidptr) fn (req []u8, fd int, mut out []u8) ! {
+	if stateful_handler == unsafe { nil } {
+		return request_handler
+	}
+	return fn [state, stateful_handler] (req []u8, fd int, mut out []u8) ! {
+		stateful_handler(req, fd, mut out, state)!
+	}
 }
 
 @[direct_array_access]
@@ -717,8 +742,8 @@ pub fn run_io_uring_backend(server Server, mut threads []thread) {
 			eprintln('Failed to create listener for worker ${i}')
 			exit(1)
 		}
-		threads[i] = spawn io_uring_worker_main(listener, i, server.request_handler, server.limits,
-			server.active_conns, server.inflight[i], server.draining)
+		threads[i] = spawn io_uring_worker_main(listener, i, server.request_handler, server.stateful_handler,
+			server.make_state, server.limits, server.active_conns, server.inflight[i], server.draining)
 	}
 
 	println('listening on http://localhost:${server.port}/ (io_uring)')


### PR DESCRIPTION
## Summary

Give the **io_uring** backend the same per-worker-state contract the epoll backend already has: `make_state` + `stateful_handler`. Previously io_uring accepted only a stateless `request_handler` (make_state / stateful / async were epoll-only), forcing io_uring entries to either share state under a lock or allocate per request. Closes #93.

## How it works

Each ring worker (`io_uring_worker_main`) calls `make_state()` **once on its own thread** — after CPU pinning, so the state's allocations are thread- and NUMA-local — then folds that `state` into a plain `RequestHandler`-shaped closure via the new `build_iou_handler`. The ring hot path (`io_uring_worker_loop` → `drain_iou_requests` / `start_iou_body_drain`) stays a plain handler, so every downstream function is unchanged. This mirrors the epoll backend's `process_events_plain` + `build_handler` exactly.

State is **per-worker** — each ring worker owns its own value, no sharing and no lock, just like epoll.

## Changes

- **`new_server`**: `stateful_handler` is now accepted on `.io_uring` (was epoll-only). `async_handler` stays epoll/kqueue-only — that's the separate async-runtime work (#83).
- **`http_server_io_uring_linux.c.v`**: `io_uring_worker_main` takes `stateful_handler` + `make_state`, builds the per-worker state + effective handler (`build_iou_handler`), and passes it to the loop. `run_io_uring_backend` threads them through at spawn. The stateless `request_handler` path is unchanged (`build_iou_handler` returns it verbatim when no `stateful_handler` is set).
- **Docs**: `ServerConfig` / `Server` comments + `http_server/README.md` now list `stateful_handler` as an io_uring-supported handler path.

## Verification

Built with local V (module resolves to this working tree):

- **Stateful io_uring** server (`make_state` returns a per-worker counter, `stateful_handler` increments it): three sequential requests return `count=1`, `count=2`, `count=3` — proving `make_state` ran once and the state pointer persists and threads through the ring across requests.
- **Stateless io_uring** (`request_handler`) server still responds correctly — no regression.

## Follow-up

This unblocks the last convergence step for the HttpArena `vanilla-io_uring` entry (MDA2AV/HttpArena#965): its DB-render paths can drop the per-request local scratch and reuse a per-worker buffer, matching the epoll twin. (DB *throughput* itself is still gated on the async runtime, #83.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
