### PR TITLE
feat(http_server): async runtime for the io_uring backend (oneshot IORING_OP_POLL_ADD) — closes #83

### DIFF
--- a/http_server/README.md
+++ b/http_server/README.md
@@ -15,7 +15,7 @@ per-request allocation.
 | Platform | Backend | Accept model | Handlers supported |
 |---|---|---|---|
 | Linux | `.epoll` *(default)* | one central acceptor → round-robins fds to per-worker epolls | `request_handler`, `stateful_handler`, `async_handler`, TLS |
-| Linux | `.io_uring` | per-worker `SO_REUSEPORT` listener + multishot accept (kernel 5.19+) | `request_handler`, `stateful_handler` |
+| Linux | `.io_uring` | per-worker `SO_REUSEPORT` listener + multishot accept (kernel 5.19+) | `request_handler`, `stateful_handler`, `async_handler` |
 | macOS | kqueue | per-worker | `request_handler`, `async_handler` |
 | Windows | IOCP | per-worker | `request_handler` |
 
@@ -29,7 +29,8 @@ Provide **exactly one** of:
   is dispatched with it. Linux epoll + io_uring (each ring worker builds its own state).
 - **`async_handler` (+ optional `make_state`)** — may PARK a request on any fd via
   `ac.watch(...)` and resume by a continuation in the worker loop (DB sockets,
-  upstreams, timers, `EPOLLOUT` backpressure). Linux/epoll + macOS/kqueue.
+  upstreams, timers, write backpressure). Linux epoll + io_uring (readiness via a
+  oneshot `IORING_OP_POLL_ADD` on the worker's own ring) and macOS/kqueue.
 
 `on_worker_start` arms clientless background watches (e.g. a periodic timerfd that
 refreshes per-worker state with no extra thread). Linux/epoll, plaintext only.

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -240,9 +240,10 @@ pub:
 	make_state       fn () voidptr        = unsafe { nil }
 	// async_handler opts into the async runtime: the handler may PARK a request on
 	// any fd via ac.watch(...) and return .suspend, resumed by a continuation when
-	// that fd is ready — all in the worker's epoll loop (DB sockets, upstreams,
-	// timers, EPOLLOUT backpressure). Optional make_state gives each worker its own
-	// state. Linux/epoll only; ignored by other backends. See core.AsyncHandler.
+	// that fd is ready — all in the worker's own event loop (DB sockets, upstreams,
+	// timers). Optional make_state gives each worker its own state. Linux epoll +
+	// io_uring (readiness via a oneshot IORING_OP_POLL_ADD on the worker's ring)
+	// and macOS/kqueue. See core.AsyncHandler.
 	async_handler core.AsyncHandler = unsafe { nil }
 	// on_worker_start runs once per worker (after make_state, before the loop) to
 	// arm CLIENTLESS background watches — e.g. a periodic timerfd that refreshes
@@ -317,10 +318,11 @@ pub fn new_server(config ServerConfig) !Server {
 		}
 	}
 	if has_async {
-		// async_handler runs on the Linux epoll worker and the macOS kqueue worker.
+		// async_handler runs on the Linux epoll and io_uring workers and the macOS
+		// kqueue worker (io_uring parks on a oneshot IORING_OP_POLL_ADD — issue #83).
 		$if linux {
-			if config.io_multiplexing != .epoll {
-				return error('async_handler requires the epoll backend')
+			if config.io_multiplexing != .epoll && config.io_multiplexing != .io_uring {
+				return error('async_handler requires the epoll or io_uring backend')
 			}
 		} $else $if darwin {
 			if config.io_multiplexing != .kqueue {

--- a/http_server/http_server_io_uring_async_linux.c.v
+++ b/http_server/http_server_io_uring_async_linux.c.v
@@ -1,0 +1,668 @@
+module http_server
+
+// Opt-in async runtime for the io_uring worker (issue #83) — the io_uring twin of
+// backend_epoll/async_linux.c.v.
+//
+// When ServerConfig.async_handler is set, each ring worker owns an IouAsyncEnv
+// (watch registry + async handler + per-worker state) and routes client reads
+// through async_iou_drain and watched-fd readiness through handle_io_uring_poll;
+// when it is not set, a single nil-check per CQE skips all of this and the
+// synchronous hot path is byte-for-byte unchanged.
+//
+// The model is the same single-threaded reactor as epoll's: a handler that needs
+// to wait on something (a DB socket, an upstream, a timerfd) calls
+// `ac.watch(ext_fd, interest, continuation, udata)` and returns `.suspend`. The
+// worker PARKS the connection and goes on serving others; readiness on ext_fd is
+// delivered as a ONESHOT IORING_OP_POLL_ADD completion (op_poll) that resumes the
+// continuation — all on the ring's own thread, so SINGLE_ISSUER is preserved by
+// construction (every poll SQE is queued from a continuation running inside the
+// CQE dispatch).
+//
+// Key differences from the epoll runtime, both simplifications:
+//
+//   * A PARKED connection has ZERO client-side ops in flight. No recv is armed
+//     (so the pool slot cannot be freed under a stale CQE — the sync path's
+//     slot-reuse-UAF hazard cannot arise here), and no send is armed: responses
+//     produced before/at the park are HELD in response_buffer until resume,
+//     because an in-flight send captures a raw data pointer that a resume
+//     appending to (and thereby reallocating) the buffer would dangle. The
+//     latency cost is bounded by the watch (one DB round-trip); the epoll-style
+//     stream-as-you-go on .suspend (SSE over async) is deferred to a follow-up.
+//
+//   * Client hangup while parked is NOT detected eagerly (no op on the client fd
+//     ⇒ no CQE). The in-flight query was already submitted; when it completes,
+//     the resume renders and flushes, the send fails on the dead peer, and the
+//     write-completion path releases the slot — the pooled DB reply is thereby
+//     always drained IN ORDER, so none of epoll's disconnect tombstoning
+//     (reactor_orphan_single / eager mark_dead) is needed for correctness. The
+//     `dead` tombstone on queue slots is kept as a defensive guard (a released /
+//     reused slot found at drain time is consumed against a scratch buffer).
+//
+// Parked-connection deadlines: read/write deadlines are cleared at park (no
+// client op is armed, so neither timeout applies) and re-arm naturally at
+// resume. A hung query on a vanished client therefore pins the slot until the
+// query returns — the same known gap as the epoll runtime (async_linux.c.v:29);
+// bound it DB-side with e.g. statement_timeout. A parked-deadline sweep is a
+// follow-up shared with epoll.
+import io_uring
+import http_server.core
+import http1_1.request_parser
+import http1_1.response
+
+// Initial size of the fd-indexed watch table (grows by doubling; same layout as
+// the epoll reactor and the pool's fd-indexed structures).
+const iou_watch_table_min = 1024
+
+// IouParkSlot is one parked client on a pipelined (multi-client) watched fd: the
+// same (conn, continuation, udata) triple a single IouWatchEntry holds, but queued
+// so one readiness edge on a multiplexed pg connection can complete several
+// requests in submission order. `client_fd` is the conn's fd CAPTURED at park time
+// — the dead/ABA identity, never re-resolved. `dead` marks a slot whose conn was
+// released/reused while parked: it stays in the queue (removing it would desync
+// the queue from the DB connection's in-flight FIFO) and its result is consumed
+// against a throwaway buffer in order, then discarded.
+struct IouParkSlot {
+mut:
+	conn      &io_uring.Connection = unsafe { nil }
+	client_fd int
+	cont      core.WakeFn = unsafe { nil }
+	udata     voidptr
+	dead      bool
+}
+
+// IouWatchEntry records one parked request on an external fd: which client
+// connection is waiting, the continuation to run on readiness, and the consumer's
+// opaque udata. `queue` is EMPTY for the common single-watch case; it is populated
+// only when a SECOND distinct client parks on an already-active fd (a pipelined
+// pg connection) — then the queue is the FIFO of parked clients and the head
+// fields are unused. Mirrors backend_epoll.WatchEntry.
+struct IouWatchEntry {
+mut:
+	active    bool
+	conn      &io_uring.Connection = unsafe { nil }
+	client_fd int
+	cont      core.WakeFn = unsafe { nil }
+	udata     voidptr
+	queue     []IouParkSlot
+	// persistent: the fd is a long-lived, caller-owned resource (a pooled DB
+	// connection), armed via watch_persistent — never closed by the runtime.
+	// Sticky once set (re-stamped on every park of a pool fd).
+	persistent bool
+}
+
+// IouAsyncEnv is one worker's async runtime: the watch registry, the async
+// handler, this worker's make_state value, and the ring (for arming polls from
+// continuations). One per worker thread, no lock. `cur_conn` is the transient
+// bridge from the fixed RegisterFn signature (which only receives AsyncCtx, and
+// AsyncCtx carries no connection pointer) to the connection whose handler or
+// continuation is CURRENTLY running — every call site sets it immediately before
+// invoking h()/cont(), and iou_async_register reads it. Single-threaded and
+// synchronous within the call, so this is safe.
+@[heap]
+struct IouAsyncEnv {
+mut:
+	h        core.AsyncHandler    = unsafe { nil }
+	state    voidptr
+	worker   &io_uring.Worker     = unsafe { nil }
+	watches  []IouWatchEntry
+	cur_conn &io_uring.Connection = unsafe { nil }
+	// Polls that could not be queued because the SQ was momentarily full. The
+	// watch entry stays active and the worker loop retries these right after its
+	// submit (which frees SQ slots) — a park is never silently dropped (the
+	// no-signal RegisterFn contract gives the handler no way to observe failure).
+	// The requested mask is persisted so a writable watch is never degraded to a
+	// readable retry (a healthy socket parked awaiting writability raises neither
+	// POLLIN nor ERR/HUP — a readable re-arm would strand it).
+	pending_polls []PendingIouPoll
+	// Set around a tombstoned slot's continuation (drain_pipelined_iou dead
+	// branch): its re-arm must ONLY re-queue the oneshot poll — the tombstone
+	// queue slot stays exactly as it is (same continuation, same udata), and the
+	// watch table must not be touched (a dedup/append there would either revive
+	// the tombstone or duplicate it).
+	rearming_dead bool
+}
+
+struct PendingIouPoll {
+	fd   int
+	mask u32
+}
+
+// iou_reactor_watch records (or re-arms) the watch for ext_fd, growing the flat
+// fd-indexed table by doubling. Port of backend_epoll's reactor_watch with the
+// client identity swapped from an fd (epoll re-resolves conns via st.conns[fd])
+// to the stable &Connection slab pointer (the io_uring pool never reallocates
+// w.conns, which is exactly what makes storing the pointer sound) plus the fd
+// captured for dead/ABA identity.
+@[direct_array_access]
+fn (mut env IouAsyncEnv) iou_reactor_watch(ext_fd int, cont core.WakeFn, udata voidptr) {
+	if ext_fd >= env.watches.len {
+		mut new_len := if env.watches.len == 0 { iou_watch_table_min } else { env.watches.len }
+		for new_len <= ext_fd {
+			new_len *= 2
+		}
+		mut grown := []IouWatchEntry{len: new_len}
+		for i in 0 .. env.watches.len {
+			grown[i] = env.watches[i]
+		}
+		env.watches = grown
+	}
+	conn := env.cur_conn
+	if !env.watches[ext_fd].active {
+		// Fresh watch — the single-watch fast path. Reset fields in place and REUSE
+		// the slot's (already-empty) queue rather than assigning an IouWatchEntry{}
+		// literal, which would default-init a fresh empty queue array — one heap
+		// allocation per park, a leak under -gc none.
+		env.watches[ext_fd].active = true
+		env.watches[ext_fd].conn = conn
+		env.watches[ext_fd].client_fd = if unsafe { conn != nil } { conn.fd } else { -1 }
+		env.watches[ext_fd].cont = cont
+		env.watches[ext_fd].udata = udata
+		env.watches[ext_fd].persistent = false
+		unsafe {
+			env.watches[ext_fd].queue.len = 0
+		}
+		return
+	}
+	// The fd already has a parked watch. A SECOND distinct client on the same fd
+	// means it is multiplexing (a pipelined pg connection): promote to a queue and
+	// fan readiness out in submission order. A re-arm by an ALREADY-parked client
+	// (the front continuation asking for more bytes) updates in place — never a
+	// duplicate append. Identity is the conn POINTER over LIVE slots only: a DEAD
+	// slot is never matched, so a released-and-reacquired slot pointer parking
+	// again can never be conflated with its predecessor's tombstone (the tombstone
+	// still drains its own orphaned reply first; the new park queues behind it,
+	// which is also FIFO-correct — its query was submitted later). Tombstone
+	// re-arms never reach this function (see rearming_dead in iou_async_register).
+	if env.watches[ext_fd].queue.len == 0 {
+		if env.watches[ext_fd].conn == conn {
+			env.watches[ext_fd].cont = cont
+			env.watches[ext_fd].udata = udata
+			return
+		}
+		// Promote: move the existing head into the queue (len is 0 here). Push into
+		// the slot's RETAINED buffer rather than assigning a literal — the buffer
+		// grows once to the max pipeline depth and is reused thereafter.
+		env.watches[ext_fd].queue << IouParkSlot{
+			conn:      env.watches[ext_fd].conn
+			client_fd: env.watches[ext_fd].client_fd
+			cont:      env.watches[ext_fd].cont
+			udata:     env.watches[ext_fd].udata
+		}
+	}
+	for i in 0 .. env.watches[ext_fd].queue.len {
+		if !env.watches[ext_fd].queue[i].dead && env.watches[ext_fd].queue[i].conn == conn {
+			env.watches[ext_fd].queue[i].cont = cont
+			env.watches[ext_fd].queue[i].udata = udata
+			return
+		}
+	}
+	env.watches[ext_fd].queue << IouParkSlot{
+		conn:      conn
+		client_fd: if unsafe { conn != nil } { conn.fd } else { -1 }
+		cont:      cont
+		udata:     udata
+	}
+}
+
+// iou_detach_rejected_watch tears down a watch that a handler registered during a
+// call whose OUTCOME rejected the park — a streamed-body head that suspended
+// (unsupported: answered 400 and condemned), or .done/.close returned after
+// ac.watch. Without this, the entry stays active with an armed oneshot poll
+// pointing at a connection that is about to be released: a reacquired slot with
+// the same pointer AND same fd number would pass every resume guard and have a
+// foreign continuation write into the new client's response stream.
+//
+// For a pool-owned fd the in-flight query's reply must still be consumed IN ORDER
+// (protocol sync), so the park is TOMBSTONED — drain_pipelined_iou runs it against
+// a scratch buffer and discards — never erased. A request-owned fd is cleared and
+// closed (the app's continuation will never run to close it): epoll async_close
+// parity. The armed oneshot poll for a cleared entry dies on the active==false
+// guard.
+fn (mut env IouAsyncEnv) iou_detach_rejected_watch(ext_fd int, conn &io_uring.Connection) {
+	if ext_fd < 0 || ext_fd >= env.watches.len || !env.watches[ext_fd].active {
+		return
+	}
+	if env.watches[ext_fd].queue.len > 0 {
+		// Pipelined fd: tombstone THIS conn's slot (keeps the FIFO aligned).
+		for i in 0 .. env.watches[ext_fd].queue.len {
+			if !env.watches[ext_fd].queue[i].dead && env.watches[ext_fd].queue[i].conn == conn {
+				env.watches[ext_fd].queue[i].dead = true
+				return
+			}
+		}
+		return
+	}
+	if env.watches[ext_fd].conn != conn {
+		return // someone else's single watch — not ours to tear down
+	}
+	if env.watches[ext_fd].persistent {
+		// Pool-owned single watch: convert to a one-slot dead tombstone (the epoll
+		// reactor_orphan_single shape) so the orphaned reply is drained in order
+		// and the pooled fd stays open for reuse.
+		env.watches[ext_fd].queue << IouParkSlot{
+			conn:      env.watches[ext_fd].conn
+			client_fd: env.watches[ext_fd].client_fd
+			cont:      env.watches[ext_fd].cont
+			udata:     env.watches[ext_fd].udata
+			dead:      true
+		}
+		return
+	}
+	env.iou_reactor_clear(ext_fd)
+	C.close(ext_fd)
+}
+
+// iou_reactor_clear marks ext_fd's slot free. Only the parked-request record is
+// dropped (a pool-owned fd is re-armed by the next watch); a stale poll CQE then
+// finds `active == false` and is ignored.
+@[direct_array_access; inline]
+fn (mut env IouAsyncEnv) iou_reactor_clear(ext_fd int) {
+	if ext_fd >= 0 && ext_fd < env.watches.len {
+		env.watches[ext_fd].active = false
+	}
+}
+
+// iou_async_register is installed into AsyncCtx.register; it is what ac.watch()
+// ultimately calls. It records the watch and queues a oneshot POLL_ADD on the
+// external fd — the SQE is flushed by the worker loop's next submit_and_wait.
+// Runs on the ring's own worker thread (continuations execute inside the CQE
+// dispatch), so SINGLE_ISSUER holds and no synchronization is needed.
+fn iou_async_register(mut ac core.AsyncCtx, ext_fd int, interest core.WatchInterest, cont core.WakeFn, udata voidptr) {
+	if ext_fd < 0 {
+		// A consumer handed us a failed fd (e.g. timerfd_create returned -1); never
+		// index the flat table at a negative slot. Arm nothing.
+		ac.last_watched = -1
+		return
+	}
+	mut env := unsafe { &IouAsyncEnv(ac.reactor) }
+	mask := (if interest == .writable { io_uring.pollout } else { io_uring.pollin }) | io_uring.pollerr | io_uring.pollhup
+	if env.rearming_dead {
+		// Tombstone re-arm (drain_pipelined_iou dead branch): the queue slot stays
+		// exactly as it is — only the consumed oneshot poll needs re-queueing. The
+		// watch table is NOT touched: a dedup/append here would revive or duplicate
+		// the tombstone.
+		env.iou_queue_poll(ext_fd, mask)
+		ac.last_watched = ext_fd
+		return
+	}
+	env.iou_reactor_watch(ext_fd, cont, udata)
+	if ac.persistent {
+		// Pool-owned fd (watch_persistent): never closed by the runtime. Sticky —
+		// re-stamped every park (a fresh single watch resets the entry).
+		env.watches[ext_fd].persistent = true
+	}
+	env.iou_queue_poll(ext_fd, mask)
+	ac.last_watched = ext_fd
+}
+
+// iou_queue_poll queues the oneshot poll SQE, falling back to the pending list on
+// a momentarily-full SQ. The handler has ALREADY committed by the time this runs
+// (query submitted) and cannot observe a failure, so the park must not be
+// dropped: the worker loop re-queues pending polls right after its next submit
+// frees SQ slots. POLL_ADD reports current readiness at submit, so a late arm
+// cannot lose the wakeup.
+fn (mut env IouAsyncEnv) iou_queue_poll(ext_fd int, mask u32) {
+	if io_uring.prepare_poll(&env.worker.ring, ext_fd, mask) {
+		return
+	}
+	for p in env.pending_polls {
+		if p.fd == ext_fd {
+			return // already queued for retry — never arm duplicate polls
+		}
+	}
+	env.pending_polls << PendingIouPoll{
+		fd:   ext_fd
+		mask: mask
+	}
+}
+
+// iou_retry_pending_polls re-queues polls that hit a full SQ (with their original
+// interest mask), keeping the ones that still don't fit. Called by the worker
+// loop right after its submit (which frees SQ slots).
+@[direct_array_access]
+fn iou_retry_pending_polls(mut env IouAsyncEnv) {
+	mut kept := 0
+	for i in 0 .. env.pending_polls.len {
+		p := env.pending_polls[i]
+		if p.fd < env.watches.len && env.watches[p.fd].active {
+			if !io_uring.prepare_poll(&env.worker.ring, p.fd, p.mask) {
+				env.pending_polls[kept] = p
+				kept++
+			}
+		}
+	}
+	unsafe {
+		env.pending_polls.len = kept
+	}
+}
+
+// iou_async_ctx builds the per-invocation AsyncCtx for a handler/continuation
+// call. loop_fd is -1 — io_uring has no event-loop fd; the ring is reached via
+// env.worker inside register.
+@[inline]
+fn iou_async_ctx(mut env IouAsyncEnv, client_fd int, ready_fd int, ready_err bool, udata voidptr) core.AsyncCtx {
+	return core.AsyncCtx{
+		client_fd: client_fd
+		ready_fd:  ready_fd
+		ready_err: ready_err
+		udata:     udata
+		state:     env.state
+		loop_fd:   -1
+		reactor:   unsafe { voidptr(env) }
+		register:  iou_async_register
+	}
+}
+
+// async_iou_drain answers every complete request currently buffered, appending
+// each response to response_buffer, and STOPS at the first request that suspends
+// (the connection parks; the rest stay buffered and are drained when the watch
+// resumes). The async twin of drain_iou_requests with the epoll async_drain step
+// contract. CALLER CONTRACT: env.cur_conn must be the connection being drained
+// (register reads it to identify the parker).
+//
+// Responses produced before a park are HELD (not flushed) — see the module
+// comment: a parked connection must have no in-flight send, because a later
+// resume appends to response_buffer and an append can reallocate it under a
+// send's captured pointer. The caller flushes iff the burst ends unparked.
+@[direct_array_access; manualfree]
+fn async_iou_drain(mut env IouAsyncEnv, mut conn io_uring.Connection, limits Limits) {
+	mut pos := 0
+	// A borrowed static-asset buffer a handler queued via queue_buf, deferred so it
+	// can either be sent DIRECTLY (sole response of an unparked burst) or copied
+	// into response_buffer IN ORDER before whatever follows.
+	mut pend := voidptr(unsafe { nil })
+	mut pend_len := i64(0)
+	for pos < conn.read_buf.len && conn.awaiting_fd < 0 && !conn.close_after_send {
+		if pend != unsafe { nil } {
+			unsafe { conn.response_buffer.push_many(pend, int(pend_len)) }
+			pend = unsafe { nil }
+		}
+		total := request_parser.frame_request_length_lim_idx(buf_view(conn.read_buf, pos,
+			conn.read_buf.len - pos), limits.max_header_bytes, limits.max_body_bytes)
+		if total == -1 {
+			break // incomplete — wait for more bytes
+		}
+		if total < -1 {
+			match -total {
+				413 { conn.response_buffer << response.status_413_response }
+				431 { conn.response_buffer << response.status_431_response }
+				else { conn.response_buffer << response.tiny_bad_request_response }
+			}
+			conn.close_after_send = true
+			core.set_queue_buf_allowed(false)
+			return
+		}
+		req := buf_view(conn.read_buf, pos, total)
+		// Borrowing is allowed only when the write buffer is empty, so a borrowed
+		// send can be the WHOLE response (see post-loop; a park downgrades it to a
+		// copy so ordering survives the deferred flush).
+		core.set_queue_buf_allowed(conn.response_buffer.len == 0)
+		mut ac := iou_async_ctx(mut env, conn.fd, -1, false, unsafe { nil })
+		step := env.h(req, mut conn.response_buffer, mut ac)
+		if qb := core.take_queued_buf() {
+			pend = qb.ptr
+			pend_len = qb.len
+		}
+		pos += total
+		match step {
+			.done {}
+			.suspend {
+				// Park: no client op will be armed until the watch resumes. Clear the
+				// read deadline — nothing is mid-read, and the sweep must not shut a
+				// parked connection down as a slow reader.
+				conn.awaiting_fd = ac.last_watched
+				conn.read_deadline = 0
+			}
+			.close {
+				conn.close_after_send = true
+			}
+		}
+		if step != .suspend && ac.last_watched >= 0 {
+			// The handler registered a watch but did NOT park (.done/.close after
+			// ac.watch — a contract violation): tear it down so no armed poll can
+			// later resume against this (soon-recycled) connection.
+			env.iou_detach_rejected_watch(ac.last_watched, env.cur_conn)
+		}
+		// Peer pipelines requests but never reads responses: bail before the pending
+		// batch grows without bound.
+		if conn.response_buffer.len - conn.bytes_sent > iou_max_pending_write {
+			conn.close_after_send = true
+		}
+	}
+	core.set_queue_buf_allowed(false)
+	if pend != unsafe { nil } {
+		// A sole borrowed response of an UNPARKED, still-open burst is sent DIRECTLY
+		// from the borrowed buffer. If the burst parked (flush deferred to resume) or
+		// anything else is pending, copy it in order instead — the write-completion
+		// path handles send_buf and response_buffer as alternatives, never both.
+		if conn.response_buffer.len == 0 && conn.awaiting_fd < 0 && !conn.close_after_send {
+			conn.send_buf = pend
+			conn.send_total = int(pend_len)
+		} else {
+			unsafe { conn.response_buffer.push_many(pend, int(pend_len)) }
+		}
+	}
+	// Compact the consumed prefix, keeping any leftover (partial or parked-behind)
+	// request at the buffer front for the resume to drain.
+	if pos > 0 {
+		leftover := conn.read_buf.len - pos
+		if leftover > 0 {
+			unsafe {
+				C.memmove(conn.read_buf.data, &u8(conn.read_buf.data) + pos, usize(leftover))
+			}
+		}
+		unsafe {
+			conn.read_buf.len = leftover
+		}
+	}
+}
+
+// async_start_iou_body_drain is the async twin of start_iou_body_drain: a
+// large-body request is answered from its HEAD alone (the handler must complete
+// synchronously — a head handler that suspends mid-large-body is unsupported, as
+// on epoll, and drops the connection with a 400), then the body is drained and
+// discarded by the body_drain machinery. Returns the same tri-state contract as
+// the sync twin via `true` = handled / `false` = head incomplete.
+@[direct_array_access]
+fn async_start_iou_body_drain(mut env IouAsyncEnv, mut conn io_uring.Connection, total int, limits Limits) bool {
+	head_len := request_parser.frame_head_len(conn.read_buf)
+	if head_len <= 0 || head_len > conn.read_buf.len {
+		return false // head not complete in the buffer yet — keep buffering
+	}
+	head := buf_view(conn.read_buf, 0, head_len)
+	core.set_queue_buf_allowed(false)
+	mut ac := iou_async_ctx(mut env, conn.fd, -1, false, unsafe { nil })
+	if env.h(head, mut conn.response_buffer, mut ac) != .done {
+		// suspend/close on a streamed-body head is unsupported (as on epoll):
+		// answer 400 and condemn. The handler may ALREADY have registered a watch
+		// (armed poll + submitted query) before suspending — tear it down, or the
+		// armed poll would later resume against this recycled connection (and a
+		// pooled fd's orphaned reply must still be drained in order: tombstoned).
+		if ac.last_watched >= 0 {
+			env.iou_detach_rejected_watch(ac.last_watched, env.cur_conn)
+		}
+		conn.response_buffer << response.tiny_bad_request_response
+		conn.close_after_send = true
+		unsafe {
+			conn.read_buf.len = 0
+		}
+		return true
+	}
+	body_in_buf := conn.read_buf.len - head_len
+	conn.body_drain = i64(total - head_len) - i64(body_in_buf)
+	if conn.body_drain < 0 {
+		conn.body_drain = 0
+	}
+	unsafe {
+		conn.read_buf.len = 0 // head + buffered body consumed; reuse buffer to drain
+	}
+	return true
+}
+
+// iou_finish_resume completes a connection's `.done` resume: drain any requests
+// that were pipelined behind the parked one (they may re-park), then flush the
+// held batch — or release / re-arm recv as the state demands. The io_uring
+// analogue of epoll's `.done → async_serve` re-drain, split from the poll handler
+// so the single-watch and pipelined paths share it.
+fn iou_finish_resume(mut env IouAsyncEnv, mut conn io_uring.Connection, limits Limits, active_conns &core.Counter) {
+	worker := env.worker
+	if conn.read_buf.len > 0 && !conn.close_after_send {
+		env.cur_conn = unsafe { &conn }
+		async_iou_drain(mut env, mut conn, limits)
+	}
+	if conn.awaiting_fd >= 0 {
+		return // re-parked behind a new watch: hold everything until it resolves
+	}
+	if conn.send_buf != unsafe { nil } || conn.response_buffer.len > conn.bytes_sent {
+		iou_flush_response(worker, mut conn, limits)
+		return
+	}
+	if conn.close_after_send {
+		// .close resume (or an error) with nothing pending to send — drop directly;
+		// a parked connection has no in-flight op, so releasing here is safe.
+		iou_release(worker, mut conn, active_conns, limits.max_connections > 0)
+		return
+	}
+	iou_arm_recv(worker, mut conn, limits)
+}
+
+// handle_io_uring_poll runs a parked request's continuation when its watched fd
+// fires (the op_poll CQE). The io_uring twin of epoll's async_on_ready. For
+// POLL_ADD the CQE res carries the returned event mask (or a negative errno);
+// POLLERR/POLLHUP (or an errno) surface as the portable AsyncCtx.ready_err.
+@[direct_array_access; manualfree]
+fn handle_io_uring_poll(cqe &C.io_uring_cqe, mut env IouAsyncEnv, limits Limits, active_conns &core.Counter) {
+	ext_fd := io_uring.decode_ext_fd(C.io_uring_cqe_get_data64(cqe))
+	if ext_fd < 0 || ext_fd >= env.watches.len || !env.watches[ext_fd].active {
+		return // stale edge — the watch was already resumed/cleared
+	}
+	res := cqe.res
+	ready_err := res < 0 || (u32(res) & (io_uring.pollerr | io_uring.pollhup)) != 0
+	// A pipelined fd (multiple parked clients on one multiplexed pg connection):
+	// fan this readiness edge out to the queued continuations in submission order.
+	if env.watches[ext_fd].queue.len > 0 {
+		drain_pipelined_iou(mut env, ext_fd, ready_err, limits, active_conns)
+		return
+	}
+	cont := env.watches[ext_fd].cont
+	udata := env.watches[ext_fd].udata
+	mut conn := env.watches[ext_fd].conn
+	parked_fd := env.watches[ext_fd].client_fd
+	env.iou_reactor_clear(ext_fd) // consumed; the continuation re-arms if it needs more
+	if unsafe { conn == nil } || unsafe { conn.owner == nil } || conn.fd != parked_fd {
+		return // slot released/reused under the park — nothing to resume
+	}
+	conn.awaiting_fd = -1
+	env.cur_conn = conn
+	mut ac := iou_async_ctx(mut env, conn.fd, ext_fd, ready_err, udata)
+	step := cont(mut conn.response_buffer, mut ac)
+	if step != .suspend && ac.last_watched >= 0 {
+		// Continuation re-watched but did not park (.done/.close after ac.watch):
+		// tear the stray watch down before the connection moves on / is released.
+		env.iou_detach_rejected_watch(ac.last_watched, conn)
+	}
+	match step {
+		.done {
+			iou_finish_resume(mut env, mut *conn, limits, active_conns)
+		}
+		.suspend {
+			// Multi-step chain: register already queued a fresh oneshot poll. Stay
+			// parked; bytes (if any) stay HELD — no send while parked (see module
+			// comment; epoll's stream-as-you-go on .suspend is a follow-up here).
+			conn.awaiting_fd = ac.last_watched
+		}
+		.close {
+			// A parked connection has no in-flight op, so releasing here is safe.
+			iou_release(env.worker, mut *conn, active_conns, limits.max_connections > 0)
+		}
+	}
+}
+
+// drain_pipelined_iou fans one readiness edge on a multiplexed pg connection out
+// to the clients queued on it, in submission order — the io_uring twin of epoll's
+// drain_pipelined. The queue head aligns with the connection's front in-flight
+// query, so heads are run until one cannot complete yet (.suspend): by FIFO, if
+// the front query is not ready no later one is either. Each .done is finished
+// (leftover drained + batch flushed) before the next head runs.
+@[direct_array_access; manualfree]
+fn drain_pipelined_iou(mut env IouAsyncEnv, ext_fd int, ready_err bool, limits Limits, active_conns &core.Counter) {
+	for env.watches[ext_fd].queue.len > 0 {
+		slot := env.watches[ext_fd].queue[0]
+		mut conn := slot.conn
+		// A tombstoned or released/reused slot: run its continuation against a
+		// throwaway buffer purely to CONSUME its in-flight query result in order
+		// (keeping the queue aligned with the DB connection's FIFO), then discard.
+		// Never dereference conn state for a dead slot — identity is the captured fd.
+		if slot.dead || unsafe { conn == nil } || unsafe { conn.owner == nil }
+			|| conn.fd != slot.client_fd {
+			mut scratch := []u8{}
+			mut dac := iou_async_ctx(mut env, slot.client_fd, ext_fd, ready_err, slot.udata)
+			// rearming_dead: a re-arm from this tombstone's continuation must ONLY
+			// re-queue the oneshot poll — the queue slot stays as-is and the watch
+			// table is untouched (see iou_async_register).
+			env.rearming_dead = true
+			dead_step := slot.cont(mut scratch, mut dac)
+			env.rearming_dead = false
+			if dead_step == .suspend {
+				break // result not ready yet — the tombstone stays at the head
+			}
+			env.watches[ext_fd].queue.delete(0)
+			env.iou_reactor_clear_if_drained(ext_fd)
+			continue
+		}
+		conn.awaiting_fd = -1
+		env.cur_conn = conn
+		mut ac := iou_async_ctx(mut env, conn.fd, ext_fd, ready_err, slot.udata)
+		step := slot.cont(mut conn.response_buffer, mut ac)
+		if step != .suspend && ac.last_watched >= 0 && ac.last_watched != ext_fd {
+			// Continuation watched a DIFFERENT fd but did not park: stray watch —
+			// tear it down. (last_watched == ext_fd can't happen on a non-suspend:
+			// a re-watch of ext_fd updates this same queue slot, which the .done/
+			// .close arms below then pop.)
+			env.iou_detach_rejected_watch(ac.last_watched, conn)
+		}
+		match step {
+			.done {
+				// Pop BEFORE finishing: the finish re-drain may read a request
+				// pipelined behind this one and re-park the client on ext_fd
+				// (appended at the tail). And if this pop DRAINED the queue, clear
+				// the slot BEFORE finishing: a re-park inside iou_finish_resume must
+				// become a FRESH, live single watch — a trailing "queue empty ⇒
+				// active=false" epilogue would deactivate that re-park's watch and
+				// strand its request forever (its poll CQE would find active=false
+				// and be dropped as stale).
+				env.watches[ext_fd].queue.delete(0)
+				env.iou_reactor_clear_if_drained(ext_fd)
+				iou_finish_resume(mut env, mut *conn, limits, active_conns)
+			}
+			.suspend {
+				// Front query not ready yet. The continuation re-armed ext_fd in place
+				// (iou_reactor_watch found it already queued — no duplicate) and
+				// register queued a fresh oneshot poll. Keep it at the head and stop:
+				// nothing behind it is ready.
+				conn.awaiting_fd = ext_fd
+				break
+			}
+			.close {
+				env.watches[ext_fd].queue.delete(0)
+				env.iou_reactor_clear_if_drained(ext_fd)
+				iou_release(env.worker, mut *conn, active_conns, limits.max_connections > 0)
+			}
+		}
+	}
+	// No trailing epilogue on purpose: deactivation happens INLINE at each pop that
+	// drains the queue (iou_reactor_clear_if_drained above), always BEFORE a
+	// continuation/finish that could re-park on this same fd. The drained queue's
+	// buffer is retained either way (len 0 from the delete(0)s; the next pipeline
+	// cycle on this pool-owned fd refills it without reallocating).
+}
+
+// iou_reactor_clear_if_drained deactivates ext_fd's watch when its pipelined
+// queue has just been fully consumed. MUST run before any continuation or finish
+// that could re-park on ext_fd (see the .done arm of drain_pipelined_iou).
+@[direct_array_access; inline]
+fn (mut env IouAsyncEnv) iou_reactor_clear_if_drained(ext_fd int) {
+	if env.watches[ext_fd].queue.len == 0 {
+		env.watches[ext_fd].active = false
+	}
+}

--- a/http_server/http_server_io_uring_linux.c.v
+++ b/http_server/http_server_io_uring_linux.c.v
@@ -193,7 +193,7 @@ fn handle_io_uring_accept(worker &io_uring.Worker, cqe &C.io_uring_cqe, limits L
 	}
 }
 
-fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn (req []u8, fd int, mut out []u8) !, limits Limits, active_conns &core.Counter) {
+fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn (req []u8, fd int, mut out []u8) !, env &IouAsyncEnv, limits Limits, active_conns &core.Counter) {
 	track := limits.max_connections > 0
 	res := cqe.res
 	c_ptr := io_uring.decode_connection_ptr(C.io_uring_cqe_get_data64(cqe))
@@ -201,6 +201,7 @@ fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn
 		return
 	}
 	mut conn := unsafe { &io_uring.Connection(c_ptr) }
+	has_async := unsafe { env != nil }
 	if res <= 0 {
 		// res == 0: peer closed (EOF, incl. the half-close from a timeout sweep).
 		// res < 0: recv error (e.g. -ECONNRESET, -ECANCELED).
@@ -225,8 +226,21 @@ fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn
 		conn.read_buf.len += res
 	}
 	// Answer every complete request now buffered (pipelining), appending each
-	// raw response to response_buffer and compacting the partial leftover.
-	drain_iou_requests(mut conn, handler, limits)
+	// raw response to response_buffer and compacting the partial leftover. The
+	// async drain additionally PARKS the connection at the first .suspend.
+	if has_async {
+		mut e := unsafe { &IouAsyncEnv(env) }
+		e.cur_conn = conn
+		async_iou_drain(mut *e, mut *conn, limits)
+	} else {
+		drain_iou_requests(mut conn, handler, limits)
+	}
+	if has_async && conn.awaiting_fd >= 0 {
+		// Parked: hold every buffered response and arm NO client op — the op_poll
+		// completion on awaiting_fd resumes this connection (iou_finish_resume
+		// then flushes / re-arms). See the async module comment for the invariant.
+		return
+	}
 	req_cap := if limits.max_request_bytes > 0 {
 		limits.max_request_bytes
 	} else {
@@ -246,13 +260,26 @@ fn handle_io_uring_read(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn
 		iou_flush_response(worker, mut *conn, limits)
 		return
 	}
+	if conn.close_after_send {
+		// An async .close (or error) can leave nothing pending to send — drop now
+		// rather than fall through to arming a recv on a condemned connection.
+		iou_release(worker, mut *conn, active_conns, track)
+		return
+	}
 	// Nothing complete yet. A body too large to be worth buffering is STREAMED:
 	// answer it from the head alone, then drain+discard the body. This keeps memory
 	// at O(read_buf_cap) instead of growing read_buf into a multi-MB block and
 	// ping-ponging recv→CQE→re-arm thousands of times for a 20 MiB upload.
 	total := request_parser.frame_expected_total(conn.read_buf)
 	if total > iou_stream_body_above && total <= req_cap {
-		if start_iou_body_drain(mut conn, handler, total) {
+		started := if has_async {
+			mut e := unsafe { &IouAsyncEnv(env) }
+			e.cur_conn = conn
+			async_start_iou_body_drain(mut *e, mut *conn, total, limits)
+		} else {
+			start_iou_body_drain(mut conn, handler, total)
+		}
+		if started {
 			if conn.close_after_send || conn.body_drain == 0 {
 				// Handler errored on the head (send the error, then close), or the
 				// whole body happened to be buffered already — either way send now.
@@ -426,7 +453,7 @@ fn start_iou_body_drain(mut conn io_uring.Connection, handler fn (req []u8, fd i
 	return true
 }
 
-fn handle_io_uring_write(worker &io_uring.Worker, cqe &C.io_uring_cqe, limits Limits, active_conns &core.Counter) {
+fn handle_io_uring_write(worker &io_uring.Worker, cqe &C.io_uring_cqe, env &IouAsyncEnv, limits Limits, active_conns &core.Counter) {
 	track := limits.max_connections > 0
 	res := cqe.res
 	c_ptr := io_uring.decode_connection_ptr(C.io_uring_cqe_get_data64(cqe))
@@ -477,18 +504,57 @@ fn handle_io_uring_write(worker &io_uring.Worker, cqe &C.io_uring_cqe, limits Li
 		conn.response_buffer.clear() // len = 0, capacity kept for the next batch
 	}
 	conn.bytes_sent = 0
+	if unsafe { env != nil } {
+		// Async path: requests pipelined BEHIND a parked/answered one may still sit
+		// in read_buf (the resume drained before flushing, but a burst that parked
+		// during THIS send's completion re-drain can leave more). Drain them now
+		// instead of arming a recv that would wait for bytes that never come.
+		if conn.awaiting_fd >= 0 {
+			return // parked (defensive: a parked conn should have no in-flight send)
+		}
+		if conn.read_buf.len > 0 {
+			mut e := unsafe { &IouAsyncEnv(env) }
+			e.cur_conn = conn
+			async_iou_drain(mut *e, mut *conn, limits)
+			if conn.awaiting_fd >= 0 {
+				return // parked on a new watch: hold responses until it resumes
+			}
+			if conn.send_buf != unsafe { nil } || conn.response_buffer.len > conn.bytes_sent {
+				iou_flush_response(worker, mut *conn, limits)
+				return
+			}
+			if conn.close_after_send {
+				iou_release(worker, mut *conn, active_conns, track)
+				return
+			}
+		}
+	}
 	// Keep-alive: read the next request. read_buf still holds any pipelined
 	// leftover; iou_arm_recv re-arms the read deadline iff that leftover is a
 	// partial request, and leaves an idle keep-alive wait deadline-free.
 	iou_arm_recv(worker, mut *conn, limits)
 }
 
-fn dispatch_io_uring_cqe(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn (req []u8, fd int, mut out []u8) !, limits Limits, active_conns &core.Counter) {
+fn dispatch_io_uring_cqe(worker &io_uring.Worker, cqe &C.io_uring_cqe, handler fn (req []u8, fd int, mut out []u8) !, env &IouAsyncEnv, limits Limits, active_conns &core.Counter) {
 	op := io_uring.decode_op_type(C.io_uring_cqe_get_data64(cqe))
 	match op {
-		io_uring.op_accept { handle_io_uring_accept(worker, cqe, limits, active_conns) }
-		io_uring.op_read { handle_io_uring_read(worker, cqe, handler, limits, active_conns) }
-		io_uring.op_write { handle_io_uring_write(worker, cqe, limits, active_conns) }
+		io_uring.op_accept {
+			handle_io_uring_accept(worker, cqe, limits, active_conns)
+		}
+		io_uring.op_read {
+			handle_io_uring_read(worker, cqe, handler, env, limits, active_conns)
+		}
+		io_uring.op_write {
+			handle_io_uring_write(worker, cqe, env, limits, active_conns)
+		}
+		io_uring.op_poll {
+			// A watched external fd (async runtime) became ready: resume the parked
+			// continuation(s). Only armed when an async_handler is configured.
+			if unsafe { env != nil } {
+				mut e := unsafe { &IouAsyncEnv(env) }
+				handle_io_uring_poll(cqe, mut *e, limits, active_conns)
+			}
+		}
 		else {}
 	}
 }
@@ -528,7 +594,7 @@ fn iou_sweep_timeouts(worker &io_uring.Worker) {
 // up on the main thread and driving it here would make every submit_and_wait
 // fail; doing it all here keeps the ring single-owner (and matches how every
 // thread-per-core io_uring server sets up).
-fn io_uring_worker_main(listener int, cpu_id int, handler fn (req []u8, fd int, mut out []u8) !, stateful_handler core.StatefulHandler, make_state fn () voidptr, limits Limits, active_conns &core.Counter, inflight &core.Counter, draining &core.Counter) {
+fn io_uring_worker_main(listener int, cpu_id int, handler fn (req []u8, fd int, mut out []u8) !, stateful_handler core.StatefulHandler, async_handler core.AsyncHandler, make_state fn () voidptr, limits Limits, active_conns &core.Counter, inflight &core.Counter, draining &core.Counter) {
 	maybe_pin_worker(cpu_id)
 	mut worker := &io_uring.Worker{}
 	worker.cpu_id = cpu_id
@@ -574,7 +640,21 @@ fn io_uring_worker_main(listener int, cpu_id int, handler fn (req []u8, fd int, 
 	}
 	eff_handler := build_iou_handler(handler, stateful_handler, state)
 
-	io_uring_worker_loop(worker, eff_handler, limits, active_conns)
+	// Async runtime (issue #83): with an async_handler set, this worker owns an
+	// IouAsyncEnv (watch registry + state + ring access) and the drain/dispatch
+	// route through the async twins in http_server_io_uring_async_linux.c.v. nil
+	// when unset — the sync hot path then pays one nil-check per CQE and nothing else.
+	mut env := &IouAsyncEnv(unsafe { nil })
+	if async_handler != unsafe { nil } {
+		env = &IouAsyncEnv{
+			h:       async_handler
+			state:   state
+			worker:  worker
+			watches: []IouWatchEntry{len: iou_watch_table_min}
+		}
+	}
+
+	io_uring_worker_loop(worker, eff_handler, env, limits, active_conns)
 }
 
 // build_iou_handler resolves the effective synchronous per-worker handler: with no
@@ -591,7 +671,7 @@ fn build_iou_handler(request_handler fn (req []u8, fd int, mut out []u8) !, stat
 }
 
 @[direct_array_access]
-fn io_uring_worker_loop(worker &io_uring.Worker, handler fn (req []u8, fd int, mut out []u8) !, limits Limits, active_conns &core.Counter) {
+fn io_uring_worker_loop(worker &io_uring.Worker, handler fn (req []u8, fd int, mut out []u8) !, env &IouAsyncEnv, limits Limits, active_conns &core.Counter) {
 	io_uring.prepare_accept(&worker.ring, worker.socket_fd, worker.use_multishot)
 
 	// Only arm the periodic timeout wake when a read or write timeout is
@@ -632,7 +712,7 @@ fn io_uring_worker_loop(worker &io_uring.Worker, handler fn (req []u8, fd int, m
 				break
 			}
 			for i in 0 .. int(n) {
-				dispatch_io_uring_cqe(worker, cqes[i], handler, limits, active_conns)
+				dispatch_io_uring_cqe(worker, cqes[i], handler, env, limits, active_conns)
 			}
 			C.io_uring_cq_advance(&worker.ring, n)
 			if int(n) < io_uring.drain_batch {
@@ -642,6 +722,13 @@ fn io_uring_worker_loop(worker &io_uring.Worker, handler fn (req []u8, fd int, m
 			// to free SQ slots before draining the rest (keeps the SQ from ever
 			// overflowing, regardless of how many completions piled up).
 			C.io_uring_submit(&worker.ring)
+		}
+		// Re-queue watch polls that hit a momentarily-full SQ during the drain —
+		// the submit at the top of the next iteration flushes them. A park is
+		// never silently dropped (see iou_async_register).
+		if unsafe { env != nil } && env.pending_polls.len > 0 {
+			mut e := unsafe { &IouAsyncEnv(env) }
+			iou_retry_pending_polls(mut *e)
 		}
 		if sweep_on {
 			iou_sweep_timeouts(worker)
@@ -743,7 +830,8 @@ pub fn run_io_uring_backend(server Server, mut threads []thread) {
 			exit(1)
 		}
 		threads[i] = spawn io_uring_worker_main(listener, i, server.request_handler, server.stateful_handler,
-			server.make_state, server.limits, server.active_conns, server.inflight[i], server.draining)
+			server.async_handler, server.make_state, server.limits, server.active_conns,
+			server.inflight[i], server.draining)
 	}
 
 	println('listening on http://localhost:${server.port}/ (io_uring)')

--- a/http_server/io_uring/io_uring_linux.c.v
+++ b/http_server/io_uring/io_uring_linux.c.v
@@ -63,6 +63,20 @@ pub const drain_batch = 256
 pub const op_accept = u8(1)
 pub const op_read = u8(2)
 pub const op_write = u8(3)
+// op_poll: a oneshot IORING_OP_POLL_ADD on an EXTERNAL fd (a watched DB socket,
+// timerfd, ...) armed by the async runtime (AsyncCtx.watch). Its user_data packs
+// the WATCHED fd in the pointer bits — NOT a &Connection — because the reactor's
+// watch table is fd-indexed and can be reallocated by growth (a packed pointer
+// into it would dangle); the fd is stable and re-looked-up on completion.
+pub const op_poll = u8(4)
+
+// poll(2) event bits (asm-generic/poll.h; identical values to the epoll bits) for
+// prepare_poll masks and for decoding a poll CQE's res (which carries the RETURNED
+// EVENT MASK, not a byte count).
+pub const pollin = u32(0x001)
+pub const pollout = u32(0x004)
+pub const pollerr = u32(0x008)
+pub const pollhup = u32(0x010)
 
 // IO uring CQE flags
 pub const ioring_cqe_f_more = u32(1 << 1)
@@ -97,6 +111,13 @@ pub fn decode_op_type(data u64) u8 {
 @[inline]
 pub fn decode_connection_ptr(data u64) voidptr {
 	return voidptr(data & ptr_mask)
+}
+
+// decode_ext_fd recovers the watched fd an op_poll CQE was tagged with (see
+// prepare_poll: the pointer bits carry the fd, not a &Connection).
+@[inline]
+pub fn decode_ext_fd(data u64) int {
+	return int(data & ptr_mask)
 }
 
 // ==================== C Bindings ====================
@@ -151,6 +172,7 @@ fn C.io_uring_prep_multishot_accept(sqe &C.io_uring_sqe, fd int, addr voidptr, a
 fn C.io_uring_sqe_set_data64(sqe &C.io_uring_sqe, data u64)
 fn C.io_uring_prep_recv(sqe &C.io_uring_sqe, fd int, buf voidptr, nbytes usize, flags int)
 fn C.io_uring_prep_send(sqe &C.io_uring_sqe, fd int, buf voidptr, nbytes usize, flags int)
+fn C.io_uring_prep_poll_add(sqe &C.io_uring_sqe, fd int, poll_mask u32)
 fn C.io_uring_submit(ring &C.io_uring) int
 
 // One syscall per loop iteration: flush every SQE queued since the last call
@@ -243,6 +265,15 @@ pub mut:
 	// borrowed: never freed or modified here, and guaranteed to outlive the send.
 	send_buf   voidptr
 	send_total int
+
+	// >= 0 while a request on this connection is PARKED on the async runtime
+	// (AsyncCtx.watch returned .suspend awaiting this external fd). A parked
+	// connection has NO client-side op in flight — no recv (so the slot cannot be
+	// freed under a stale CQE) and no send (responses buffered before/at the park
+	// are HELD in response_buffer until resume: an in-flight send's captured data
+	// pointer would dangle if a resume appended to, and thereby reallocated, the
+	// buffer). The op_poll CQE on awaiting_fd is what eventually resumes it.
+	awaiting_fd int = -1
 }
 
 // ==================== Worker Structure ====================
@@ -308,6 +339,7 @@ pub fn pool_acquire(mut w Worker, fd int) &Connection {
 	c.body_drain = 0
 	c.send_buf = unsafe { nil }
 	c.send_total = 0
+	c.awaiting_fd = -1
 	// Lock-free buffer REUSE: the per-worker pool is single-issuer (only this
 	// worker thread ever touches w.conns/free_stack), so a slot's buffers persist
 	// across connections with zero atomics. Reuse the pooled buffer (reset len,
@@ -384,6 +416,7 @@ pub fn pool_release(mut w Worker, mut c Connection) {
 	c.body_drain = 0
 	c.send_buf = unsafe { nil }
 	c.send_total = 0
+	c.awaiting_fd = -1
 	c.owner = unsafe { nil }
 	unsafe {
 		idx := int(u64(&c) - u64(&w.conns[0])) / int(sizeof(Connection))
@@ -476,6 +509,24 @@ pub fn prepare_send(ring &C.io_uring, mut c Connection, data &u8, data_len usize
 	}
 	C.io_uring_prep_send(sqe, c.fd, unsafe { data }, data_len, C.MSG_NOSIGNAL)
 	C.io_uring_sqe_set_data64(sqe, encode_user_data(op_write, &c))
+	return true
+}
+
+// prepare_poll posts a ONESHOT IORING_OP_POLL_ADD on an external fd (a watched DB
+// socket / timerfd) for the async runtime. Oneshot on purpose: it fires exactly one
+// CQE and is gone — the continuation re-arms per park (mirrors the epoll runtime's
+// consume-then-re-arm), so there is never a dangling poll on a pooled fd to cancel
+// at release time. POLL_ADD reports CURRENT readiness at submit, so an fd that is
+// already readable completes immediately (no lost wakeup). The CQE's res carries
+// the returned poll mask (or a negative errno). user_data packs the fd itself, not
+// a pointer (see op_poll). Returns false if the SQ is full.
+pub fn prepare_poll(ring &C.io_uring, fd int, poll_mask u32) bool {
+	sqe := C.io_uring_get_sqe(ring)
+	if unsafe { sqe == nil } {
+		return false
+	}
+	C.io_uring_prep_poll_add(sqe, fd, poll_mask)
+	C.io_uring_sqe_set_data64(sqe, encode_user_data(op_poll, voidptr(usize(fd))))
 	return true
 }
 


### PR DESCRIPTION
## Summary

Implements the async runtime for the **io_uring** backend — the plan from the design study on #83. `async_handler` + `ac.watch(fd)` + `pg_async` now run on io_uring exactly as on epoll: a handler that returns `.suspend` parks its connection; readiness arrives as a **oneshot `IORING_OP_POLL_ADD`** completion on the ring itself, resuming the continuation on the ring's own thread. The epoll entry's DB handler code runs **verbatim** — only `io_multiplexing: .io_uring` changes. Closes #83.

## Design (as studied on the issue)

- **`op_poll` + fd-tagged user_data**: the poll CQE's user_data carries the *watched fd*, not a pointer — the fd-indexed watch table grows by reallocation, so a packed pointer would dangle. `cqe.res` is decoded as the returned **poll mask** (`POLLERR|POLLHUP` → the portable `ac.ready_err`).
- **`SINGLE_ISSUER` holds by construction**: every poll SQE is queued from a continuation running inside the CQE dispatch, on the ring's owner thread. No cross-thread anything; the reactor is per-worker, lock-free.
- **Oneshot, re-armed per park** (the epoll consume-then-re-arm shape): nothing dangling to cancel on a pooled fd; `POLL_ADD` reports current readiness at submit, so a late arm cannot lose a wakeup (probe-verified).
- **Parked = zero client ops in flight.** No recv (the sync path's slot-reuse-UAF cannot arise) and no send — responses produced before/at a park are **held** until resume, because a resume appending to `response_buffer` could realloc it under an in-flight send's captured pointer. (Stream-as-you-go on `.suspend` — SSE over async — is a documented follow-up.)
- **Client hangup while parked is not detected eagerly** (no op ⇒ no CQE): the resume flushes, the send fails on the dead peer, the write path releases the slot — the pooled DB reply is always drained **in order**, so epoll's disconnect-tombstoning machinery isn't needed for correctness here (the `dead` tombstone remains as a defensive guard).
- **SQ-full at park is never silently dropped** (`RegisterFn` returns void, the handler has already submitted its query): the poll goes to a per-worker pending list retried by the loop right after each submit.
- **Pipelined multi-client watches** (several parked clients multiplexed on one pg connection) are ported from epoll's `drain_pipelined` — with one deliberate difference: deactivation of a fully-drained queue happens **inline at each pop, before** the `.done` finish that may re-park the same client on the same fd. A trailing "queue empty ⇒ inactive" epilogue (the epoll shape) deactivates that re-park's fresh watch and strands it forever — reproduced deterministically (`pool_size=1`, client Y on `pg_sleep` + client X pipelining `/db /db`): **0/2 responses pre-fix 3/3 runs, 2/2 post-fix 6/6 runs**. The epoll twin has the same latent epilogue hazard — I'll file it separately.

Sync hot path: unchanged byte-for-byte — the worker threads a nil-able `IouAsyncEnv`; without an `async_handler` the only new cost is one nil-check per CQE.

## Files

- `io_uring/io_uring_linux.c.v` — `op_poll`, poll-mask consts, `prepare_poll`, `decode_ext_fd`, `Connection.awaiting_fd` (+51)
- `http_server_io_uring_async_linux.c.v` — **new**: watch table (single + pipelined queue promotion), `iou_async_register`, `async_iou_drain` (park-aware, `queue_buf` borrow honored), `async_start_iou_body_drain`, `handle_io_uring_poll`, `drain_pipelined_iou`, `iou_finish_resume` (+532)
- `http_server_io_uring_linux.c.v` — env threading through worker main/loop/dispatch/read/write (+116/−22)
- `http_server.c.v` — `new_server` accepts `async_handler` on `.io_uring`; docs
- `README.md` — backend table + handler-paths section

## Verification

- **Phase-0 probe** (committed reasoning in the study): `io_uring_prep_poll_add` links via `fn C.`; CQE res is the mask; oneshot no-refire; already-readable completes immediately; hangup → `POLLIN|POLLHUP` — all under `SINGLE_ISSUER|DEFER_TASKRUN`.
- **timerfd park/resume**: 1000/1000 concurrent parks answered; `/wait /now /wait` pipelined on ONE connection returns **in order**; 20 sequential keep-alive parks; server healthy after clients hang up mid-park.
- **pg_async, io_uring vs epoll** (same binary, `BACKEND` env): `/db` and `/health` **byte-identical** (headers+body); HTTP-pipelined `/db /health /db` in order; 32 concurrent `/db` over a 4-conn pool exercising the pipelined pg-fd queue: 32/32.
- **HOL — the #83 acceptance test**: `/health` answers in **8 ms** while 8 × `pg_sleep(0.2)` queries are parked (blocking libpq: 200–1600 ms).
- **Sustained wrk `/db`**: io_uring 55.4k rps vs epoll 57.5k rps (**parity**, p99 2.2 ms; 0 non-2xx below pool inflight capacity); `/health` 210k rps on the async build (sync path unaffected, client-bound).
- **Pooled conns survive aborts mid-query** (orphaned replies drained in order; same conns keep serving).
- `v test http_server/ pg_async/`: 6/6. **helgrind** (mixed async load): no races in any new async function (only the known startup spawn/GC false positives shared with epoll). Compiles clean under `-prod -gc none`.


## Hardening from adversarial review (both fixed + reproduced end-to-end)

1. **Queue-drain re-park stranding** — deactivation of a fully-drained pipelined queue now happens **inline at each pop, before** the `.done` finish that can re-park the same client on the same fd (a trailing epilogue deactivated the re-park's fresh watch: repro with `pool_size=1` — client Y on `/slow`, client X pipelining `/db /db` — gave **0/2 pre-fix (3/3 runs), 2/2 post-fix (6/6 runs)**).
2. **Watch-then-reject teardown** (`iou_detach_rejected_watch`) — a handler whose park is *rejected* (streamed large-body head returning `.suspend` → 400, or `.done`/`.close` after `ac.watch`) no longer leaves an active watch + armed poll pointing at a soon-recycled connection (same-slot-same-fd ABA → foreign continuation writing into a stranger's response). Pooled fds are **tombstoned** so the in-flight reply still drains in order — verified: **5/5 rounds** of 2 MiB POST rejects followed by `/db` return **byte-exact** rows (no PG FIFO desync). Request-owned fds are cleared+closed (epoll `async_close` parity). Tombstone re-arms bypass the watch table (`rearming_dead`); live dedup skips dead slots.
3. SQ-full pending polls keep their **original mask** (a writable watch is never degraded to a readable retry) and are deduped per fd.

Both epoll twins of hazards 1–2 exist latently in `backend_epoll/async_linux.c.v` (drain_pipelined epilogue; `async_start_body_drain` un-cleared watch) — filed separately.

## Known gaps (documented in the module comment, shared with epoll or follow-ups)

- Parked-connection timeout: deadlines are cleared at park (the sweep must not kill parked conns as slow readers); a hung query on a vanished client pins the slot until the query returns — same gap as epoll (`async_linux.c.v:29`); bound DB-side via `statement_timeout`. A parked-deadline sweep is a shared follow-up.
- `.suspend` stream-as-you-go (SSE over async on io_uring) deferred — bytes accumulate until `.done`.
- `on_worker_start` (clientless background watches) remains epoll-only.

## Follow-up unblocked

The HttpArena `vanilla-io_uring` entry can now adopt the epoll entry's `async_handler` + `pg_async` DB code verbatim — closing the DB-profile gap (`fortunes` 283 rps vs 165k, `async-db` 26–48×, `api-*`) that #83 tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
