### PR TITLE
fix(request_parser): reject CL+TE, unterminated chunks, and length overflow (#104, #109)

### DIFF
--- a/.github/workflows/conformance_h1spec.yml
+++ b/.github/workflows/conformance_h1spec.yml
@@ -68,6 +68,14 @@ jobs:
       - name: Unit tests (hard gate)
         shell: bash
         run: v -cc gcc -no-parallel test examples/conformance/src
+      - name: Request-parser framer tests (hard gate)
+        shell: bash
+        # Split-point framing tests incl. the CL+TE (#104), missing-chunk-terminator
+        # (#109) and chunk-size / Content-Length overflow regression cases — the
+        # last guard against a hostile request re-crashing a worker (SIGSEGV) or
+        # smuggling. Not covered by the example matrices; runs here on Linux (glibc
+        # provides memmem — this test can't build on macOS, a separate gotcha).
+        run: v -cc gcc -no-parallel test http_server/http1_1/request_parser/
       - name: Backend behaviour tests (epoll, hard gate)
         shell: bash
         # Drives a real epoll server over raw sockets: pipelining, framing,

--- a/http_server/http1_1/request_parser/request_parser.v
+++ b/http_server/http1_1/request_parser/request_parser.v
@@ -522,6 +522,15 @@ pub fn frame_request_length_lim_idx(buf []u8, max_header int, max_body int) int 
 			}
 			if buf[pos + 1] == lf_char {
 				body_start := pos + 2
+				// RFC 9112 §6.1: a message with BOTH Content-Length and
+				// Transfer-Encoding is the classic request-smuggling ambiguity and
+				// MUST be rejected. Do it here — the moment both are known — instead
+				// of letting the chunked framer run: with a non-chunked body it would
+				// return -1 (incomplete) forever and stall the connection until the
+				// read timeout, never surfacing the 400 (issue #104).
+				if chunked && content_length >= 0 {
+					return frame_err_malformed
+				}
 				if chunked {
 					// Cold path: the chunked framer still returns a Result; map it
 					// to a sentinel (the one boxing here is off the GET hot path).
@@ -687,19 +696,34 @@ fn line_header_value(buf []u8, line_start int, line_len int, name string) ?Slice
 	}
 }
 
+// max_declared bounds a declared length (Content-Length or a chunk-size). A body
+// larger than this is refused outright — no legitimate request needs it, and it
+// keeps the value well inside a 32-bit `int` so the accumulator below can never
+// overflow into a negative/wrapped value (which previously produced a wrong
+// content_length, and for chunk-sizes an out-of-bounds index / smuggling desync).
+// ~1 GiB: comfortably above any real upload, far below int overflow.
+const max_declared = 1 << 30
+
 fn parse_content_length(buf []u8, s Slice) !int {
 	if s.len == 0 {
 		return error('empty Content-Length')
 	}
-	mut n := 0
+	// Accumulate in i64 so the arithmetic can't wrap a 32-bit int; reject over the
+	// cap. A 32-bit accumulator let a Content-Length of 2147483648 wrap to < 0, so
+	// a textually-present header framed as if absent. Checking i64 > cap each step
+	// also bounds a long digit run before it can grow without limit.
+	mut n := i64(0)
 	for i in s.start .. s.start + s.len {
 		c := buf[i]
 		if c < `0` || c > `9` {
 			return error('non-digit in Content-Length')
 		}
-		n = n * 10 + int(c - `0`)
+		n = n * 10 + i64(c - `0`)
+		if n > max_declared {
+			return error('Content-Length exceeds ${max_declared} bytes')
+		}
 	}
-	return n
+	return int(n)
 }
 
 // ci_contains reports whether the value slice contains `needle` (ASCII, CI).
@@ -741,7 +765,13 @@ fn frame_chunked_total(buf []u8, body_start int, max_body int) !int {
 		}
 		line_lf := find_byte(&buf[pos], buf.len - pos, lf_char) or { return -1 }
 		size_end := pos + line_lf // index of LF
