### PR TITLE
feat(http_server): 100 Continue for Expect: 100-continue on epoll (RFC 9110 §10.1.1)

### DIFF
--- a/http_server/backend_behaviors_test.v
+++ b/http_server/backend_behaviors_test.v
@@ -351,6 +351,33 @@ fn check_half_close_after_request(backend IOBackend, port int) ! {
 	server.shutdown(500)
 }
 
+// check_expect_100_continue: a client that sends the head with
+// `Expect: 100-continue` and holds the body must be prompted with an interim
+// `100 Continue` (RFC 9110 §10.1.1); after it sends the body it gets the final
+// response. Without the prompt the server would wait for a body the client is
+// deliberately withholding, and the request would stall.
+fn check_expect_100_continue(backend IOBackend, port int) ! {
+	mut server := new_server(ServerConfig{
+		port:            port
+		io_multiplexing: backend
+		handler:         bb_ok_handler
+	})!
+	bb_start(mut server, port)
+
+	mut c := net.dial_tcp('127.0.0.1:${port}')!
+	// Head only — the 5-byte body is withheld until we see 100 Continue.
+	c.write('POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nExpect: 100-continue\r\n\r\n'.bytes())!
+	got100 := read_until_count(mut c, 'HTTP/1.1 100', 1, 3000)
+	assert got100 == 1, '${backend}: Expect: 100-continue must be answered with an interim 100, got ${got100}'
+	// Now send the body; the final 200 must follow.
+	c.write('hello'.bytes())!
+	got200 := read_until_count(mut c, 'HTTP/1.1 200', 1, 3000)
+	c.close() or {}
+	assert got200 == 1, '${backend}: final response must follow the body after 100 Continue, got ${got200}'
+
+	server.shutdown(500)
+}
+
 // --- io_uring -------------------------------------------------------------
 
 fn test_iouring_large_upload_drain() ! {
@@ -424,5 +451,11 @@ fn test_epoll_graceful_shutdown() ! {
 fn test_epoll_half_close_after_request() ! {
 	$if linux {
 		check_half_close_after_request(.epoll, 8136)!
+	}
+}
+
+fn test_epoll_expect_100_continue() ! {
+	$if linux {
+		check_expect_100_continue(.epoll, 8137)!
 	}
 }

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -465,6 +465,23 @@ fn serve_conn(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, limits 
 			}
 			return
 		}
+		// Expect: 100-continue (RFC 9110 §10.1.1). drain_requests left a partial
+		// request in read_buf (its body has not fully arrived); if its head is
+		// complete and asks for 100-continue, prompt the client ONCE by queueing an
+		// interim 100 for the end-of-burst flush. Gated so the hot path pays nothing:
+		// only reached when bytes remain buffered (drain consumed a complete request
+		// otherwise) and never re-scanned once sent_100 is set.
+		if cs.read_buf.len == 0 {
+			if cs.sent_100 {
+				cs.sent_100 = false // request fully consumed — re-arm for the next one
+			}
+		} else if !cs.sent_100 && cs.body_drain == 0 {
+			head_len := request_parser.frame_head_len(cs.read_buf)
+			if head_len > 0 && request_parser.head_expects_100_continue(cs.read_buf, head_len) {
+				cs.write_buf << response.status_100_continue_response
+				cs.sent_100 = true
+			}
+		}
 	}
 	// Read-timeout bookkeeping — BEFORE the flush below, which may close the
 	// connection (close_conn resets the state; arming after it would leak a

--- a/http_server/backend_epoll/conn_state_linux.c.v
+++ b/http_server/backend_epoll/conn_state_linux.c.v
@@ -121,6 +121,12 @@ mut:
 	// paths close the connection once the buffer drains instead of keeping it
 	// alive — a half-closed peer will never send another request. See issue #103.
 	close_after_flush bool
+	// Set once a 100 Continue interim response has been sent for the request
+	// currently mid-read, so a peer that sends `Expect: 100-continue` and dribbles
+	// its body across edges is prompted exactly once (RFC 9110 §10.1.1). Reset per
+	// connection (a keep-alive connection may carry several Expect requests, but
+	// only one is ever mid-read at a time, and close_conn clears it).
+	sent_100 bool
 }
 
 // PlainState is the per-worker connection table. `parked` counts connections
@@ -437,6 +443,7 @@ fn close_conn(epoll_fd int, fd int, active_conns &core.Counter, mut st PlainStat
 			cs.body_drain = 0
 			cs.awaiting_fd = -1
 			cs.close_after_flush = false
+			cs.sent_100 = false
 			st.conns[fd] = unsafe { nil }
 			st.free_conns << cs
 		}

--- a/http_server/http1_1/request_parser/request_parser.v
+++ b/http_server/http1_1/request_parser/request_parser.v
@@ -666,6 +666,43 @@ pub fn frame_head_len(buf []u8) int {
 	return -1
 }
 
