### PR TITLE
fix(http_server): epoll TLS worker passed the make_state fn pointer as state (garbage for stateful+TLS) — closes #95

### DIFF
--- a/.github/workflows/build_test_examples_on_darwin.yml
+++ b/.github/workflows/build_test_examples_on_darwin.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up V
         uses: vlang/setup-v@v1.7
+        with:
+          clean: false
       - name: Remove Vlang folder to avoid conflicts
         shell: bash
         run: |

--- a/http_server/backend_epoll/worker_linux.c.v
+++ b/http_server/backend_epoll/worker_linux.c.v
@@ -244,7 +244,17 @@ fn process_events_plain(worker_id int, epoll_fd int, request_handler core.Reques
 @[direct_array_access; manualfree]
 fn process_events_tls(worker_id int, epoll_fd int, request_handler core.RequestHandler, stateful_handler core.StatefulHandler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter, cfg &tls.Config) {
 	maybe_pin_worker(worker_id)
-	handler := build_handler(request_handler, stateful_handler, make_state)
+	// Build THIS worker's per-thread state ONCE, then bind it into the handler — same
+	// as the plaintext worker. NOTE: pass make_state()'s RESULT, not the make_state fn
+	// pointer itself: build_handler's 3rd arg is the `state voidptr`, so passing the
+	// uncalled fn made a stateful+TLS handler cast the make_state address as its state
+	// (garbage). make_state is nil for the common stateless-TLS case (build_handler then
+	// ignores state), so only stateful+TLS was affected.
+	mut state := voidptr(unsafe { nil })
+	if make_state != unsafe { nil } {
+		state = make_state()
+	}
+	handler := build_handler(request_handler, stateful_handler, state)
 	mut events := [socket.max_connection_size]C.epoll_event{}
 	mut sessions := map[int]&TlsConn{}
 	sweep_on := limits.read_timeout_ms > 0 || limits.write_timeout_ms > 0


### PR DESCRIPTION
## Bug

`process_events_tls` built the effective handler with the **uncalled** `make_state` function pointer where `build_handler` expects the per-worker `state voidptr`:

```v
handler := build_handler(request_handler, stateful_handler, make_state)  // make_state, not make_state()
```

`build_handler(request_handler, stateful_handler, state voidptr)` binds its 3rd arg into the stateful closure. So on the TLS path `state` was the **address of the `make_state` function**, and a `stateful_handler` dispatched over TLS cast that (`&MyCtx(state)`) → garbage read / crash.

The plaintext worker (`process_events_plain`) already did it correctly (`state = make_state()` first). This only affected **`stateful_handler` + TLS on epoll**; stateless TLS is unaffected because `build_handler` ignores `state` when `stateful_handler == nil`.

## Fix

Mirror the plaintext worker: call `make_state()` once per TLS worker (after `maybe_pin_worker`) and pass its result.

## Verification

Built with `-d vanilla_tls`. A **stateful + TLS** epoll server (self-signed cert, per-worker counter) returns `tls-count=1`, `tls-count=2`, `tls-count=3` across three HTTPS requests — per-worker state built and threaded correctly, no crash.

Pre-existing bug, found during the review of the io_uring `make_state` work (#93 / #94); unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)