-		mut size := 0
+		// Accumulate the chunk-size in i64 so the arithmetic itself can never wrap a
+		// 32-bit int, then reject anything over max_declared. A 32-bit accumulator
+		// let 0x80000000 wrap NEGATIVE (crlf_at went out of bounds → segfault under
+		// @[direct_array_access]) and 0x100000000 wrap to EXACTLY 0 (hijacking the
+		// size==0 terminating-chunk branch → smuggling desync). Checking i64 > cap
+		// after each digit catches both before size is ever used as an index.
+		mut size64 := i64(0)
 		mut j := pos
 		for j < size_end && buf[j] != cr_char {
 			c := buf[j]
@@ -749,9 +779,13 @@ fn frame_chunked_total(buf []u8, body_start int, max_body int) !int {
 				break // chunk extensions: ignore the rest of the size line
 			}
 			d := hex_digit(c) or { return error_with_code('invalid chunk size', 400) }
-			size = size * 16 + d
+			size64 = size64 * 16 + d
+			if size64 > max_declared {
+				return error_with_code('chunk size exceeds ${max_declared} bytes', 400)
+			}
 			j++
 		}
+		size := int(size64)
 		data_start := size_end + 1
 		if size == 0 {
 			// Terminating chunk; require the closing CRLF (trailers not modeled).
@@ -763,10 +797,19 @@ fn frame_chunked_total(buf []u8, body_start int, max_body int) !int {
 			}
 			return -1
 		}
-		next := data_start + size + 2 // data + trailing CRLF
-		if next > buf.len {
-			return -1
+		// chunk-data is followed by a REQUIRED CRLF (RFC 9112 §7.1). Verify those
+		// two bytes really are CR LF instead of assuming them — a body like
+		// `5\r\nhello0\r\n\r\n` (data runs straight into the next chunk-size, no
+		// terminator) would otherwise frame to a bogus length and desync the
+		// connection, serving the malformed request as if valid (issue #109).
+		crlf_at := data_start + size
+		if crlf_at + 1 >= buf.len {
+			return -1 // terminator not buffered yet
 		}
+		if buf[crlf_at] != cr_char || buf[crlf_at + 1] != lf_char {
+			return error_with_code('chunk-data not terminated by CRLF', 400)
+		}
+		next := crlf_at + 2 // data + trailing CRLF
 		pos = next
 	}
 	return -1

--- a/http_server/http1_1/request_parser/request_parser_test.v
+++ b/http_server/http1_1/request_parser/request_parser_test.v
@@ -383,6 +383,86 @@ fn test_frame_chunked() {
 	assert frame_request_length(req[..req.len - 1])! == -1 // missing final CRLF
 }
 