+// head_expects_100_continue reports whether the request head buffered in
+// `buf[..head_len]` carries `Expect: 100-continue` (RFC 9110 §10.1.1). Scans the
+// header lines for an `Expect` field whose value contains `100-continue`
+// (case-insensitive). Off the hot path: the backend calls this ONCE per
+// connection, and only while a body is still pending (a rare shape), so the walk
+// never touches the GET/no-body or fully-buffered request path.
+@[direct_array_access]
+pub fn head_expects_100_continue(buf []u8, head_len int) bool {
+	if head_len <= 0 || head_len > buf.len {
+		return false
+	}
+	// Skip the request line (first LF); Expect can only be a header field.
+	rl := find_byte_idx(&buf[0], head_len, lf_char)
+	if rl < 0 {
+		return false
+	}
+	mut pos := rl + 1
+	for pos < head_len {
+		if buf[pos] == cr_char {
+			break // blank line => end of headers
+		}
+		line_lf := find_byte_idx(&buf[pos], head_len - pos, lf_char)
+		if line_lf < 0 {
+			break
+		}
+		line_start := pos
+		line_len := line_lf - 1 // bytes before the CR
+		pos = line_start + line_lf + 1
+		if v := line_header_value(buf, line_start, line_len, 'Expect') {
+			if ci_contains(buf, v, '100-continue') {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // content_length returns the request's Content-Length header value, or -1 if it
 // is absent or unparseable. Lets a handler answer by declared length even when
 // the engine drained (never buffered) the body.

--- a/http_server/http1_1/request_parser/request_parser_test.v
+++ b/http_server/http1_1/request_parser/request_parser_test.v
@@ -475,6 +475,27 @@ fn test_frame_malformed_content_length() {
 	}
 }
 
+// head_expects_100_continue detects `Expect: 100-continue` in a buffered head so
+// the backend can prompt the client (RFC 9110 §10.1.1). Case-insensitive on both
+// the field-name and the value; must not false-match another header or a request
+// that merely mentions the token in a different field.
+fn test_head_expects_100_continue() {
+	// Present (exact) — head_len is the whole buffer (head only, no body yet).
+	h1 := 'POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\nExpect: 100-continue\r\n\r\n'.bytes()
+	assert head_expects_100_continue(h1, h1.len)
+	// Case-insensitive name + value.
+	h2 := 'POST / HTTP/1.1\r\nHost: x\r\nEXPECT: 100-Continue\r\n\r\n'.bytes()
+	assert head_expects_100_continue(h2, h2.len)
+	// Absent.
+	h3 := 'POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\n'.bytes()
+	assert !head_expects_100_continue(h3, h3.len)
+	// The token in a DIFFERENT header must not match.
+	h4 := 'POST / HTTP/1.1\r\nHost: x\r\nX-Note: 100-continue please\r\n\r\n'.bytes()
+	assert !head_expects_100_continue(h4, h4.len)
+	// A prefix that hasn't reached the header yet: no false positive.
+	assert !head_expects_100_continue('POST / HTTP/1.1\r\n'.bytes(), 17)
+}
+
 // Split-point fuzzing: the regression guard for the read-loop framing. For a
 // full request, EVERY prefix shorter than the message reports incomplete (-1),
 // and the exact full length reports complete. No sockets involved.

--- a/http_server/http1_1/response/response.c.v
+++ b/http_server/http1_1/response/response.c.v
@@ -13,6 +13,14 @@ pub const status_413_response = 'HTTP/1.1 413 Payload Too Large\r\nContent-Lengt
 pub const status_431_response = 'HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const status_408_response = 'HTTP/1.1 408 Request Timeout\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 
+// Interim 100 Continue (RFC 9110 §10.1.1): sent when a request carries
+// `Expect: 100-continue` and the server is willing to receive the body, to
+// prompt the client to send it. It is an informational (1xx) response — no
+// body, no Content-Length — and is followed by the normal final response once
+// the body arrives. pub so the epoll backend can APPEND it to the batched write
+// buffer ahead of the eventual final response.
+pub const status_100_continue_response = 'HTTP/1.1 100 Continue\r\n\r\n'.bytes()
+
 // HTTP response helpers.
 
 // send_response writes the full response, looping over partial writes.


### PR DESCRIPTION
Closes the last ⚪ on the conformance scorecard: `Expect: 100-continue`.

## Problem

A client that sends the request head with `Expect: 100-continue` and **withholds the body** until prompted got **no response on epoll** — the framer waits for a body that never arrives, so the connection stalled (h1spec "Expect: 100-continue handling" → ⚪ blocked). The handler can't fix this: the request never frames as complete, so it never reaches the handler.

## Fix

When `drain_requests` leaves a **complete head with a pending body**, the epoll reader emits an interim `100 Continue` once to prompt the client (RFC 9110 §10.1.1), then answers normally once the body arrives.

## Performance — kept ~zero, gated

The added work runs **only after `drain_requests` and only when bytes remain buffered**. A complete request is fully consumed by `drain_requests`, so the GET / fully-buffered-POST hot path hits just:

```v
if cs.read_buf.len == 0 {
    if cs.sent_100 { cs.sent_100 = false }   // common case: sent_100 is false → short-circuits
}
```

— two compares, **no writes, no scan, no allocation** on the alloc-free hot path. The `Expect`-header scan (`head_expects_100_continue`, a new *pure* request_parser helper) runs **at most once per connection** and only while a body is genuinely pending (off the hot path by definition). The CI benchmark A/B (`bench.yml`, triggered by `http_server/**`) will confirm on merge.

## Scope

- **epoll**: fixed here.
- **kqueue**: already satisfied h1spec's "interim 100 **or** immediate 4xx" via its `444` path — unchanged.
- **io_uring**: its own read path; out of scope for this change.

## Tests
- `head_expects_100_continue` unit tests (case-insensitivity, absent, false-match on another header, prefix) in `request_parser_test.v`.
- `test_epoll_expect_100_continue` behaviour test: head → **100** → body → **200**.
- Both run on Linux CI (the framer + backend gates added in the previous PRs).

Verified locally: build clean, `v fmt` clean, kqueue still 33/33 h1spec, conformance unit tests green. Epoll behaviour validated by this PR's CI (I'm on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
