### PR TITLE
ci(conformance): pin -cc gcc -no-parallel to fix flaky build

### DIFF
--- a/.github/workflows/conformance_h1spec.yml
+++ b/.github/workflows/conformance_h1spec.yml
@@ -52,11 +52,16 @@ jobs:
           sudo apt-get install -y liburing-dev linux-libc-dev
 
       # --- Hard gate: deterministic handler-level conformance assertions --------
-      # `-cc gcc -no-parallel`: the default (non -prod) build hits two V-toolchain
-      # flakes — tcc can't parse liburing's <stdatomic.h> (and the tcc->gcc
-      # fallback is a race), and parallel debug codegen non-deterministically emits
-      # an unmangled `array_free` (undefined-reference link error). Pinning gcc +
-      # serial codegen removes both, matching the example matrix workflows.
+      # `-cc gcc -no-parallel`: the default build hits two V-toolchain flakes —
+      #   * -no-parallel fixes the codegen data race in vlang/v#27749: parallel
+      #     codegen races on g.table.find_sym() and emits builtin methods
+      #     unmangled (`array_free` vs `builtin__array_free`) → intermittent
+      #     `undefined reference` at link. It is a codegen bug, so it is NOT
+      #     C-compiler-dependent; only -no-parallel eliminates it.
+      #   * -cc gcc avoids the separate tcc<->gcc fallback race on liburing's
+      #     <stdatomic.h> (which every http_server build pulls in).
+      # Matches the example matrix workflows. -prod is not immune to #27749, so
+      # keep -no-parallel here even though these are debug builds.
       - name: Build examples/conformance
         shell: bash
         run: v -cc gcc -no-parallel examples/conformance/src

--- a/.github/workflows/conformance_h1spec.yml
+++ b/.github/workflows/conformance_h1spec.yml
@@ -52,12 +52,17 @@ jobs:
           sudo apt-get install -y liburing-dev linux-libc-dev
 
       # --- Hard gate: deterministic handler-level conformance assertions --------
+      # `-cc gcc -no-parallel`: the default (non -prod) build hits two V-toolchain
+      # flakes — tcc can't parse liburing's <stdatomic.h> (and the tcc->gcc
+      # fallback is a race), and parallel debug codegen non-deterministically emits
+      # an unmangled `array_free` (undefined-reference link error). Pinning gcc +
+      # serial codegen removes both, matching the example matrix workflows.
       - name: Build examples/conformance
         shell: bash
-        run: v examples/conformance/src
+        run: v -cc gcc -no-parallel examples/conformance/src
       - name: Unit tests (hard gate)
         shell: bash
-        run: v test examples/conformance/src
+        run: v -cc gcc -no-parallel test examples/conformance/src
 
       # --- Report: live-server probe with h1spec --------------------------------
       - name: Install h1spec (uv)

--- a/.github/workflows/conformance_http11probe.yml
+++ b/.github/workflows/conformance_http11probe.yml
@@ -57,8 +57,9 @@ jobs:
           sudo apt-get install -y liburing-dev linux-libc-dev
       - name: Build examples/conformance
         shell: bash
-        # `-cc gcc -no-parallel`: avoids the default-build V-toolchain flakes
-        # (tcc + <stdatomic.h>, and a non-deterministic unmangled `array_free`).
+        # `-cc gcc -no-parallel`: -no-parallel fixes the codegen data race
+        # vlang/v#27749 (unmangled `array_free` -> undefined reference at link),
+        # -cc gcc avoids the tcc<->gcc fallback race on liburing's <stdatomic.h>.
         # Matches the example matrix and the h1spec conformance workflow.
         run: v -cc gcc -no-parallel examples/conformance/src
       - name: Start the conformance server

--- a/.github/workflows/conformance_http11probe.yml
+++ b/.github/workflows/conformance_http11probe.yml
@@ -57,7 +57,10 @@ jobs:
           sudo apt-get install -y liburing-dev linux-libc-dev
       - name: Build examples/conformance
         shell: bash
-        run: v examples/conformance/src
+        # `-cc gcc -no-parallel`: avoids the default-build V-toolchain flakes
+        # (tcc + <stdatomic.h>, and a non-deterministic unmangled `array_free`).
+        # Matches the example matrix and the h1spec conformance workflow.
+        run: v -cc gcc -no-parallel examples/conformance/src
       - name: Start the conformance server
         shell: bash
         run: |


### PR DESCRIPTION
## Problem

The `(Linux) HTTP/1.1 Conformance (h1spec)` workflow **failed on the main-push run** for #106 at the `Build examples/conformance` step:

```
warning: tcc compilation failed, falling back to cc
cc: undefined reference to `array_free'
cc: collect2: error: ld returned 1 exit status
```

It **passed** on the PR run of the same commit — this is the known **non-deterministic** default-build V-toolchain flake: parallel debug codegen occasionally emits an unmangled `array_free`, and the tcc→gcc fallback on liburing's `<stdatomic.h>` is a race. The example matrix workflow (`build_test_examples_on_linux.yml`) already documents and works around it with `-cc gcc -no-parallel`; the conformance workflows were built with plain `v` and so were still exposed.

## Fix

Pin `-cc gcc -no-parallel` on the `v` build/test invocations in both `conformance_h1spec.yml` and `conformance_http11probe.yml`, matching the example matrix. `-prod` builds are immune; this only touches these default-mode CI builds.

## Test plan
- [x] `v -no-parallel test examples/conformance/src` — green locally
- [x] Both workflow YAMLs valid
- [ ] Green on this PR's CI run (the point of the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