+// issue #104: Content-Length + Transfer-Encoding together must be REJECTED at
+// the framing layer (400), not stall as "incomplete". The framer previously
+// committed to chunked framing and, with a non-chunked body, returned -1 forever
+// (stalling the connection until the read timeout) so the 400 never surfaced.
+fn test_frame_cl_te_conflict_rejected() {
+	// TE + CL with a plain (non-chunked) body: must be a hard 400, not -1.
+	req :=
+		'POST /x HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\nhello'.bytes()
+	if _ := frame_request_length(req) {
+		assert false, 'CL+TE must be rejected (#104)'
+	} else {
+		assert err.code() == 400, 'CL+TE must map to 400, got ${err.code()}'
+	}
+	// Header order must not matter, and it must reject as soon as the blank line
+	// is seen — even before any body bytes arrive.
+	no_body :=
+		'POST /x HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n'.bytes()
+	if _ := frame_request_length(no_body) {
+		assert false, 'CL+TE (no body yet) must be rejected (#104)'
+	} else {
+		assert err.code() == 400
+	}
+}
+
+// issue #109: chunk-data MUST be followed by CRLF (RFC 9112 §7.1). A body where
+// the data runs straight into the next token (no terminator) must be rejected
+// 400, not framed to a bogus length that desyncs the connection.
+fn test_frame_chunked_missing_terminator() {
+	// `5\r\nhello0\r\n\r\n`: the 5-byte "hello" chunk is NOT followed by CRLF.
+	req :=
+		'POST /x HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello0\r\n\r\n'.bytes()
+	if _ := frame_request_length(req) {
+		assert false, 'chunk-data without a CRLF terminator must be rejected (#109)'
+	} else {
+		assert err.code() == 400, 'missing chunk terminator must map to 400, got ${err.code()}'
+	}
+	// A correctly-terminated single chunk still frames exactly.
+	ok :=
+		'POST /x HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n'.bytes()
+	assert frame_request_length(ok)! == ok.len
+}
+
+// Overflow hardening (found by adversarial review of the #109 change). V's `int`
+// is 32-bit signed; a chunk-size or Content-Length that overflows it must be
+// rejected 400, never wrapped: a wrap-to-negative chunk size made crlf_at go
+// out of bounds (segfault under -prod's @[direct_array_access]); a wrap-to-zero
+// (0x100000000) hijacked the size==0 terminating branch (smuggling desync); an
+// overflowing Content-Length framed a present header as absent.
+fn test_frame_chunk_size_overflow_negative() {
+	// 0x80000000 = 2^31 wraps to a negative int without the cap.
+	req := 'POST /x HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n80000000\r\nAB'.bytes()
+	if _ := frame_request_length(req) {
+		assert false, 'overflowing chunk size must be rejected, not wrapped'
+	} else {
+		assert err.code() == 400
+	}
+}
+
+fn test_frame_chunk_size_overflow_to_zero() {
+	// 0x100000000 = 2^32 wraps to EXACTLY 0 without the cap → must NOT be treated
+	// as a terminating chunk that frames the message early.
+	req :=
+		'POST /x HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n100000000\r\n\r\nSMUGGLED'.bytes()
+	if got := frame_request_length(req) {
+		assert false, 'chunk size 0x100000000 must be rejected, framed to ${got} (smuggling)'
+	} else {
+		assert err.code() == 400
+	}
+}
+
+fn test_frame_content_length_overflow() {
+	// 2147483648 = 2^31 overflows a 32-bit int; must be rejected, not wrapped < 0.
+	req := 'POST /x HTTP/1.1\r\nHost: x\r\nContent-Length: 2147483648\r\n\r\n'.bytes()
+	if _ := frame_request_length(req) {
+		assert false, 'overflowing Content-Length must be rejected'
+	} else {
+		assert err.code() == 400
+	}
+}
+
 fn test_frame_incomplete_request_line() {
 	assert frame_request_length('GET / HTT'.bytes())! == -1
 	assert frame_request_length('GET'.bytes())! == -1


### PR DESCRIPTION
Three framer fixes, all with split-point regression tests in `request_parser_test.v`. Closes #104 and #109.

## #104 — Content-Length + Transfer-Encoding stall → 400

The framer committed to chunked framing whenever TE was present and ignored a coexisting Content-Length. With a non-chunked body it returned `-1` (incomplete) **forever**, stalling the connection until the read timeout — the smuggling rejection (RFC 9112 §6.1) never surfaced. Now rejected `400` the moment both headers are seen (at the blank line), regardless of order or body bytes.

## #109 — chunk-data with a missing CRLF terminator → 400

`frame_chunked_total` advanced `data_start + size + 2` **assuming** the trailing CRLF. A body like `5\r\nhello0\r\n\r\n` (data runs straight into the next size, no terminator) framed to a bogus length and desynced the connection, serving it as valid. Now the two bytes are verified to be CR LF (RFC 9112 §7.1); otherwise `400`.

## Integer-overflow hardening (found by adversarial review of the #109 change)

An adversarial review of the diff surfaced a **pre-existing** overflow in the same functions that the #109 change would otherwise leave exploitable — I fixed it here:

- **`0x80000000` chunk-size → negative wrap → SIGSEGV.** The 32-bit `int` accumulator wrapped negative; the new CR/LF index (`crlf_at = data_start + size`) went hugely negative, and the guard `crlf_at + 1 >= buf.len` is false for negatives, so `buf[crlf_at]` read out of bounds. Under `-prod` (`@[direct_array_access]` elides bounds checks) a **~68-byte request crashed the worker** — reproduced live (`CONN REFUSED` after the first probe).
- **`0x100000000` chunk-size → wraps to exactly 0** → hijacks the `size==0` terminating-chunk branch → **request-smuggling desync** (framer declares the message complete early, leaving attacker bytes as a "next" request).
- **`Content-Length: 2147483648` → wraps < 0** → a textually-present header framed as absent.

Fix: accumulate both the chunk-size and Content-Length in **i64** and reject over a **1 GiB cap** (`max_declared`) before the value is ever used as an index.

## Verification (end-to-end via `examples/conformance`, kqueue local)

| input | before | after |
|---|---|---|
| CL+TE (either order) | 444 stall / accept | **400** |
| `5\r\nhello0\r\n\r\n` (no term) | 200 | **400** |
| chunk `0x80000000` | **SIGSEGV** | **400**, server alive |
| chunk `0x100000000` | smuggle | **400** |
| `Content-Length: 2147483648` | wrap < 0 | **400** |
| valid chunked / CL=5 / GET | ok | ok (no regression) |

`h1spec --strict`: **33/33**. `v test examples/conformance/src`: green. `v fmt`: clean.

> The framer unit tests (`request_parser_test.v`) can't build on macOS (a pre-existing `memmem`/`_GNU_SOURCE` gotcha), so I verified via the running server; the new `test_frame_*` cases run on Linux CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
