### PR TITLE
feat(windows): real IOCP backend - keep-alive, pipelining, limits, timeouts

### DIFF
--- a/.github/workflows/build_test_examples_on_windows.yml
+++ b/.github/workflows/build_test_examples_on_windows.yml
@@ -7,18 +7,42 @@ on:
     branches: [ main ]
 
 jobs:
+  # The http_server module tests include the backend-agnostic behaviour suite
+  # (pipelining, split-request framing, max_connections, read timeout,
+  # graceful shutdown, large-upload streaming drain), which runs against the
+  # IOCP backend on Windows.
+  module-tests:
+    runs-on: windows-latest
+    name: http_server module tests
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up V
+        uses: vlang/setup-v@v1.7
+      - name: Remove Vlang folder to avoid conflicts
+        shell: bash
+        run: |
+          rm -rfv vlang || true
+      - name: Test http_server
+        shell: bash
+        run: |
+          v test http_server
+
   examples-building-and-testing:
     runs-on: windows-latest
     name: ${{ matrix.folder }}
     strategy:
       fail-fast: false # Continue other jobs if one fails
       matrix:
+        # examples/database and examples/hexagonal need libpq (and sqlite),
+        # which the Windows runner does not provide — they are covered by the
+        # Linux workflow.
         folder:
+          - examples/auth/src
           - examples/compression/src
-          - examples/database/src
           - examples/etag/src
-          - examples/hexagonal/src
           - examples/io_uring_demo/src
+          - examples/json_api/src
+          - examples/middleware/src
           - examples/simple/src
           - examples/simple2/src
           - examples/sse/src
@@ -30,11 +54,6 @@ jobs:
         shell: bash
         run: |
           rm -rfv vlang || true
-
-      - name: Install dependencies
-        shell: bash
-        run: |
-          echo "No additional dependencies to install on Windows."
 
       - name: Build ${{ matrix.folder }}
         shell: bash

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -60,22 +60,16 @@
   - Multiple parameters: `/users/:id/posts/:post_id`
   - 404 handling, query strings, method validation
 
-### 3. Windows IOCP Overlapped Structure
+### 3. Windows IOCP Overlapped Structure — ✅ RESOLVED
 - **File:** `http_server/http_server_windows.c.v`
 - **Issue:** `h_event` in OVERLAPPED structure never initialized
-- **Impact:** Undefined behavior on Windows async operations
-- **Priority:** 🟡 MEDIUM (Windows only)
-- **Effort:** 30 minutes
-- **Strategy:**
-  ```v
-  // Create event handle properly:
-  overlapped := C.OVERLAPPED{
-      h_event: C.CreateEventA(0, 0, 0, 0)
-  }
-  // Clean up event on connection close:
-  C.CloseHandle(overlapped.h_event)
-  ```
-- **Testing:** Test on Windows with multiple concurrent connections
+- **Resolution:** The IOCP backend was rewritten around completion-port
+  dispatch only — no event handles at all. Each connection embeds two
+  `WinOp` contexts (OVERLAPPED first field, zeroed before every post); a
+  completion's `lpOverlapped` pointer IS the op context, so `hEvent` is
+  never used and nothing leaks.
+- **Testing:** Covered by the backend behaviour suite
+  (`http_server/backend_behaviors_test.v`) running against IOCP on Windows.
 
 ### 4. Empty Kqueue Write Callback
 - **File:** `http_server/kqueue/kqueue_darwin.c.v:114`
@@ -570,19 +564,18 @@
 - **Dependencies:** #4 (fix write callback)
 - **Testing:** Test on macOS with persistent connections
 
-### 20. Complete IOCP Keep-Alive Implementation
+### 20. Complete IOCP Keep-Alive Implementation — ✅ RESOLVED
 - **File:** `http_server/http_server_windows.c.v`
 - **Issue:** Partial keep-alive implementation
-- **Impact:** Windows performance degraded
-- **Priority:** 🟡 MEDIUM
-- **Effort:** 3 hours
-- **Strategy:**
-  - Track connection state in IOCP context
-  - Re-post WSARecv after response
-  - Handle connection timeouts
-  - Proper cleanup of OVERLAPPED structures
-- **Dependencies:** #3 (fix overlapped)
-- **Testing:** Test on Windows with concurrent persistent connections
+- **Resolution:** Full rewrite: per-worker IOCP ports (shared-nothing),
+  persistent pooled per-connection buffers, request framing via
+  `request_parser`, HTTP/1.1 keep-alive + pipelining (batch answered in one
+  WSASend), large-body streaming drain (drain-then-respond), limits
+  (max_connections / 413 / 431), read+write timeout sweep, and graceful
+  shutdown through the shared `draining` flag.
+- **Testing:** `http_server/backend_behaviors_test.v` (pipelining, split
+  framing, max_connections, read timeout, graceful shutdown, 2 MiB upload
+  drain) passes on Windows; sustained-load run: ~287K req/s, 0 errors.
 
 ### 21. Add Timeout Support to Event Loops
 - **Files:** All backend files

--- a/http_server/README.md
+++ b/http_server/README.md
@@ -25,7 +25,7 @@ per-request allocation.
 | Linux | `.epoll` *(default)* | one central acceptor → round-robins fds to per-worker epolls | `.suspend` watches, `make_state`, `on_worker_start`, TLS |
 | Linux | `.io_uring` | per-worker `SO_REUSEPORT` listener + multishot accept (kernel 5.19+) | `.suspend` watches (oneshot `IORING_OP_POLL_ADD`), `make_state` |
 | macOS | kqueue | per-worker | `.suspend` watches, `make_state` |
-| Windows | IOCP | per-worker | `.done`/`.close` only (`.suspend` closes), `make_state` |
+| Windows | IOCP | one central acceptor → round-robins fds to per-worker IOCP ports | `.done`/`.close` only (`.suspend` closes), `make_state`, limits + timeouts |
 
 ## The handler contract
 

--- a/http_server/backend_behaviors_test.v
+++ b/http_server/backend_behaviors_test.v
@@ -358,6 +358,41 @@ fn test_iouring_graceful_shutdown() ! {
 	}
 }
 
