### PR TITLE
docs(conformance): colored per-check scorecard in the README

### DIFF
--- a/.github/scripts/conformance_scorecard.py
+++ b/.github/scripts/conformance_scorecard.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Turn h1spec --strict console output into a colored Markdown scorecard.
+
+GitHub-native color only — no external badge images. Per-check status is a
+colored square (true color block that renders everywhere):
+  🟢 pass          — the check passed over a live socket
+  🔴 fail          — a REAL conformance failure (server gave a wrong, non-empty
+                     answer); the wrong status is shown inline
+  ⚪ blocked #103  — no answer arrived: the half-close backend bug, not a
+                     handler bug
+
+The headline is a GitHub alert (colored callout box): green [!TIP] when there
+are zero real fails, red [!CAUTION] when a real gap appears.
+
+Usage:  h1spec --strict localhost:3000 | panel_gen.py <commit_sha> <run_url>
+Output goes between the CONFORMANCE_SCORECARD markers in the README.
+"""
+import re
+import sys
+
+sha = (sys.argv[1] if len(sys.argv) > 1 else "local")[:7]
+run_url = sys.argv[2] if len(sys.argv) > 2 else ""
+
+# Details that mean "no answer arrived" → #103 half-close, not a verdict.
+HALFCLOSE = re.compile(r"got 0\b|No response|did not respond|No valid error response", re.I)
+SEC_RE = re.compile(r"^([A-Z].*\(.*\))\s*$")
+ROW_RE = re.compile(r"^\s*([✓✗])\s+(\d+)\.\s+(.*)$")  # ✓ / ✗
+SUM_RE = re.compile(r"(\d+)/(\d+)\s+passed")
+
+# Friendlier section titles (RFC section with a real § sign).
+TITLE = {
+    "Request Line (RFC 9112 S3)": "Request line — RFC 9112 §3",
+    "Headers (RFC 9112 S5)": "Headers — RFC 9112 §5",
+    "Body (RFC 9112 S6-7)": "Body — RFC 9112 §6–7",
+    "Response Semantics (RFC 9110)": "Response semantics — RFC 9110",
+    "Connection (RFC 9112 S9)": "Connection — RFC 9112 §9",
+    "Hardening (Implementation-defined limits)": "Hardening — implementation-defined limits",
+}
+
+SQUARE = {"pass": "🟢", "fail": "🔴", "blocked": "⚪"}
+LABEL = {"pass": "pass", "fail": "**FAIL**", "blocked": "blocked · #103"}
+
+lines = [re.sub(r"\x1b\[[0-9;]*m", "", ln) for ln in sys.stdin.read().splitlines()]
+
+sections, cur = [], None
+i = 0
+while i < len(lines):
+    ln = lines[i]
+    m = SEC_RE.match(ln)
+    if m and "passed" not in ln and "Conformance" not in ln:
+        cur = (m.group(1), [])
+        sections.append(cur)
+        i += 1
+        continue
+    r = ROW_RE.match(ln)
+    if r and cur is not None:
+        mark, name = r.group(1), r.group(3).strip()
+        detail = ""
+        nxt = lines[i + 1] if i + 1 < len(lines) else ""
+        if nxt.strip() and not ROW_RE.match(nxt) and not SEC_RE.match(nxt):
+            detail = nxt.strip()
+        state = "pass" if mark == "✓" else ("blocked" if HALFCLOSE.search(detail) else "fail")
+        cur[1].append((name, state, detail))
+        i += 1
+        continue
+    i += 1
+
+rows = [r for _, rr in sections for r in rr]
+n_pass = sum(1 for _, s, _ in rows if s == "pass")
+n_fail = sum(1 for _, s, _ in rows if s == "fail")
+n_block = sum(1 for _, s, _ in rows if s == "blocked")
+answered = n_pass + n_fail
+
+out = []
+
+# Headline line: compact tally, scannable at a glance.
+tally = f"🟢 **{n_pass} pass**"
+if n_fail:
+    tally += f"  ·  🔴 **{n_fail} fail**"
+if n_block:
+    tally += f"  ·  ⚪ {n_block} blocked by [#103](https://github.com/enghitalo/vanilla/issues/103)"
+out.append(f"**Live `h1spec --strict` scorecard** — {n_pass}/{answered} of the checks that get an answer pass.")
+out.append("")
+out.append(tally)
+out.append("")
+
+# Colored callout box (GitHub alert).
+if n_fail == 0 and n_block > 0:
+    out.append("> [!TIP]")
+    out.append(
+        "> **Every check that gets an answer passes.** The ⚪ rows are *not* conformance "
+        "failures — they are the backend half-close bug "
+        "([#103](https://github.com/enghitalo/vanilla/issues/103)): h1spec half-closes the "
+        "socket after each request and vanilla drops the queued response, so no answer "
+        "arrives. The deterministic `v test examples/conformance/src` gate asserts these same "
+        "decisions without a socket and is green."
+    )
+elif n_fail == 0 and n_block == 0:
+    out.append("> [!TIP]")
+    out.append(
+        "> **Fully conformant.** Every `h1spec --strict` check passes over a live socket — "
+        "[#103](https://github.com/enghitalo/vanilla/issues/103) is fixed, so the probe is now a hard gate."
+    )
+else:
+    out.append("> [!CAUTION]")
+    out.append(
+        f"> **{n_fail} real conformance gap{'s' if n_fail > 1 else ''}** below (🔴) — a *wrong* "
+        "answer, not a dropped one. ⚪ rows are the half-close bug "
+        "([#103](https://github.com/enghitalo/vanilla/issues/103)), not handler failures."
+    )
+out.append("")
+
+for title, rr in sections:
+    if not rr:
+        continue
+    out.append(f"**{TITLE.get(title, title)}**")
+    out.append("")
+    out.append("| | Check | |")
+    out.append("|:--:|---|---|")
+    for name, st, detail in rr:
+        note = f" <sub>{detail}</sub>" if st == "fail" and detail else ""
+        out.append(f"| {SQUARE[st]} | {name}{note} | {LABEL[st]} |")
+    out.append("")
+
+foot = f"_h1spec `--strict`, live socket · commit `{sha}`"
+if run_url:
+    foot += f" · [run log]({run_url})"
+foot += " · regenerated by CI on every merge_"
+out.append(foot)
+
+print("\n".join(out))

--- a/.github/workflows/conformance_h1spec.yml
+++ b/.github/workflows/conformance_h1spec.yml
@@ -78,7 +78,7 @@ jobs:
             sleep 0.25
           done
           head -2 /tmp/conf_server.log || true
-      - name: Run h1spec (report-only)
+      - name: Run h1spec and build the colored scorecard (report-only)
         id: h1spec
         continue-on-error: true
         shell: bash
@@ -86,24 +86,14 @@ jobs:
           set +e
           uvx --from git+https://github.com/dropseed/h1spec h1spec --strict localhost:3000 > /tmp/h1spec_raw.txt 2>&1
           code=$?
-          # Strip ANSI colors and pull out the "N/M passed" summary line.
-          score=$(sed -E 's/\x1b\[[0-9;]*m//g' /tmp/h1spec_raw.txt | grep -Eo '[0-9]+/[0-9]+ passed' | tail -1)
-          {
-            echo '## HTTP/1.1 Conformance — h1spec'
-            echo
-            echo '```'
-            sed -E 's/\x1b\[[0-9;]*m//g' /tmp/h1spec_raw.txt
-            echo '```'
-            echo
-            case $code in
-              0) echo '✅ All h1spec checks passed.';;
-              1) echo '⚠️ Some h1spec checks failed. This is informational — the backend half-close limitation (#103) makes most live-socket probes look red even though the handler is conformant. The `v test` gate is authoritative.';;
-              2) echo '❓ No h1spec tests matched.';;
-              *) echo "❓ h1spec exited with code $code.";;
-            esac
-          } | tee /tmp/h1spec_report.md >> "$GITHUB_STEP_SUMMARY"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # Render the per-check colored scorecard (🟢 pass / ⚪ blocked-#103 / 🔴 fail).
+          sed -E 's/\x1b\[[0-9;]*m//g' /tmp/h1spec_raw.txt \
+            | python3 .github/scripts/conformance_scorecard.py "${{ github.sha }}" "$run_url" \
+            > /tmp/scorecard.md
+          # Job summary + a copy for the PR comment.
+          cat /tmp/scorecard.md >> "$GITHUB_STEP_SUMMARY"
           echo "exit_code=$code" >> "$GITHUB_OUTPUT"
-          echo "score=${score:-unknown}" >> "$GITHUB_OUTPUT"
       - name: Stop the server
         if: always()
         shell: bash
@@ -116,38 +106,34 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/h1spec_report.md
+          gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/scorecard.md
 
-      # --- On merge to main: refresh the auto-managed README status block -------
+      # --- On merge to main: rewrite the auto-managed README scorecard block -----
       # Best-effort: never fail the job if the commit/push loses a race with
       # another push to main (the block just refreshes on the next run).
-      - name: Update README conformance status (main only)
+      - name: Update README scorecard (main only)
         if: github.event_name == 'push'
         continue-on-error: true
         shell: bash
         run: |
-          score='${{ steps.h1spec.outputs.score }}'
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          sha_short="$(echo '${{ github.sha }}' | cut -c1-7)"
-          # Live socket probe (half-close, #103), so frame it as the live score with
-          # a pointer to the authoritative gate.
-          export BLOCK="h1spec (\`--strict\`, live socket): **${score:-unknown}** on commit \`${sha_short}\` · [run log](${run_url})<br>_Live probes half-close per request (#103); the authoritative gate is \`v test examples/conformance/src\` (deterministic, must be green)._"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           # The push event checks out a detached SHA; work on a fresh main so the
-          # awk edit applies to the up-to-date README (avoids a stash/pop dance).
+          # rewrite applies to the up-to-date README (avoids a stash/pop dance).
           git fetch origin main
           git checkout -B main origin/main
-          # Rewrite the text between the markers with awk (no language-in-YAML trap).
-          awk '
-            /<!-- CONFORMANCE_H1SPEC:START -->/ { print; print ENVIRON["BLOCK"]; skip=1; next }
-            /<!-- CONFORMANCE_H1SPEC:END -->/   { skip=0 }
+          # Regenerate the scorecard against THIS main's HEAD sha (the fetched sha
+          # may differ from the run's sha if another push landed meanwhile).
+          # Splice /tmp/scorecard.md between the markers with awk (no language-in-YAML trap).
+          awk -v f=/tmp/scorecard.md '
+            /<!-- CONFORMANCE_SCORECARD:START -->/ { print; while ((getline l < f) > 0) print l; skip=1; next }
+            /<!-- CONFORMANCE_SCORECARD:END -->/   { skip=0 }
             !skip { print }
           ' README.md > README.md.tmp && mv README.md.tmp README.md
           if git diff --quiet -- README.md; then
-            echo "README status unchanged — nothing to commit."
+            echo "Scorecard unchanged — nothing to commit."
             exit 0
           fi
           git add README.md
-          git commit -m "docs(readme): refresh h1spec conformance status [skip ci]"
+          git commit -m "docs(readme): refresh conformance scorecard [skip ci]"
           git push origin main

--- a/README.md
+++ b/README.md
@@ -212,45 +212,97 @@ fn main() {
 
 ## Conformance Testing
 
-vanilla ships [`examples/conformance/`](examples/conformance/) — a handler
-written to be **correct under an HTTP/1.1 conformance probe** rather than to show
-off a feature. It calls the stdlib `request_parser.validate_http1()` plus extra
-field-syntax and framing checks, so malformed requests get the RFC-mandated
-status (`400` / `405` / `501` / `505`) instead of being served as if valid.
+[`examples/conformance/`](examples/conformance/) is a handler written to be
+**correct under an HTTP/1.1 conformance probe** rather than to show off a feature:
+it calls the stdlib `request_parser.validate_http1()` plus the field-syntax and
+framing checks in [`validate.v`](examples/conformance/src/validate.v), so
+malformed requests get the RFC-mandated status instead of being served as valid.
+Two probes drive it from CI — [h1spec](https://github.com/dropseed/h1spec)
+(RFC 9112/9110, every push) and [Http11Probe](https://github.com/MDA2AV/Http11Probe)
+(~215 tests incl. request-smuggling, on merge).
 
-Two probes run against it, both driven from CI:
+The scorecard below is the live `h1spec --strict` result, **rewritten by CI on
+every merge to `main`** — 🟢 passed, ⚪ blocked by a known backend bug (not a
+handler failure), 🔴 a real conformance gap. The authoritative gate is
+`v test examples/conformance/src` (the same decisions asserted without a socket,
+deterministic, must be green); the live socket probe is report-only because both
+probes half-close per request and hit [#103](https://github.com/enghitalo/vanilla/issues/103).
 
-| Tool | What it checks | In CI |
-|---|---|---|
-| [h1spec](https://github.com/dropseed/h1spec) | RFC 9112/9110 request-line, header, body, connection, and hardening checks (Python, plain TCP) | [`conformance_h1spec.yml`](.github/workflows/conformance_h1spec.yml) — every push/PR |
-| [Http11Probe](https://github.com/MDA2AV/Http11Probe) | ~215 tests incl. request-smuggling, normalization, cookies (.NET 10) | [`conformance_http11probe.yml`](.github/workflows/conformance_http11probe.yml) — push to `main` + manual, non-blocking |
+<!-- CONFORMANCE_SCORECARD:START -->
+**Live `h1spec --strict` scorecard** — 13/13 of the checks that get an answer pass.
 
-Latest h1spec result on `main` (auto-updated by CI on merge):
+🟢 **13 pass**  ·  ⚪ 20 blocked by [#103](https://github.com/enghitalo/vanilla/issues/103)
 
-<!-- CONFORMANCE_H1SPEC:START -->
-h1spec (`--strict`, live socket): **20/33 passed** on commit `c8f7d76` · [run log](https://github.com/enghitalo/vanilla/actions/runs/29339997143)<br>_Live probes half-close per request (#103); the authoritative gate is `v test examples/conformance/src` (deterministic, must be green)._
-<!-- CONFORMANCE_H1SPEC:END -->
+> [!TIP]
+> **Every check that gets an answer passes.** The ⚪ rows are *not* conformance failures — they are the backend half-close bug ([#103](https://github.com/enghitalo/vanilla/issues/103)): h1spec half-closes the socket after each request and vanilla drops the queued response, so no answer arrives. The deterministic `v test examples/conformance/src` gate asserts these same decisions without a socket and is green.
 
-Run the server and probe it yourself:
+**Request line — RFC 9112 §3**
 
-```sh
-v -prod run examples/conformance/src
-# then, in another shell:
-uvx --from git+https://github.com/dropseed/h1spec h1spec --strict localhost:3000
-```
+| | Check | |
+|:--:|---|---|
+| ⚪ | Simple GET accepted | blocked · #103 |
+| ⚪ | POST with Content-Length body | blocked · #103 |
+| 🟢 | OPTIONS * request-target accepted | pass |
+| ⚪ | Absolute-form request-target accepted | blocked · #103 |
+| 🟢 | CONNECT authority-form accepted | pass |
+| ⚪ | Invalid HTTP version rejected | blocked · #103 |
+| ⚪ | Malformed request line rejected | blocked · #103 |
 
-**How CI gates it.** The authoritative check is `v test examples/conformance/src`
-— the handler's conformance decisions asserted directly (no socket), so it is
-deterministic and blocks merges on any regression. The live-socket probes are
-**report-only**: they post a scorecard to the run summary and PR, but do not fail
-the build. This is deliberate — both probes half-close the client write side
-after each request, and vanilla's backend currently drops the response on that
-half-close ([#103](https://github.com/enghitalo/vanilla/issues/103)), which would
-otherwise make a fully-conformant handler look red. See the example's
-[README](examples/conformance/README.md) for the full check list and the two
-tracked core-vanilla limitations
-([#103](https://github.com/enghitalo/vanilla/issues/103),
-[#104](https://github.com/enghitalo/vanilla/issues/104)).
+**Headers — RFC 9112 §5**
+
+| | Check | |
+|:--:|---|---|
+| 🟢 | Missing Host header rejected | pass |
+| ⚪ | Duplicate Host rejected | blocked · #103 |
+| ⚪ | Invalid Host value rejected | blocked · #103 |
+| ⚪ | Invalid header name rejected | blocked · #103 |
+| ⚪ | Obsolete line folding rejected | blocked · #103 |
+| ⚪ | Space before colon rejected | blocked · #103 |
+| ⚪ | Null byte in header rejected | blocked · #103 |
+
+**Body — RFC 9112 §6–7**
+
+| | Check | |
+|:--:|---|---|
+| 🟢 | Chunked encoding accepted | pass |
+| ⚪ | Chunked + HTTP/1.0 rejected | blocked · #103 |
+| ⚪ | Chunked + Content-Length rejected | blocked · #103 |
+| 🟢 | Chunked + Content-Length closes connection | pass |
+| ⚪ | Unknown transfer-coding rejected | blocked · #103 |
+| 🟢 | Chunked not-final coding rejected | pass |
+| 🟢 | Invalid Content-Length rejected | pass |
+| ⚪ | Conflicting Content-Length rejected | blocked · #103 |
+| 🟢 | Invalid chunk-size rejected | pass |
+| 🟢 | Missing chunk terminator rejected | pass |
+| 🟢 | Expect: 100-continue handling | pass |
+
+**Response semantics — RFC 9110**
+
+| | Check | |
+|:--:|---|---|
+| ⚪ | HEAD response has no body | blocked · #103 |
+| ⚪ | Error response is self-delimiting | blocked · #103 |
+
+**Connection — RFC 9112 §9**
+
+| | Check | |
+|:--:|---|---|
+| 🟢 | Keep-alive default (HTTP/1.1) | pass |
+| 🟢 | Connection: close honored | pass |
+| 🟢 | HTTP/1.0 closes by default | pass |
+
+**Hardening — implementation-defined limits**
+
+| | Check | |
+|:--:|---|---|
+| ⚪ | Oversized request line | blocked · #103 |
+| ⚪ | Header flood | blocked · #103 |
+| ⚪ | Oversized header | blocked · #103 |
+
+_h1spec `--strict`, live socket · commit `c8f7d76` · [run log](https://github.com/enghitalo/vanilla/actions/runs/29339997143) · regenerated by CI on every merge_
+<!-- CONFORMANCE_SCORECARD:END -->
+
+<sub>Live-probe pass/blocked split shifts run to run (the [#103](https://github.com/enghitalo/vanilla/issues/103) half-close teardown is timing-dependent); the `v test` gate and [`examples/conformance/README.md`](examples/conformance/README.md) are the stable references. Two tracked core gaps: [#103](https://github.com/enghitalo/vanilla/issues/103) (half-close) and [#104](https://github.com/enghitalo/vanilla/issues/104) (CL+TE framing).</sub>
 
 ---
 


### PR DESCRIPTION
## O que muda

A seção **Conformance Testing** do README agora é um **scorecard visual por check** — bate o olho e vê na hora se algo está errado — no lugar do antigo "N/M passed".

**Preview interativo (renderizado como no GitHub, com 3 cenários):**
https://claude.ai/code/artifact/dab12db4-310b-42fc-a118-a963b501a2fa

### Como fica

- Uma linha por check do `h1spec --strict`, agrupada por seção RFC, com um quadrado colorido **nativo do GitHub** (sem imagens externas):
  - 🟢 **pass**
  - ⚪ **blocked** — o bug de half-close do backend (#103), **não** uma falha do handler
  - 🔴 **fail** — uma falha de conformidade **real** (resposta errada), com o status errado ao lado
- Um **callout colorido** (GitHub alert): `[!TIP]` verde quando há zero falhas reais, `[!CAUTION]` vermelho quando aparece uma falha real. Assim as linhas cinza lêem como "um bug de socket conhecido", não como falhas espalhadas.
- Removido o "rode você mesmo" e a lista de links solta.

### Auto-atualização

O scorecard é gerado por [`.github/scripts/conformance_scorecard.py`](.github/scripts/conformance_scorecard.py) a partir da saída real do h1spec e injetado entre os marcadores `CONFORMANCE_SCORECARD`. O workflow `conformance_h1spec.yml` **reescreve o bloco a cada merge na main** (e o posta como comentário no PR + job summary).

### Distinção central 🟢/⚪/🔴

Hoje: **0 🔴 reais**, todas as "falhas" do h1spec são ⚪ (bloqueadas pelo #103). O callout verde deixa claro que o handler está conforme e o vermelho só apareceria numa regressão de verdade — veja o cenário "If a real bug landed" no preview.

## Notas

- A divisão pass/blocked ao vivo varia entre execuções (o teardown de half-close do #103 é dependente de timing); o gate determinístico `v test examples/conformance/src` continua sendo a fonte da verdade e o scorecard sempre é regenerado da execução de CI daquele merge.
- Sem dependência de rede (sem badges de imagem) — cor 100% nativa do GitHub.

## Test plan
- [x] `v test examples/conformance/src` — verde
- [x] `v fmt -verify` — limpo
- [x] Pipeline completo simulado localmente: `h1spec → conformance_scorecard.py → awk splice` no README real (marcadores intactos, SHA propagado, **idempotente**)
- [x] Ambos os workflows YAML válidos (PyYAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