+// --- iocp (Windows) ---------------------------------------------------------
+// The same backend-agnostic checks, against the Windows IOCP backend. On
+// Windows `IOBackend` has the single member `iocp` (= 0), so the casts keep
+// this file compiling on every OS.
+
+fn test_iocp_large_upload_drain() ! {
+	$if windows {
+		check_large_upload_drain(unsafe { IOBackend(0) }, 8145)!
+	}
+}
+
+fn test_iocp_pipelining_and_framing() ! {
+	$if windows {
+		check_pipelining_and_framing(unsafe { IOBackend(0) }, 8141)!
+	}
+}
+
+fn test_iocp_max_connections() ! {
+	$if windows {
+		check_max_connections(unsafe { IOBackend(0) }, 8142)!
+	}
+}
+
+fn test_iocp_read_timeout() ! {
+	$if windows {
+		check_read_timeout(unsafe { IOBackend(0) }, 8143)!
+	}
+}
+
+fn test_iocp_graceful_shutdown() ! {
+	$if windows {
+		check_graceful_shutdown(unsafe { IOBackend(0) }, 8144)!
+	}
+}
+
 // --- epoll (default backend) ----------------------------------------------
 
 fn test_epoll_large_upload_drain() ! {

--- a/http_server/backend_epoll/reactor_pipelining_test.v
+++ b/http_server/backend_epoll/reactor_pipelining_test.v
@@ -1,3 +1,4 @@
+// vtest build: linux
 module backend_epoll
 
 import http_server.core

--- a/http_server/http1_1/request_parser/request_parser.v
+++ b/http_server/http1_1/request_parser/request_parser.v
@@ -62,27 +62,47 @@ fn find_byte_idx(buf &u8, len int, c u8) int {
 	return int(unsafe { &u8(p) - buf })
 }
 
+// memmem_idx_portable is the Windows stand-in for GNU memmem (msvcrt has no
+// equivalent): memchr hops to each candidate first byte (memchr is the
+// optimized primitive msvcrt does have), then one memcmp confirms the needle.
+// Zero allocation; returns the match index or -1.
 @[inline]
-fn find_sequence(buf &u8, len int, bytes_ptr &u8, bytes_len int) !int {
-	unsafe {
-		p := C.memmem(buf, len, bytes_ptr, bytes_len)
-		if p == nil {
-			return error('bytes not found')
-		}
-		return int(&u8(p) - buf)
-	}
-}
-
-// find_sequence_idx is the no-Result hot-path twin of find_sequence: index of the
-// needle, or -1. Avoids the `!int` Result boxing on the per-request `\r\n\r\n`
-// scan (see find_byte_idx).
-@[inline]
-fn find_sequence_idx(buf &u8, len int, bytes_ptr &u8, bytes_len int) int {
-	p := unsafe { C.memmem(buf, len, bytes_ptr, bytes_len) }
-	if p == unsafe { nil } {
+fn memmem_idx_portable(buf &u8, len int, bytes_ptr &u8, bytes_len int) int {
+	if bytes_len <= 0 || len < bytes_len {
 		return -1
 	}
-	return int(unsafe { &u8(p) - buf })
+	first := unsafe { *bytes_ptr }
+	mut pos := 0
+	for pos <= len - bytes_len {
+		p := unsafe { C.memchr(buf + pos, first, usize(len - bytes_len - pos + 1)) }
+		if p == unsafe { nil } {
+			return -1
+		}
+		idx := int(unsafe { &u8(p) - buf })
+		if unsafe { C.memcmp(&u8(p), bytes_ptr, bytes_len) } == 0 {
+			return idx
+		}
+		pos = idx + 1
+	}
+	return -1
+}
+
+// find_sequence_idx returns the index of the needle, or -1 — a plain int, no
+// `!int` Result boxing on the per-request `\r\n\r\n` scan (see find_byte_idx).
+// libc memmem where it exists (AVX2-accelerated via glibc IFUNC); the
+// memchr+memcmp twin on Windows. (The old `find_sequence` Result wrapper had
+// no callers left and was removed.)
+@[inline]
+fn find_sequence_idx(buf &u8, len int, bytes_ptr &u8, bytes_len int) int {
+	$if windows {
+		return memmem_idx_portable(buf, len, bytes_ptr, bytes_len)
+	} $else {
+		p := unsafe { C.memmem(buf, len, bytes_ptr, bytes_len) }
+		if p == unsafe { nil } {
+			return -1
+		}
+		return int(unsafe { &u8(p) - buf })
+	}
 }
 
 // Fast comparison of two byte slices

--- a/http_server/http_server.c.v
+++ b/http_server/http_server.c.v
@@ -137,7 +137,7 @@ pub fn (mut s Server) test(requests [][]u8) ![][]u8 {
 			n := C.send(client_fd, &req[sent], req.len - sent, 0)
 			if n <= 0 {
 				println('[test] Failed to send request at byte ${sent}')
-				C.close(client_fd)
+				socket.close_socket(client_fd)
 				return error('Failed to send request')
 			}
 			sent += n
@@ -194,7 +194,7 @@ pub fn (mut s Server) test(requests [][]u8) ![][]u8 {
 		responses << buf.clone()
 	}
 
-	C.close(client_fd)
+	socket.close_socket(client_fd) // closesocket on Windows, close elsewhere
 	println('[test] Client closed, shutting down server socket...')
 	// Shutdown server after last response: stop every listener (the io_uring
 	// backend has one per worker), falling back to socket_fd if unset.
@@ -284,6 +284,9 @@ pub fn new_server(config ServerConfig) !Server {
 	$if windows {
 		if io_multiplexing != .iocp {
 			return error('Windows only supports IOCP backend')
+		}
+		if config.tls_config != unsafe { nil } {
+			return error('TLS is not yet supported on the Windows/IOCP backend')
 		}
 	} $else $if linux {
 		if io_multiplexing != .epoll && io_multiplexing != .io_uring {

--- a/http_server/http_server_windows.c.v
+++ b/http_server/http_server_windows.c.v
@@ -1,10 +1,47 @@
+// Windows-specific HTTP server implementation using I/O completion ports —
+// the counterpart of backend_epoll (Linux) and async_darwin.c.v (macOS).
+//
+// Same shared-nothing thread-per-core model as the epoll backend, adapted to
+// COMPLETION semantics (IOCP tells you an operation finished, not that a fd is
+// ready):
+//   • one IOCP port per worker thread — a connection is handed to one worker
+//     at accept and never leaves it, so per-connection state needs no locks;
+//   • persistent per-connection read/write buffers, pooled on a per-worker
+//     free list (zero allocation per request, buffers reused across
+//     connections);
+//   • exactly ONE overlapped operation in flight per connection (recv OR
+//     send, never both), so the buffers are never reallocated or appended to
+//     while the kernel holds a pointer into them;
+//   • HTTP/1.1 keep-alive + pipelining — every complete request buffered by a
+//     recv completion is answered into the write buffer, and the whole batch
+//     goes out in a single WSASend;
+//   • large-body streaming drain — a body past win_stream_body_above is
+//     answered from its head and then consumed off the socket in O(buffer)
+//     memory, with the response HELD until the drain completes
+//     (drain-then-respond, same ordering contract as the epoll backend);
+//   • limits: max_connections (refused at accept), max_header/max_body (parser
+//     sentinels → 431/413), max_request_bytes (413), read/write timeouts
+//     (deadline sweep driven by the GetQueuedCompletionStatus timeout).
+//
+// The handler contract is core.Handler, unchanged. This worker has no watch
+// reactor yet (IOCP is completion-based; watching arbitrary readiness like
+// epoll needs an AFD-style poll bridge), so `.suspend` DROPS the connection —
+// see core.reject_register.
+//
+// Known headroom: completions dequeue ONE per GetQueuedCompletionStatus call.
+// GetQueuedCompletionStatusEx would batch them (the epoll worker's amortized
+// epoll_wait equivalent), but tcc's kernel32 export table lacks it
+// (vlang/v#27792) — switch to batch dequeue once that lands, or load it via
+// GetProcAddress if profiles demand it sooner.
 module http_server
 
-import socket
-import runtime
 import iocp
-import http1_1.response
+import socket
+import time
+import sync.stdatomic
 import http_server.core
+import http1_1.request_parser
+import http1_1.response
 
 // Backend selection
 pub enum IOBackend {
@@ -14,360 +51,661 @@ pub enum IOBackend {
 #include <winsock2.h>
 #include <windows.h>
 
-$if windows {
-	#include <mswsock.h>
+// C.WSAGetLastError / C.memmove come from builtin's program-wide decls.
+
+const win_read_buf_cap = 8 * 1024
+const win_write_buf_cap = 16 * 1024
+const win_max_request_bytes = 8 * 1024 * 1024
+// Write-side cap: close a connection whose peer pipelines requests but never
+// drains responses (otherwise write_buf would grow without bound).
+const win_max_pending_write = 8 * 1024 * 1024
+// A request whose framed size exceeds this is STREAMED, not buffered: the head
+// is answered and the body is drained (recv'd into the fixed buffer and
+// discarded) instead of growing read_buf into a multi-MB block.
+const win_stream_body_above = 1024 * 1024
+// Deadline sweep cadence while something is parked (mirrors the epoll worker's
+// 250 ms timeout wait).
+const win_sweep_interval_ns = u64(250) * 1_000_000
+
+// Accept-loop errno values that mean the LISTENER itself is gone (closed by
+// shutdown()/test teardown), as opposed to a per-connection failure.
+const wsaeintr = 10004 // WSAEINTR: blocking accept canceled
+const wsaeinval = 10022 // WSAEINVAL: socket no longer listening
+const wsaenotsock = 10038 // WSAENOTSOCK: listener handle already closed
+
+const op_read = 0
+const op_write = 1
+
+// WinOp is one overlapped operation's kernel-visible context. The OVERLAPPED
+// must stay the FIRST field: a completion's lpOverlapped pointer IS the WinOp,
+// recovered with a plain cast. Two of these are embedded in every WinConn
+// (one recv, one send) so posting an operation allocates nothing.
+struct WinOp {
+mut:
+	ov     C.OVERLAPPED
+	wsabuf C.WSABUF
+	kind   int // op_read | op_write
+	conn   &WinConn = unsafe { nil }
 }
 
-const acceptex_guid = C.WSAID_ACCEPTEX
-const max_iocp_workers = runtime.nr_cpus()
-const buffer_size = 8192
-
-fn C.GetOverlappedResult(h_file voidptr, lp_overlapped voidptr, lp_number_of_bytes_transferred &u32,
-	b_wait bool) bool
-
-struct WorkerContext {
-pub mut:
-	iocp_handle voidptr
-	handler     core.Handler @[required]
-	make_state  fn () voidptr = unsafe { nil }
-	state       voidptr
-	running     bool
-	thread_id   u32
+// WinConn is allocated once per connection (on hand-off from the accept loop)
+// and reused until the connection closes; retired states keep their buffers on
+// the worker's free list — the same pooling as the epoll backend's ConnState.
+@[heap]
+struct WinConn {
+mut:
+	fd        int = -1
+	read_op   WinOp
+	write_op  WinOp
+	read_buf  []u8 // persistent request buffer; len = bytes buffered
+	write_buf []u8 // persistent response buffer; [write_off..len) pending
+	write_off int
+	// >0 while a large request body is being streamed (drained + discarded):
+	// the head was already answered, this many body bytes are still to be
+	// consumed off the socket; the response is HELD until it reaches 0.
+	body_drain i64
+	// flush whatever is pending, then close (handler .close, 4xx canned
+	// responses, over-cap batches).
+	close_after bool
+	// closesocket() was issued while an overlapped op was still outstanding
+	// (deadline sweep): the state must stay alive until the canceled
+	// completion drains through the port, then it is recycled.
+	closing        bool
+	read_deadline  u64 // monotonic ns; >0 while a request is mid-read
+	write_deadline u64 // monotonic ns; >0 while a send is in flight
+	slot           int // index in WinState.conns, for O(1) swap-remove
 }
 
-struct AcceptContext {
-pub mut:
-	listen_socket int
-	iocp_handle   voidptr
-	accept_socket int
-	overlapped    C.OVERLAPPED
-	local_addr    [sizeof(C.sockaddr_in) + 16]u8
-	remote_addr   [sizeof(C.sockaddr_in) + 16]u8
+// WinState is the per-worker connection registry: a compact live list (the
+// deadline sweep iterates it; dispatch never does — completions carry their
+// WinOp pointer) plus the ConnState-style free list. One per worker, no lock.
+struct WinState {
+mut:
+	conns      []&WinConn
+	free_conns []&WinConn
+	parked     int // conns with an armed deadline — gates the sweep entirely
+	last_sweep u64
 }
 
-fn get_system_error() string {
-	error_code := C.WSAGetLastError()
-	mut buffer := [256]u16{}
-	C.FormatMessageW(C.FORMAT_MESSAGE_FROM_SYSTEM | C.FORMAT_MESSAGE_IGNORE_INSERTS,
-		unsafe { nil }, error_code, 0, &buffer[0], 256, unsafe { nil })
-	return string_from_wide(&buffer[0])
-}
-
-fn worker_thread(mut ctx WorkerContext) {
-	println('[iocp-worker] Worker thread started')
-
-	// Per-worker state, built ON this worker thread (thread-local, no lock);
-	// every handler call on this worker reaches it via worker.state.
-	if ctx.make_state != unsafe { nil } {
-		ctx.state = ctx.make_state()
+// win_buf_view returns a non-owning []u8 window over buf[start..start+length]
+// without slice-marking bookkeeping — same rationale as the epoll backend's
+// buf_view (see conn_state_linux.c.v): read_buf is manually managed, the view
+// is consumed before the next recv can move it.
+@[inline]
+fn win_buf_view(buf []u8, start int, length int) []u8 {
+	mut v := unsafe { buf }
+	unsafe {
+		v.data = &u8(buf.data) + start
+		v.len = length
+		v.cap = length
+		v.flags.clear(.managed)
 	}
+	return v
+}
 
-	for ctx.running {
-		mut bytes_transferred := u32(0)
-		mut completion_key := u64(0)
-		mut overlapped := &C.OVERLAPPED(unsafe { nil })
+// win_conn_for takes a retired WinConn from the pool (buffers retained) or
+// allocates a fresh one, registers it in the live list and stamps the fd.
+fn win_conn_for(mut st WinState, fd int) &WinConn {
+	if st.free_conns.len > 0 {
+		mut pooled := st.free_conns.pop()
+		pooled.fd = fd
+		pooled.slot = st.conns.len
+		st.conns << pooled
+		return pooled
+	}
+	mut cs := &WinConn{
+		read_buf:  []u8{len: 0, cap: win_read_buf_cap}
+		write_buf: []u8{len: 0, cap: win_write_buf_cap}
+		fd:        fd
+		slot:      st.conns.len
+	}
+	// Same no-scan gating as the epoll ConnState (see conn_state_linux.c.v).
+	$if vanilla_noscan ? {
+		unsafe {
+			cs.read_buf.flags.set(.noscan_data)
+			cs.write_buf.flags.set(.noscan_data)
+		}
+	}
+	// The op→conn back-pointers never change for the life of the allocation.
+	cs.read_op.kind = op_read
+	cs.read_op.conn = cs
+	cs.write_op.kind = op_write
+	cs.write_op.conn = cs
+	st.conns << cs
+	return cs
+}
 
-		success := iocp.get_queued_completion_status(ctx.iocp_handle, &bytes_transferred,
-			&completion_key, &overlapped, iocp.infinity)
+// win_clear_deadlines disarms both deadlines, keeping the parked count exact.
+@[inline]
+fn win_clear_deadlines(mut st WinState, mut cs WinConn) {
+	if cs.read_deadline != 0 {
+		cs.read_deadline = 0
+		st.parked--
+	}
+	if cs.write_deadline != 0 {
+		cs.write_deadline = 0
+		st.parked--
+	}
+}
 
-		if !success {
-			// Check if it's a shutdown signal
-			if overlapped == unsafe { nil } && bytes_transferred == 0 && completion_key == 0 {
-				println('[iocp-worker] Received shutdown signal')
-				break
-			}
-			error_code := C.WSAGetLastError()
-			if error_code == 64 { // WAIT_TIMEOUT
-				continue
-			}
-			eprintln('[iocp-worker] GetQueuedCompletionStatus failed: ${get_system_error()}')
+// win_recycle removes a connection from the live list (swap-remove via the
+// slot index) and returns its state to the pool, buffers retained. The socket
+// is already closed by the caller.
+@[direct_array_access]
+fn win_recycle(mut st WinState, mut cs WinConn) {
+	mut last := st.conns[st.conns.len - 1]
+	st.conns[cs.slot] = last
+	last.slot = cs.slot
+	st.conns.delete_last()
+	unsafe {
+		cs.read_buf.len = 0
+		cs.write_buf.len = 0
+	}
+	cs.write_off = 0
+	cs.body_drain = 0
+	cs.close_after = false
+	cs.closing = false
+	cs.read_deadline = 0
+	cs.write_deadline = 0
+	cs.fd = -1
+	st.free_conns << cs
+}
+
+// win_close_conn tears a connection down when NO overlapped op is outstanding
+// (i.e. from within its own completion handler): close the socket, release the
+// accounting, recycle the state.
+fn win_close_conn(mut st WinState, mut cs WinConn, active_conns &core.Counter) {
+	win_clear_deadlines(mut st, mut cs)
+	socket.close_socket(cs.fd)
+	stdatomic.add_i64(&active_conns.n, -1)
+	win_recycle(mut st, mut cs)
+}
+
+// win_kill_conn tears a connection down while an overlapped op IS outstanding
+// (the deadline sweep): closesocket cancels the op; the canceled completion
+// drains through the port and the worker loop recycles the state there.
+fn win_kill_conn(mut st WinState, mut cs WinConn, active_conns &core.Counter) {
+	win_clear_deadlines(mut st, mut cs)
+	cs.closing = true
+	socket.close_socket(cs.fd)
+	stdatomic.add_i64(&active_conns.n, -1)
+}
+
+// win_sweep_timeouts closes connections whose read/write deadline has passed.
+// Runs only when something is parked and a timeout is configured.
+@[direct_array_access]
+fn win_sweep_timeouts(now u64, mut st WinState, active_conns &core.Counter) {
+	for i in 0 .. st.conns.len {
+		mut cs := st.conns[i]
+		if cs.closing {
 			continue
 		}
-
-		// Handle shutdown signal
-		if bytes_transferred == 0 && completion_key == 0 && overlapped == unsafe { nil } {
-			println('[iocp-worker] Received shutdown signal')
-			break
-		}
-
-		// Cast overlapped back to IOData
-		mut io_data := unsafe { &iocp.IOData(overlapped) }
-
-		match io_data.operation {
-			.accept {
-				handle_accept_completion(io_data, mut ctx)
-			}
-			.read {
-				handle_read_completion(io_data, mut ctx)
-			}
-			.write {
-				handle_write_completion(mut io_data, mut ctx)
-			}
-			.close {
-				socket.close_socket(io_data.socket_fd)
-				iocp.free_io_data(io_data)
-			}
+		if cs.read_deadline > 0 && now > cs.read_deadline {
+			// Courtesy 408, BEST-EFFORT: the socket is non-blocking, so against
+			// a full send buffer (peer stopped reading) this fails with
+			// WSAEWOULDBLOCK instead of stalling the worker — the same EAGAIN
+			// drop the epoll backend's non-blocking sockets give it.
+			response.send_status_408_response(cs.fd)
+			win_kill_conn(mut st, mut cs, active_conns)
+		} else if cs.write_deadline > 0 && now > cs.write_deadline {
+			win_kill_conn(mut st, mut cs, active_conns)
 		}
 	}
-
-	println('[iocp-worker] Worker thread exiting')
 }
 
-fn handle_accept_completion(io_data &iocp.IOData, mut ctx WorkerContext) {
-	socket_fd := io_data.socket_fd
-
-	// Set socket options for accepted connection
-	opt := 1
-	C.setsockopt(u64(socket_fd), C.SOL_SOCKET, C.SO_UPDATE_ACCEPT_CONTEXT, &socket_fd,
-		sizeof(socket_fd))
-
-	// Associate the accepted socket with IOCP
-	iocp.associate_handle_with_iocp(ctx.iocp_handle, socket_fd, u64(socket_fd)) or {
-		eprintln('[iocp-worker] Failed to associate accepted socket: ${err}')
-		socket.close_socket(socket_fd)
-		return
+// win_post_recv arms the connection's single recv op. During a body drain the
+// whole buffer is a scratch window capped at the bytes still to discard (never
+// over-reading into a pipelined next request); otherwise the spare capacity
+// after the buffered partial. Callers guarantee spare > 0 (win_arm_recv grows
+// the buffer first).
+fn win_post_recv(mut cs WinConn) bool {
+	mut dst := unsafe { &u8(cs.read_buf.data) }
+	mut window := cs.read_buf.cap
+	if cs.body_drain == 0 {
+		dst = unsafe { &u8(cs.read_buf.data) + cs.read_buf.len }
+		window = cs.read_buf.cap - cs.read_buf.len
+	} else if cs.body_drain < i64(window) {
+		window = int(cs.body_drain)
 	}
-
-	// Post a read operation on the new socket
-	post_read_operation(socket_fd, ctx.iocp_handle)
-
-	// Post another accept on the listening socket
-	// (We need to get the listening socket from somewhere - stored in context)
+	cs.read_op.wsabuf.buf = unsafe { &char(dst) }
+	cs.read_op.wsabuf.len = u32(window)
+	unsafe { vmemset(&cs.read_op.ov, 0, int(sizeof(C.OVERLAPPED))) }
+	return iocp.post_recv(cs.fd, &cs.read_op.wsabuf, &cs.read_op.ov)
 }
 
-@[manualfree]
-fn handle_read_completion(io_data &iocp.IOData, mut ctx WorkerContext) {
-	socket_fd := io_data.socket_fd
-	bytes_read := io_data.bytes_transferred
+// win_post_send arms the connection's single send op over the pending
+// [write_off..len) window and starts the write deadline (once per batch).
+fn win_post_send(mut st WinState, mut cs WinConn, limits core.Limits) bool {
+	if limits.write_timeout_ms > 0 && cs.write_deadline == 0 {
+		cs.write_deadline = time.sys_mono_now() + u64(limits.write_timeout_ms) * 1_000_000
+		st.parked++
+	}
+	cs.write_op.wsabuf.buf = unsafe { &char(&u8(cs.write_buf.data) + cs.write_off) }
+	cs.write_op.wsabuf.len = u32(cs.write_buf.len - cs.write_off)
+	unsafe { vmemset(&cs.write_op.ov, 0, int(sizeof(C.OVERLAPPED))) }
+	return iocp.post_send(cs.fd, &cs.write_op.wsabuf, &cs.write_op.ov)
+}
 
-	if bytes_read == 0 {
-		// Connection closed
-		socket.close_socket(socket_fd)
-		iocp.free_io_data(io_data)
+// win_update_read_deadline arms the read deadline ONCE while a request is
+// mid-read (partial bytes buffered, or a large body mid-drain) and clears it
+// when the buffer is idle — the same once-per-request semantics as the other
+// backends (read_timeout_ms bounds the TOTAL time to receive a request).
+@[inline]
+fn win_update_read_deadline(limits core.Limits, mut st WinState, mut cs WinConn) {
+	if cs.read_buf.len > 0 || cs.body_drain > 0 {
+		if limits.read_timeout_ms > 0 && cs.read_deadline == 0 {
+			cs.read_deadline = time.sys_mono_now() + u64(limits.read_timeout_ms) * 1_000_000
+			st.parked++
+		}
+	} else if cs.read_deadline != 0 {
+		cs.read_deadline = 0
+		st.parked--
+	}
+}
+
+// win_compact_read_buf drops the first `pos` consumed bytes, keeping the
+// leftover (partial / not-yet-answered) request at the buffer front.
+@[direct_array_access; inline]
+fn win_compact_read_buf(mut cs WinConn, pos int) {
+	if pos <= 0 {
 		return
 	}
+	leftover := cs.read_buf.len - pos
+	if leftover > 0 {
+		unsafe { C.memmove(cs.read_buf.data, &u8(cs.read_buf.data) + pos, usize(leftover)) }
+	}
+	unsafe {
+		cs.read_buf.len = leftover
+	}
+}
 
-	// Process the request — server-owned response buffer, handler appends raw bytes.
-	request_data := io_data.buffer[..bytes_read]
-	mut response_data := []u8{len: 0, cap: 4096}
+// win_drain_requests answers every complete request currently buffered,
+// appending each response to write_buf (the whole batch flushes in ONE send).
+// Mirrors the epoll drain_requests minus the watch runtime: `.suspend` cannot
+// park here (no reactor), so it drops the connection.
+@[direct_array_access]
+fn win_drain_requests(h core.Handler, mut cs WinConn, limits core.Limits, state voidptr) {
+	mut pos := 0
+	// ONE EventLoop handle per burst; register is the shared reject stub, so a
+	// handler that suspends anyway is detected below and dropped.
 	mut event_loop := core.EventLoop{
-		client_fd: socket_fd
+		client_fd: cs.fd
 		register:  core.reject_register
 	}
-	step := ctx.handler(request_data, mut response_data, socket_fd, ctx.state, mut event_loop)
-	if step != .done {
-		// .close: flush whatever the handler appended (its error response), then
-		// drop. .suspend: parking is not supported on this backend (no watch
-		// reactor; see core.reject_register) — nothing was armed, so drop the
-		// connection rather than strand a request that can never be resumed.
-		if step == .suspend {
-			eprintln('[iocp] handler returned .suspend but the IOCP worker has no watch reactor; dropping the connection')
+	for pos < cs.read_buf.len {
+		total := request_parser.frame_request_length_lim_idx(win_buf_view(cs.read_buf, pos,
+			cs.read_buf.len - pos), limits.max_header_bytes, limits.max_body_bytes)
+		if total == -1 {
+			break // incomplete — wait for more bytes
 		}
-		if step == .close && response_data.len > 0 {
-			response.send_response(socket_fd, response_data.data, response_data.len) or {}
+		if total < -1 {
+			match -total {
+				413 { cs.write_buf << response.status_413_response }
+				431 { cs.write_buf << response.status_431_response }
+				else { cs.write_buf << response.tiny_bad_request_response }
+			}
+
+			cs.close_after = true
+			pos = cs.read_buf.len // connection is closing; discard the rest
+			break
 		}
-		unsafe { response_data.free() }
-		socket.close_socket(socket_fd)
-		iocp.free_io_data(io_data)
-		return
-	}
-
-	// Prepare write operation
-	mut write_io_data := iocp.create_io_data(socket_fd, .write, response_data.len)
-	unsafe {
-		C.memcpy(&write_io_data.buffer[0], response_data.data, response_data.len)
-	}
-	write_io_data.wsabuf.len = u32(response_data.len)
-	unsafe { response_data.free() } // copied into write_io_data above
-
-	// Post write operation
-	flags := u32(0)
-	result := iocp.post_send(socket_fd, &write_io_data.wsabuf, 1, flags, &write_io_data.overlapped)
-
-	if result == socket.socket_error {
-		error_code := C.WSAGetLastError()
-		if error_code != 997 { // ERROR_IO_PENDING
-			eprintln('[iocp-worker] WSASend failed: ${get_system_error()}')
-			socket.close_socket(socket_fd)
-			iocp.free_io_data(write_io_data)
-		}
-	}
-
-	// Free read IO data
-	iocp.free_io_data(io_data)
-
-	// Prepare for next read (keep-alive)
-	// In a real implementation, we'd parse the request to determine if keep-alive
-	// For simplicity, we always post another read
-	post_read_operation(socket_fd, ctx.iocp_handle)
-}
-
-fn handle_write_completion(mut io_data iocp.IOData, mut ctx WorkerContext) {
-	socket_fd := io_data.socket_fd
-
-	// Check if all data was sent
-	if io_data.bytes_transferred < io_data.wsabuf.len {
-		// Partial write, adjust buffer and repost
-		remaining := io_data.wsabuf.len - io_data.bytes_transferred
-		unsafe {
-			C.memmove(&io_data.buffer[0], &io_data.buffer[io_data.bytes_transferred], remaining)
-		}
-		io_data.wsabuf.len = remaining
-
-		flags := u32(0)
-		result := iocp.post_send(socket_fd, &io_data.wsabuf, 1, flags, &io_data.overlapped)
-
-		if result == socket.socket_error {
-			error_code := C.WSAGetLastError()
-			if error_code != 997 { // ERROR_IO_PENDING
-				socket.close_socket(socket_fd)
-				iocp.free_io_data(io_data)
+		req := win_buf_view(cs.read_buf, pos, total)
+		step := h(req, mut cs.write_buf, cs.fd, state, mut event_loop)
+		pos += total
+		match step {
+			.done {}
+			.suspend {
+				eprintln('[iocp] handler returned .suspend but the Windows/IOCP worker has no watch reactor yet; dropping the connection')
+				cs.close_after = true
+			}
+			.close {
+				cs.close_after = true
 			}
 		}
-	} else {
-		// Write completed
-		iocp.free_io_data(io_data)
-		// Note: We don't close the socket here to allow keep-alive
-		// The next read operation was already posted in handle_read_completion
+
+		if cs.close_after {
+			break
+		}
+		// Peer pipelines without reading responses: bail before the batch is unbounded.
+		if cs.write_buf.len - cs.write_off > win_max_pending_write {
+			cs.close_after = true
+			break
+		}
+	}
+	win_compact_read_buf(mut cs, pos)
+}
+
+// win_start_body_drain answers a large-body request from its HEAD alone, then
+// puts the connection into streaming-drain mode for the body. Such handlers
+// must answer by Content-Length and complete synchronously. Returns 1 =
+// draining started, 2 = answer 400 and close, 0 = head not complete yet.
+@[direct_array_access]
+fn win_start_body_drain(h core.Handler, mut cs WinConn, limits core.Limits, state voidptr, total int) int {
+	head_len := request_parser.frame_head_len(cs.read_buf)
+	if head_len <= 0 || head_len > cs.read_buf.len {
+		return 0 // head not complete in the buffer yet — grow/recv more
+	}
+	content_length := total - head_len
+	head := win_buf_view(cs.read_buf, 0, head_len)
+	mut event_loop := core.EventLoop{
+		client_fd: cs.fd
+		register:  core.reject_register
+	}
+	if h(head, mut cs.write_buf, cs.fd, state, mut event_loop) != .done {
+		// suspend/close on a streamed-body request is unsupported — answer 400
+		// and drop rather than leave a half-drained connection.
+		cs.write_buf << response.tiny_bad_request_response
+		cs.close_after = true
+		unsafe {
+			cs.read_buf.len = 0
+		}
+		return 2
+	}
+	// DRAIN-THEN-RESPOND: the head response is buffered in write_buf but NOT
+	// flushed here; win_advance holds it until body_drain reaches 0 so a client
+	// that writes the whole request before reading is never desynced.
+	body_in_buf := cs.read_buf.len - head_len
+	cs.body_drain = i64(content_length) - i64(body_in_buf)
+	if cs.body_drain < 0 {
+		cs.body_drain = 0
+	}
+	unsafe {
+		cs.read_buf.len = 0 // head (and any buffered body bytes) consumed
+	}
+	return 1
+}
+
+// win_arm_recv posts the connection's next receive, first doing the
+// full-buffer management the epoll serve_conn does at its loop top: a framed
+// size past the streaming threshold starts a body drain; a bounded larger
+// request grows the buffer toward its exact size; an unknown size doubles.
+// Never posts a zero-length window.
+fn win_arm_recv(h core.Handler, mut st WinState, mut cs WinConn, limits core.Limits, active_conns &core.Counter, state voidptr) {
+	if cs.body_drain == 0 && cs.read_buf.len == cs.read_buf.cap {
+		req_cap := if limits.max_request_bytes > 0 {
+			limits.max_request_bytes
+		} else {
+			win_max_request_bytes
+		}
+		target := request_parser.frame_expected_total(cs.read_buf)
+		if target > win_stream_body_above && target <= req_cap {
+			match win_start_body_drain(h, mut cs, limits, state, target) {
+				1 {
+					if cs.body_drain == 0 {
+						// the whole body was already buffered — release the response
+						win_advance(h, mut st, mut cs, limits, active_conns, state)
+						return
+					}
+					// fall through: post the first drain recv below
+				}
+				2 {
+					win_advance(h, mut st, mut cs, limits, active_conns, state) // flush the 400, then close
+					return
+				}
+				else {} // head not complete yet → grow below
+			}
+		}
+		if cs.body_drain == 0 && cs.read_buf.len == cs.read_buf.cap {
+			if target > cs.read_buf.cap && target <= req_cap {
+				unsafe { cs.read_buf.grow_cap(target - cs.read_buf.cap) }
+			} else {
+				unsafe { cs.read_buf.grow_cap(cs.read_buf.cap) }
+			}
+		}
+	}
+	win_update_read_deadline(limits, mut st, mut cs)
+	if !win_post_recv(mut cs) {
+		win_close_conn(mut st, mut cs, active_conns)
 	}
 }
 
-fn post_read_operation(socket_fd int, iocp_handle voidptr) {
-	read_io_data := iocp.create_io_data(socket_fd, .read, buffer_size)
+// win_advance decides the connection's next overlapped op after a burst of
+// request handling: flush the batched responses (ONE send per burst; held
+// while a body drain is in progress), close if the burst ended the
+// connection, or arm the next receive.
+fn win_advance(h core.Handler, mut st WinState, mut cs WinConn, limits core.Limits, active_conns &core.Counter, state voidptr) {
+	if cs.body_drain == 0 && cs.write_buf.len > cs.write_off {
+		if !win_post_send(mut st, mut cs, limits) {
+			win_close_conn(mut st, mut cs, active_conns)
+		}
+		return
+	}
+	if cs.close_after {
+		win_close_conn(mut st, mut cs, active_conns)
+		return
+	}
+	win_arm_recv(h, mut st, mut cs, limits, active_conns, state)
+}
 
-	flags := u32(0)
-	result := iocp.post_recv(socket_fd, &read_io_data.wsabuf, 1, &flags, &read_io_data.overlapped)
+// win_on_recv handles a completed receive: streaming-drain accounting, or
+// append + answer every complete request + advance.
+fn win_on_recv(h core.Handler, mut st WinState, mut cs WinConn, n int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, state voidptr) {
+	if n <= 0 {
+		// 0 bytes on a stream recv = orderly close by the peer.
+		win_close_conn(mut st, mut cs, active_conns)
+		return
+	}
+	if cs.body_drain > 0 {
+		// Streaming-drain: the bytes landed in the scratch window and are
+		// discarded (the window was capped, so this never goes negative).
+		cs.body_drain -= i64(n)
+		win_advance(h, mut st, mut cs, limits, active_conns, state)
+		return
+	}
+	// In-flight window for the graceful-shutdown drain (per-worker counter,
+	// own cache line — uncontended).
+	stdatomic.add_i64(&counter.n, 1)
+	unsafe {
+		cs.read_buf.len += n
+	}
+	win_drain_requests(h, mut cs, limits, state)
+	if !cs.close_after {
+		req_cap := if limits.max_request_bytes > 0 {
+			limits.max_request_bytes
+		} else {
+			win_max_request_bytes
+		}
+		if cs.read_buf.len > req_cap {
+			cs.write_buf << response.status_413_response
+			cs.close_after = true
+		}
+	}
+	stdatomic.add_i64(&counter.n, -1)
+	win_advance(h, mut st, mut cs, limits, active_conns, state)
+}
 
-	if result == socket.socket_error {
-		error_code := C.WSAGetLastError()
-		if error_code != 997 { // ERROR_IO_PENDING
-			eprintln('[iocp-worker] WSARecv failed: ${get_system_error()}')
-			socket.close_socket(socket_fd)
-			iocp.free_io_data(read_io_data)
+// win_on_send handles a completed send: advance past the sent bytes, repost
+// the remainder of a partial completion, or reset the batch and continue.
+fn win_on_send(h core.Handler, mut st WinState, mut cs WinConn, n int, limits core.Limits, active_conns &core.Counter, state voidptr) {
+	if n <= 0 {
+		win_close_conn(mut st, mut cs, active_conns)
+		return
+	}
+	cs.write_off += n
+	if cs.write_off < cs.write_buf.len {
+		// Partial completion (rare — an overlapped stream send normally
+		// completes whole): repost the remainder.
+		if !win_post_send(mut st, mut cs, limits) {
+			win_close_conn(mut st, mut cs, active_conns)
+		}
+		return
+	}
+	cs.write_buf.clear() // len = 0, capacity kept for the next batch
+	cs.write_off = 0
+	if cs.write_deadline != 0 {
+		cs.write_deadline = 0
+		st.parked--
+	}
+	if cs.close_after {
+		win_close_conn(mut st, mut cs, active_conns)
+		return
+	}
+	win_arm_recv(h, mut st, mut cs, limits, active_conns, state)
+}
+
+// win_worker is one worker thread's event loop: it owns an IOCP port, the
+// connection table and the per-worker handler state, and processes one
+// completion per iteration. Control messages (lpOverlapped == nil) are the
+// accept hand-off (key = fd) and the shutdown wake (key = 0).
+fn win_worker(port voidptr, h core.Handler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
+	// Per-worker state, built ON this worker thread (thread-local, no lock);
+	// every handler call on this worker receives it as worker_state.
+	mut state := voidptr(unsafe { nil })
+	if make_state != unsafe { nil } {
+		state = make_state()
+	}
+	mut st := WinState{
+		conns: []&WinConn{cap: 64}
+	}
+	sweep_on := limits.read_timeout_ms > 0 || limits.write_timeout_ms > 0
+	for {
+		mut bytes := u32(0)
+		mut key := usize(0)
+		mut ovp := &C.OVERLAPPED(unsafe { nil })
+		// Block until a completion arrives; wake every 250 ms only while a
+		// deadline is armed, so an idle worker burns zero CPU.
+		timeout := if sweep_on && st.parked > 0 { u32(250) } else { iocp.infinite }
+		ok := iocp.wait(port, &bytes, &key, &ovp, timeout)
+		if ovp == unsafe { nil } {
+			if ok && key == 0 {
+				break // shutdown wake
+			}
+			if ok && key != 0 {
+				// Accept hand-off: build the state and post the first recv.
+				mut cs := win_conn_for(mut st, int(key))
+				win_arm_recv(h, mut st, mut cs, limits, active_conns, state)
+			}
+			// !ok with no overlapped = the timeout tick; fall through to sweep.
+		} else {
+			mut op := unsafe { &WinOp(ovp) }
+			mut cs := op.conn
+			if cs.closing {
+				// The op this conn was killed under (deadline sweep) has
+				// drained; the socket is already closed and un-counted.
+				win_recycle(mut st, mut cs)
+			} else if !ok {
+				// Failed completion: peer reset / aborted op.
+				win_close_conn(mut st, mut cs, active_conns)
+			} else if op.kind == op_read {
+				win_on_recv(h, mut st, mut cs, int(bytes), limits, counter, active_conns, state)
+			} else {
+				win_on_send(h, mut st, mut cs, int(bytes), limits, active_conns, state)
+			}
+		}
+		if sweep_on && st.parked > 0 {
+			now := time.sys_mono_now()
+			if now - st.last_sweep >= win_sweep_interval_ns {
+				st.last_sweep = now
+				win_sweep_timeouts(now, mut st, active_conns)
+			}
 		}
 	}
 }
 
-fn accept_thread(listen_socket int, iocp_handle voidptr) {
-	println('[iocp-accept] Accept thread started')
-
+// win_accept_loop blocks in accept() on the main thread and distributes new
+// connections round-robin to the worker ports: associate the socket with the
+// worker's IOCP, then hand the fd over as a manual completion — the worker
+// allocates all per-connection state itself, so nothing is shared.
+fn win_accept_loop(socket_fd int, ports []voidptr, limits core.Limits, active_conns &core.Counter, draining &core.Counter) {
+	mut next := 0
 	for {
-		// Create a new socket for the incoming connection
-		accept_socket := int(C.socket(C.AF_INET, C.SOCK_STREAM, 0))
-		if accept_socket == int(socket.invalid_socket) {
-			eprintln('[iocp-accept] Failed to create accept socket')
-			C.sleep(100)
+		client_fd := socket.accept_client(socket_fd)
+		if client_fd < 0 {
+			if stdatomic.load_i64(&draining.n) != 0 {
+				break // graceful shutdown: the listener was closed on purpose
+			}
+			err := C.WSAGetLastError()
+			if err == wsaenotsock || err == wsaeintr || err == wsaeinval {
+				break // listener closed without draining (test teardown)
+			}
+			// Transient per-connection failure (e.g. WSAECONNRESET on a
+			// half-open connection): keep accepting, but never spin hot.
+			time.sleep(10 * time.millisecond)
 			continue
 		}
-
-		// Prepare accept IO data
-		accept_io_data := iocp.create_io_data(accept_socket, .accept, 0)
-
-		// Start asynchronous accept
-		if !iocp.start_accept_ex(listen_socket, accept_socket, &accept_io_data.overlapped) {
-			error_code := C.WSAGetLastError()
-			if error_code != 997 { // ERROR_IO_PENDING
-				eprintln('[iocp-accept] AcceptEx failed: ${get_system_error()}')
-				socket.close_socket(accept_socket)
-				iocp.free_io_data(accept_io_data)
-				C.sleep(100)
-				continue
-			}
+		// Enforce max_connections: refuse (close immediately) once at the cap.
+		if limits.max_connections > 0
+			&& stdatomic.load_i64(&active_conns.n) >= i64(limits.max_connections) {
+			socket.close_socket(client_fd)
+			continue
 		}
-
-		// Wait for accept completion
-		// In a real implementation, we'd use IOCP for accepts too
-		// For simplicity, we're using AcceptEx synchronously here
-		// A better implementation would post multiple AcceptEx operations
-		result := C.WaitForSingleObject(voidptr(accept_io_data.overlapped.h_event), iocp.infinity)
-
-		if result == 0 { // WAIT_OBJECT_0
-			bytes_received := u32(0)
-			C.GetOverlappedResult(voidptr(listen_socket), &accept_io_data.overlapped,
-				&bytes_received, false)
-
-			// Associate with IOCP and post read
-			iocp.associate_handle_with_iocp(iocp_handle, accept_socket, u64(accept_socket)) or {
-				eprintln('[iocp-accept] Failed to associate accepted socket: ${err}')
-				socket.close_socket(accept_socket)
-				iocp.free_io_data(accept_io_data)
-				continue
-			}
-
-			post_read_operation(accept_socket, iocp_handle)
-			iocp.free_io_data(accept_io_data)
-		} else {
-			socket.close_socket(accept_socket)
-			iocp.free_io_data(accept_io_data)
+		// Disable Nagle so small responses are not delayed.
+		socket.set_tcp_nodelay(client_fd)
+		port := ports[next]
+		next = (next + 1) % ports.len
+		if !iocp.associate(port, client_fd, usize(client_fd)) {
+			eprintln('[iocp] failed to associate accepted socket: WSA ${C.WSAGetLastError()}')
+			socket.close_socket(client_fd)
+			continue
+		}
+		// Registered successfully — count it (released at close).
+		stdatomic.add_i64(&active_conns.n, 1)
+		if !iocp.post(port, 0, usize(client_fd), unsafe { nil }) {
+			stdatomic.add_i64(&active_conns.n, -1)
+			socket.close_socket(client_fd)
 		}
 	}
-
-	println('[iocp-accept] Accept thread exiting')
 }
 
-pub fn run_iocp_backend(socket_fd int, handler core.Handler, make_state fn () voidptr, port int, mut threads []thread) {
-	println('[iocp] Starting IOCP backend on port ${port}')
-
-	// Create IOCP handle
-	iocp_handle := iocp.create_iocp(u32(max_iocp_workers)) or {
-		eprintln('[iocp] Failed to create IOCP: ${err}')
+pub fn run_iocp_backend(server Server, mut threads []thread) {
+	if server.socket_fd < 0 {
 		return
 	}
-
-	// Associate listening socket with IOCP
-	iocp.associate_handle_with_iocp(iocp_handle, socket_fd, u64(socket_fd)) or {
-		eprintln('[iocp] Failed to associate listening socket: ${err}')
-		return
-	}
-
-	// Create worker threads
-	mut worker_contexts := []&WorkerContext{cap: max_iocp_workers}
-	for i in 0 .. max_iocp_workers {
-		mut ctx := &WorkerContext{
-			iocp_handle: iocp_handle
-			handler:     handler
-			make_state:  make_state
-			running:     true
+	// One IOCP port per worker (concurrency 1: a single thread services each),
+	// mirroring the epoll backend's one-epoll-per-worker fan-out.
+	n_workers := threads.len
+	mut ports := []voidptr{len: n_workers, init: unsafe { nil }}
+	for i in 0 .. n_workers {
+		ports[i] = iocp.create_iocp(1) or {
+			eprintln('[iocp] ${err}')
+			for j in 0 .. i {
+				iocp.close_handle(ports[j])
+			}
+			socket.close_socket(server.socket_fd)
+			exit(1)
 		}
-		worker_contexts << ctx
-		threads[i] = spawn worker_thread(mut ctx)
-		println('[iocp] Started worker thread ${i}')
 	}
-
-	// Start accept thread
-	accept_thread_id := spawn accept_thread(socket_fd, iocp_handle)
-
-	println('listening on http://localhost:${port}/ (IOCP)')
-
-	// Wait for shutdown signal (in real implementation, this would be controlled)
-	mut dummy := 0
-	C.scanf(c'%d', &dummy)
-
-	// Shutdown all workers
-	for mut ctx in worker_contexts {
-		ctx.running = false
-		iocp.post_iocp_status(iocp_handle, 0, 0, unsafe { nil })
+	// workers is the run-thread-OWNED copy of the spawn handles. The shutdown
+	// epilogue below must join from THIS array, never from `threads`: callers
+	// commonly spawn run() with a stack-allocated Server (the tests do), and
+	// once shutdown() returns they may unwind — `threads` points into that
+	// possibly-dead struct, while `workers` lives in this frame for as long as
+	// the epilogue needs it.
+	mut workers := []thread{len: n_workers, cap: n_workers}
+	for i in 0 .. n_workers {
+		counter := server.inflight[i] // this worker's own in-flight counter
+		t := spawn win_worker(ports[i], server.handler, server.make_state, server.limits, counter,
+			server.active_conns)
+		threads[i] = t // caller-visible handle (same contract as the other backends)
+		workers[i] = t
 	}
-
-	// Wait for workers to finish
-	for i in 0 .. max_iocp_workers {
-		threads[i].wait()
+	println('listening on http://localhost:${server.port}/ (IOCP)')
+	win_accept_loop(server.socket_fd, ports, server.limits, server.active_conns, server.draining)
+	// The accept loop only returns when the listener is gone (graceful
+	// shutdown or test teardown). Wake every worker out of its blocking wait
+	// (key = 0 control message), join them, and release the ports — so a
+	// process that starts and stops servers in-process (the test binaries do)
+	// leaks neither threads nor port handles. Any completion queued BEFORE the
+	// wake is still processed first (the port is FIFO); in-flight request
+	// handling was already drained by Server.shutdown()'s counter wait.
+	for i in 0 .. n_workers {
+		iocp.post(ports[i], 0, 0, unsafe { nil })
 	}
-
-	// Close IOCP handle
-	C.CloseHandle(iocp_handle)
-
-	println('[iocp] Server stopped')
+	for i in 0 .. n_workers {
+		workers[i].wait()
+	}
+	for i in 0 .. n_workers {
+		iocp.close_handle(ports[i])
+	}
 }
 
-// run_selected_backend dispatches to the configured Windows backend. Defined per
-// OS so the all-platform facade (http_server.c.v) needs no platform-specific
-// backend import. Blocks in the accept loop.
+// run_selected_backend dispatches to the configured Windows backend. Defined
+// per OS so the all-platform facade (http_server.c.v) needs no
+// platform-specific backend import. Blocks in the accept loop.
 fn run_selected_backend(server Server, mut threads []thread) {
 	match server.io_multiplexing {
 		.iocp {
-			run_iocp_backend(server.socket_fd, server.handler, server.make_state, server.port, mut
-				threads)
+			run_iocp_backend(server, mut threads)
 		}
 	}
 }

--- a/http_server/io_uring_backend_test.v
+++ b/http_server/io_uring_backend_test.v
@@ -1,3 +1,4 @@
+// vtest build: linux
 module http_server
 
 // End-to-end smoke test for the io_uring backend. It guards the rewrite that

--- a/http_server/iocp/iocp_windows.c.v
+++ b/http_server/iocp/iocp_windows.c.v
@@ -1,166 +1,101 @@
 module iocp
 
+// Thin Win32 I/O-completion-port wrapper — the Windows counterpart of the
+// `epoll` / `kqueue` helper modules: just the typed syscall surface the
+// backend needs, no policy. The connection state machine lives in
+// http_server_windows.c.v.
+
+#flag windows -lws2_32
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>
 
+// Field names must match the Win32 definitions EXACTLY (V emits C struct
+// member access verbatim) — same declarations vlib/fasthttp uses.
 @[typedef]
 pub struct C.OVERLAPPED {
 pub mut:
-	internal      u64
-	internal_high u64
-	offset        u64
-	offset_high   u64
-	h_event       voidptr
-}
-
-pub struct CompletionKey {
-pub:
-	socket_handle int
-	operation     IOOperation
-	callback      fn (int, IOOperation, []u8) @[required] // socket_fd, operation, data
-}
-
-pub enum IOOperation {
-	accept
-	read
-	write
-	close
-}
-
-pub struct IOData {
-pub mut:
-	overlapped        C.OVERLAPPED
-	operation         IOOperation
-	socket_fd         int
-	wsabuf            C.WSABUF
-	buffer            []u8
-	bytes_transferred u32
+	Internal     usize
+	InternalHigh usize
+	Offset       u32
+	OffsetHigh   u32
+	hEvent       voidptr
 }
 
 @[typedef]
 pub struct C.WSABUF {
 pub mut:
 	len u32
-	buf &u8
+	buf &char = unsafe { nil }
 }
 
-fn C.CreateIoCompletionPort(file_handle voidptr, existing_completion_port voidptr,
-	completion_key u64, number_of_concurrent_threads u32) voidptr
+// CloseHandle and WSAGetLastError are NOT redeclared here — builtin declares
+// both (i32-typed), and V registers C signatures program-wide (vlang/v#27791),
+// so an incompatible duplicate would break other modules' call sites.
+fn C.CreateIoCompletionPort(file_handle voidptr, existing_completion_port voidptr, completion_key usize, number_of_concurrent_threads u32) voidptr
+fn C.GetQueuedCompletionStatus(completion_port voidptr, lp_number_of_bytes_transferred &u32, lp_completion_key &usize, lp_overlapped &&C.OVERLAPPED, dw_milliseconds u32) bool
+fn C.PostQueuedCompletionStatus(completion_port voidptr, dw_number_of_bytes_transferred u32, dw_completion_key usize, lp_overlapped &C.OVERLAPPED) bool
+fn C.WSARecv(s u64, lp_buffers &C.WSABUF, dw_buffer_count u32, lp_number_of_bytes_recvd &u32, lp_flags &u32, lp_overlapped &C.OVERLAPPED, lp_completion_routine voidptr) int
+fn C.WSASend(s u64, lp_buffers &C.WSABUF, dw_buffer_count u32, lp_number_of_bytes_sent &u32, dw_flags u32, lp_overlapped &C.OVERLAPPED, lp_completion_routine voidptr) int
 
-fn C.GetQueuedCompletionStatus(completion_port voidptr, lp_number_of_bytes_transferred &u32,
-	lp_completion_key &u64, lp_overlapped &&C.OVERLAPPED, dw_milliseconds u32) bool
+pub const infinite = u32(0xFFFFFFFF)
 
-fn C.PostQueuedCompletionStatus(completion_port voidptr, dw_number_of_bytes_transferred u32,
-	dw_completion_key u64, lp_overlapped &C.OVERLAPPED) bool
+// wsa_io_pending is WSA_IO_PENDING: an overlapped op was queued successfully
+// and will complete through the port — the NON-error "error" every post gets.
+pub const wsa_io_pending = 997
 
-fn C.CloseHandle(h_object voidptr) bool
-
-fn C.WSARecv(s u64, lp_buffers &C.WSABUF, dw_buffer_count u32, lp_number_of_bytes_recvd &u32,
-	lp_flags &u32, lp_overlapped &C.OVERLAPPED, lp_completion_routine voidptr) int
-
-fn C.WSASend(s u64, lp_buffers &C.WSABUF, dw_buffer_count u32, lp_number_of_bytes_sent &u32,
-	dw_flags u32, lp_overlapped &C.OVERLAPPED, lp_completion_routine voidptr) int
-
-fn C.AcceptEx(s_listen_socket u64, s_accept_socket u64, lp_output_buffer voidptr,
-	dw_receive_data_length u32, dw_local_address_length u32, dw_remote_address_length u32,
-	lpdw_bytes_received &u32, lp_overlapped &C.OVERLAPPED) bool
-
-fn C.GetAcceptExSockaddrs(lp_output_buffer voidptr, dw_receive_data_length u32,
-	dw_local_address_length u32, dw_remote_address_length u32,
-	local_sockaddr &&voidptr, local_sockaddr_length &int,
-	remote_sockaddr &&voidptr, remote_sockaddr_length &int)
-
-fn C.CreateEventA(lp_event_attributes voidptr, b_manual_reset bool, b_initial_state bool,
-	lp_name &u16) voidptr
-
-fn C.SetEvent(h_event voidptr) bool
-
-fn C.WaitForSingleObject(h_handle voidptr, dw_milliseconds u32) u32
-
-pub const infinity = u32(0xFFFFFFFF)
-
-pub struct IOCP {
-pub mut:
-	handle          voidptr
-	worker_threads  []thread
-	shutdown_signal voidptr
-}
-
+// create_iocp creates a completion port that wakes at most
+// `max_concurrent_threads` threads at once (1 for a single-worker port).
 pub fn create_iocp(max_concurrent_threads u32) !voidptr {
-	handle := C.CreateIoCompletionPort(unsafe { nil }, unsafe { nil }, 0, max_concurrent_threads)
+	handle := C.CreateIoCompletionPort(C.INVALID_HANDLE_VALUE, unsafe { nil }, 0,
+		max_concurrent_threads)
 	if handle == unsafe { nil } {
-		return error('Failed to create IOCP port')
+		return error('CreateIoCompletionPort failed: WSA ${C.WSAGetLastError()}')
 	}
 	return handle
 }
 
-pub fn associate_handle_with_iocp(iocp_handle voidptr, socket_handle int, completion_key u64) ! {
-	handle := C.CreateIoCompletionPort(voidptr(socket_handle), iocp_handle, completion_key, 0)
-	if handle == unsafe { nil } {
-		return error('Failed to associate socket with IOCP')
+// associate associates a socket with a port; every overlapped completion on
+// that socket is then delivered to the port along with `completion_key`.
+pub fn associate(iocp_handle voidptr, socket_fd int, completion_key usize) bool {
+	return C.CreateIoCompletionPort(voidptr(u64(socket_fd)), iocp_handle, completion_key, 0) != unsafe { nil }
+}
+
+// post delivers a manual completion (overlapped may be nil) — used for the
+// accept→worker connection hand-off and for shutdown wake-ups.
+pub fn post(iocp_handle voidptr, bytes u32, completion_key usize, overlapped &C.OVERLAPPED) bool {
+	return C.PostQueuedCompletionStatus(iocp_handle, bytes, completion_key, overlapped)
+}
+
+// wait dequeues ONE completion (or times out). Returns false on a failed /
+// aborted completion AND on timeout; timeout is the case where `overlapped`
+// stays nil.
+pub fn wait(iocp_handle voidptr, bytes &u32, completion_key &usize, overlapped &&C.OVERLAPPED, timeout_ms u32) bool {
+	return C.GetQueuedCompletionStatus(iocp_handle, bytes, completion_key, overlapped, timeout_ms)
+}
+
+// post_recv starts an overlapped receive. Returns true when the op is in
+// flight (its completion WILL arrive at the port — including immediate
+// success) and false on a hard post failure (nothing was queued).
+pub fn post_recv(socket_fd int, wsabuf &C.WSABUF, overlapped &C.OVERLAPPED) bool {
+	mut flags := u32(0)
+	mut recvd := u32(0)
+	if C.WSARecv(u64(socket_fd), wsabuf, 1, &recvd, &flags, overlapped, unsafe { nil }) != 0 {
+		return C.WSAGetLastError() == wsa_io_pending
 	}
+	return true
 }
 
-pub fn post_iocp_status(iocp_handle voidptr, bytes_transferred u32, completion_key u64,
-	overlapped &C.OVERLAPPED) bool {
-	return C.PostQueuedCompletionStatus(iocp_handle, bytes_transferred, completion_key, overlapped)
-}
-
-pub fn get_queued_completion_status(iocp_handle voidptr, bytes_transferred &u32,
-	completion_key &u64, overlapped &&C.OVERLAPPED, timeout_ms u32) bool {
-	return C.GetQueuedCompletionStatus(iocp_handle, bytes_transferred, completion_key, overlapped,
-		timeout_ms)
-}
-
-pub fn create_event() voidptr {
-	return C.CreateEventA(unsafe { nil }, false, false, unsafe { nil })
-}
-
-pub fn wait_for_single_object(handle voidptr, timeout_ms u32) u32 {
-	return C.WaitForSingleObject(handle, timeout_ms)
-}
-
-pub fn set_event(handle voidptr) bool {
-	return C.SetEvent(handle)
+// post_send starts an overlapped send. Same in-flight/failure contract as
+// post_recv.
+pub fn post_send(socket_fd int, wsabuf &C.WSABUF, overlapped &C.OVERLAPPED) bool {
+	mut sent := u32(0)
+	if C.WSASend(u64(socket_fd), wsabuf, 1, &sent, 0, overlapped, unsafe { nil }) != 0 {
+		return C.WSAGetLastError() == wsa_io_pending
+	}
+	return true
 }
 
 pub fn close_handle(handle voidptr) bool {
-	return C.CloseHandle(handle)
-}
-
-pub fn start_accept_ex(listen_socket int, accept_socket int, overlapped &C.OVERLAPPED) bool {
-	return C.AcceptEx(u64(listen_socket), u64(accept_socket), unsafe { nil }, 0,
-
-		sizeof(C.sockaddr_in) + 16, sizeof(C.sockaddr_in) + 16, unsafe { nil }, overlapped)
-}
-
-pub fn post_recv(socket_fd int, buffers &C.WSABUF, buffer_count u32, flags &u32,
-	overlapped &C.OVERLAPPED) int {
-	return C.WSARecv(u64(socket_fd), buffers, buffer_count, unsafe { nil }, flags, overlapped,
-		unsafe { nil })
-}
-
-pub fn post_send(socket_fd int, buffers &C.WSABUF, buffer_count u32, flags u32,
-	overlapped &C.OVERLAPPED) int {
-	return C.WSASend(u64(socket_fd), buffers, buffer_count, unsafe { nil }, flags, overlapped,
-		unsafe { nil })
-}
-
-pub fn create_io_data(socket_fd int, operation IOOperation, buffer_size int) &IOData {
-	mut io_data := &IOData{
-		socket_fd: socket_fd
-		operation: operation
-		buffer:    []u8{len: buffer_size}
-	}
-	io_data.wsabuf.len = u32(buffer_size)
-	io_data.wsabuf.buf = &io_data.buffer[0]
-	return io_data
-}
-
-pub fn free_io_data(io_data &IOData) {
-	unsafe {
-		io_data.buffer.free()
-		free(io_data)
-	}
+	return C.CloseHandle(handle) != 0
 }

--- a/http_server/socket/socket_tcp.c.v
+++ b/http_server/socket/socket_tcp.c.v
@@ -10,10 +10,9 @@ pub const max_connection_size = 1024
 // the same 65536.
 pub const listen_backlog = 65536
 
-#include <fcntl.h>
-#include <sys/socket.h>
-
 $if !windows {
+	#include <fcntl.h>
+	#include <sys/socket.h>
 	#include <netinet/in.h>
 	// superset of previous
 	#include <netinet/ip.h>
@@ -108,8 +107,7 @@ pub fn connect_to_server(port int) !int {
 pub fn set_blocking(fd int, blocking bool) {
 	$if windows {
 		mut mode := u32(if blocking { 0 } else { 1 })
-		if C.ioctlsocket(u64(fd), 0x8004667E, &mode) != 0 // FIONBIO
-		  {
+		if C.ioctlsocket(fd, C.FIONBIO, &mode) != 0 {
 			eprintln(@LOCATION + ' ioctlsocket failed: ${C.WSAGetLastError()}')
 		}
 	} $else {
@@ -127,10 +125,9 @@ pub fn set_blocking(fd int, blocking bool) {
 // immediately instead of waiting to coalesce. Standard for request/response
 // HTTP servers; the win shows on real networks (negligible on loopback).
 pub fn set_tcp_nodelay(fd int) {
-	$if !windows {
-		opt := 1
-		C.setsockopt(fd, C.IPPROTO_TCP, C.TCP_NODELAY, &opt, sizeof(opt))
-	}
+	// IPPROTO_TCP/TCP_NODELAY exist on every platform (winsock2.h on Windows).
+	opt := 1
+	C.setsockopt(fd, C.IPPROTO_TCP, C.TCP_NODELAY, &opt, sizeof(opt))
 }
 
 // set_nosigpipe stops send() to a dead peer from raising SIGPIPE on
@@ -150,9 +147,15 @@ pub fn accept_client(server_fd int) int {
 	$if linux {
 		return C.accept4(server_fd, C.NULL, C.NULL, C.SOCK_NONBLOCK)
 	} $else $if windows {
-		// Winsock SOCKET is u64; kernel handles are 32-bit-significant, so the
-		// int fd convention holds (INVALID_SOCKET truncates to -1).
-		fd := int(C.accept(u64(server_fd), C.NULL, C.NULL))
+		// Winsock SOCKET handles are 32-bit-significant, so the int fd
+		// convention holds (INVALID_SOCKET truncates to -1). The accepted
+		// socket is made NON-BLOCKING like on every other backend: overlapped
+		// (IOCP) operations are asynchronous regardless of the mode, and the
+		// mode makes the timeout sweep's synchronous courtesy 408 BEST-EFFORT —
+		// against a full kernel send buffer it fails with WSAEWOULDBLOCK
+		// instead of blocking the whole worker thread behind one stalled peer
+		// (the epoll backend gets the same safety from O_NONBLOCK + EAGAIN).
+		fd := C.accept(server_fd, C.NULL, C.NULL)
 		if fd >= 0 {
 			set_blocking(fd, false)
 		}
@@ -172,25 +175,23 @@ pub fn accept_client(server_fd int) int {
 // client IP (rate limiting, proxy trust) — it costs one getpeername syscall and
 // nothing otherwise, keeping the `fn ([]u8, int)` handler contract intact.
 pub fn peer_addr(fd int) string {
-	$if windows {
+	// One body for every platform: ws2_32 exports getpeername and inet_ntop
+	// with the same shapes the unix headers declare.
+	mut a := C.sockaddr_in{}
+	mut l := u32(sizeof(a))
+	if C.getpeername(fd, voidptr(&a), &l) != 0 {
 		return ''
-	} $else {
-		mut a := C.sockaddr_in{}
-		mut l := u32(sizeof(a))
-		if C.getpeername(fd, voidptr(&a), &l) != 0 {
-			return ''
-		}
-		mut buf := [46]u8{} // INET6_ADDRSTRLEN
-		if C.inet_ntop(C.AF_INET, voidptr(&a.sin_addr), &char(&buf[0]), 46) == 0 {
-			return ''
-		}
-		return unsafe { cstring_to_vstring(&char(&buf[0])) }
 	}
+	mut buf := [46]u8{} // INET6_ADDRSTRLEN
+	if C.inet_ntop(C.AF_INET, voidptr(&a.sin_addr), &char(&buf[0]), 46) == 0 {
+		return ''
+	}
+	return unsafe { cstring_to_vstring(&char(&buf[0])) }
 }
 
 pub fn close_socket(fd int) {
 	$if windows {
-		C.closesocket(u64(fd))
+		C.closesocket(fd)
 	} $else {
 		C.close(fd)
 	}

--- a/http_server/socket/socket_windows.c.v
+++ b/http_server/socket/socket_windows.c.v
@@ -1,5 +1,6 @@
 module socket
 
+#flag windows -lws2_32
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>
@@ -22,35 +23,22 @@ pub fn cleanup_winsock() {
 	C.WSACleanup()
 }
 
-type SOCKET = u64
-
-pub const invalid_socket = u64(~u64(0))
 pub const socket_error = -1
 
+// C declarations follow the int-fd convention everywhere (Windows SOCKET
+// handles are 32-bit-significant, INVALID_SOCKET truncates to -1) — and they
+// MUST: V registers C function signatures program-wide (vlang/v#27791), so a
+// u64-typed duplicate of a function vlib also declares int-typed (vlib/net,
+// builtin) breaks vlib's own call sites in any program importing both.
+// Functions already declared by socket_tcp.c.v (bind/connect/listen/
+// setsockopt/htons/getpeername/inet_ntop/socket/accept) are NOT redeclared
+// here.
 fn C.WSAStartup(wVersionRequired u16, lpWSAData voidptr) int
 fn C.WSACleanup() int
 fn C.WSAGetLastError() int
-fn C.closesocket(s u64) int
-fn C.ioctlsocket(s u64, cmd int, argptr &u32) int
-fn C.WSAIoctl(s u64, dwIoControlCode u32, lpvInBuffer voidptr, cbInBuffer u32,
-	lpvOutBuffer voidptr, cbOutBuffer u32, lpcbBytesReturned &u32,
-	lpOverlapped voidptr, lpCompletionRoutine voidptr) int
-fn C.accept(s u64, addr voidptr, addrlen &int) u64
-fn C.bind(s u64, name voidptr, namelen int) int
-fn C.connect(s u64, name voidptr, namelen int) int
-fn C.listen(s u64, backlog int) int
-fn C.socket(socket_family int, socket_type int, protocol int) u64
-fn C.setsockopt(s u64, level int, optname int, optval voidptr, optlen int) int
-fn C.htons(hostshort u16) u16
+fn C.closesocket(s int) int
+fn C.ioctlsocket(s int, cmd int, argptr &u32) int
 fn C.htonl(hostlong u32) u32
-fn C.ntohs(netshort u16) u16
-fn C.ntohl(netlong u32) u32
-fn C.getaddrinfo(nodename &char, servname &char, hints voidptr, res &&voidptr) int
-fn C.freeaddrinfo(res voidptr)
-fn C.getnameinfo(sa voidptr, salen int, host &char, hostlen int,
-	serv &char, servlen int, flags int) int
-fn C.inet_pton(af int, src &char, dst voidptr) int
-fn C.inet_ntop(af int, src voidptr, dst &char, size int) &char
 
 // struct C.in_addr {
 // 	s_addr u32
@@ -71,24 +59,26 @@ pub fn connect_to_server_on_windows(port int) !int {
 	}
 
 	println('[client] Creating client socket...')
-	client_fd := int(C.socket(C.AF_INET, C.SOCK_STREAM, 0))
-	if client_fd == int(invalid_socket) {
+	client_fd := C.socket(C.AF_INET, C.SOCK_STREAM, 0)
+	if client_fd < 0 {
 		println('[client] Failed to create client socket')
 		return error('Failed to create client socket')
 	}
 
 	// sin_zero padding is left out of the literal: the shared C.sockaddr_in
 	// decl doesn't name it, and C zero-inits unspecified fields anyway.
+	// 127.0.0.1, not 0.0.0.0: unlike Linux, Winsock rejects INADDR_ANY as a
+	// connect() destination with WSAEADDRNOTAVAIL.
 	mut addr := C.sockaddr_in{
 		sin_family: u16(C.AF_INET)
 		sin_port:   C.htons(u16(port))
-		sin_addr:   C.in_addr{u32(0)} // 0.0.0.0
+		sin_addr:   C.in_addr{C.htonl(u32(0x7f000001))} // 127.0.0.1
 	}
 
-	println('[client] Connecting to server on port ${port} (0.0.0.0)...')
-	if C.connect(u64(client_fd), voidptr(&addr), sizeof(addr)) == socket_error {
+	println('[client] Connecting to server on port ${port} (127.0.0.1)...')
+	if C.connect(client_fd, voidptr(&addr), sizeof(addr)) == socket_error {
 		println('[client] Failed to connect to server: error=${C.WSAGetLastError()}')
-		C.closesocket(u64(client_fd))
+		C.closesocket(client_fd)
 		return error('Failed to connect to server')
 	}
 
@@ -102,16 +92,18 @@ pub fn create_server_socket_on_windows(port int) int {
 		exit(1)
 	}
 
-	server_fd := int(C.socket(C.AF_INET, C.SOCK_STREAM, 0))
-	if server_fd == int(invalid_socket) {
+	server_fd := C.socket(C.AF_INET, C.SOCK_STREAM, 0)
+	if server_fd < 0 {
 		eprintln(@LOCATION + ' Socket creation failed: ${C.WSAGetLastError()}')
 		exit(1)
 	}
 
-	set_blocking(server_fd, false)
+	// The listening socket stays BLOCKING on purpose: the IOCP backend accepts
+	// from a plain blocking accept() loop (no readiness reactor exists to poll
+	// it), and closesocket() on shutdown unblocks that loop with an error.
 
 	opt := 1
-	if C.setsockopt(u64(server_fd), C.SOL_SOCKET, C.SO_REUSEADDR, &opt, sizeof(opt)) == socket_error {
+	if C.setsockopt(server_fd, C.SOL_SOCKET, C.SO_REUSEADDR, &opt, sizeof(opt)) == socket_error {
 		eprintln(@LOCATION + ' setsockopt SO_REUSEADDR failed: ${C.WSAGetLastError()}')
 		close_socket(server_fd)
 		exit(1)
@@ -125,13 +117,13 @@ pub fn create_server_socket_on_windows(port int) int {
 		sin_addr:   C.in_addr{u32(C.INADDR_ANY)}
 	}
 
-	if C.bind(u64(server_fd), voidptr(&server_addr), sizeof(server_addr)) == socket_error {
+	if C.bind(server_fd, voidptr(&server_addr), sizeof(server_addr)) == socket_error {
 		eprintln(@LOCATION + ' Bind failed: ${C.WSAGetLastError()}')
 		close_socket(server_fd)
 		exit(1)
 	}
 
-	if C.listen(u64(server_fd), listen_backlog) == socket_error {
+	if C.listen(server_fd, listen_backlog) == socket_error {
 		eprintln(@LOCATION + ' Listen failed: ${C.WSAGetLastError()}')
 		close_socket(server_fd)
 		exit(1)


### PR DESCRIPTION
## Summary

Implements a real Windows IOCP backend and everything the Windows build needed around it. Before this, the repo did not compile on Windows at all (unconditional `#include <sys/socket.h>`), and the IOCP file was a skeleton (accept waiting on a never-created event, no request framing, `scanf` blocking shutdown, test client connecting to `0.0.0.0` — invalid on Winsock).

### The backend (`http_server_windows.c.v`)

Same shared-nothing thread-per-core model as epoll, adapted to completion semantics:

- **one IOCP port per worker** — a blocking accept loop hands each connection to one worker for life, so per-connection state needs no locks
- **pooled per-connection state**, persistent read/write buffers — zero per-request allocation
- **exactly ONE overlapped op in flight per connection**, so buffers are never reallocated while the kernel holds a pointer into them
- **HTTP/1.1 keep-alive + pipelining** — every complete request in a burst is answered into the write buffer; the batch goes out in a single WSASend
- **large-body streaming drain** (>1 MiB): answered from the head, body consumed in O(buffer) memory, response HELD until the drain completes (drain-then-respond, same contract as epoll)
- **limits**: max_connections at accept, 413/431 parser sentinels, read/write deadline sweep (best-effort 408 — non-blocking socket, so a stalled peer can never freeze a worker)
- **graceful shutdown** wakes, joins and releases the workers and ports (joining from a run-thread-owned handle copy — the caller's `Server` may be stack-allocated and gone by then)

### Windows portability fixes

- socket layer: unix includes gated; C decls normalized to the int-fd convention — V registers C fn signatures program-wide (vlang/v#27791) and the old u64 duplicates broke vlib `net` in any program importing both; `TCP_NODELAY` now cross-platform; `peer_addr` unified; test client connects to 127.0.0.1
- request_parser: `memmem` is GNU-only — memchr+memcmp twin on Windows
- `Server.test()` uses `closesocket`; `new_server` rejects `tls_config` on Windows (not supported yet)
- two Linux-only test files gated with `// vtest build: linux`
- Windows CI: new `http_server` module-test job; matrix swapped to nine examples that build and test clean on the runner (libpq/sqlite-dependent ones stay Linux-covered)

## Test plan

- [x] `v test http_server/` on Windows: 6 passed, 2 skipped (Linux-only) — including all 5 backend-behavior checks against IOCP: pipelining, split-request framing, max_connections, read timeout (408), graceful shutdown, 2 MiB upload drain-then-respond with exact drain + keep-alive
- [x] Nine CI-matrix examples build and their tests pass on Windows
- [x] Sustained load (`-prod`): ~287K req/s, 0 errors (32 conns × 16 pipelined); ~27µs single-connection round trip on loopback
- [x] `v fmt -verify .` clean; `v -check -os linux` / `-os macos` clean (no regressions on the other backends)

Known limitation (documented in `core.v` and the module header): no watch reactor on Windows yet — `.suspend` drops the connection (same as the TLS worker). Follow-up issues track the reactor, TLS, TransmitFile and GetQueuedCompletionStatusEx batching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
