### PR TITLE
fix(limits): streamed-body max_body_bytes bypass + zero build notices

### DIFF
--- a/examples/async_date_timerfd/main.v
+++ b/examples/async_date_timerfd/main.v
@@ -101,7 +101,7 @@ fn on_start(worker_state voidptr, mut event_loop core.EventLoop) {
 // date_tick fires once a second: drain the timerfd, refresh this worker's cache,
 // and re-arm. Returns .suspend (keep the background watch alive). It never writes
 // to `out` (there is no client) and lives for the worker's whole lifetime.
-fn date_tick(mut out []u8, ready_fd int, ready_fd_error bool, watch_payload voidptr, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn date_tick(mut _outout []u8, ready_fd int, _ready_fd_errorready_fd_error bool, _watch_payloadwatch_payload voidptr, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
 	mut tmp := [8]u8{}
 	C.read(ready_fd, &tmp[0], 8) // drain the expiration count to re-level the fd
 	mut dc := unsafe { &DateCache(worker_state) }
@@ -115,7 +115,7 @@ const head = 'HTTP/1.1 200 OK\r\n'.bytes()
 const tail = 'Content-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
 
 // handle is a plain sync handler: zero time work — just append the cached Date.
-fn handle(req []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(_reqreq []u8, mut out []u8, _client_fdclient_fd int, worker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	dc := unsafe { &DateCache(worker_state) }
 	out << head
 	unsafe { out.push_many(&dc.line[0], date_line_len) }

--- a/examples/async_date_timerfd/main.v
+++ b/examples/async_date_timerfd/main.v
@@ -101,7 +101,7 @@ fn on_start(worker_state voidptr, mut event_loop core.EventLoop) {
 // date_tick fires once a second: drain the timerfd, refresh this worker's cache,
 // and re-arm. Returns .suspend (keep the background watch alive). It never writes
 // to `out` (there is no client) and lives for the worker's whole lifetime.
-fn date_tick(mut _outout []u8, ready_fd int, _ready_fd_errorready_fd_error bool, _watch_payloadwatch_payload voidptr, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn date_tick(mut _out []u8, ready_fd int, _ready_fd_error bool, _watch_payload voidptr, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
 	mut tmp := [8]u8{}
 	C.read(ready_fd, &tmp[0], 8) // drain the expiration count to re-level the fd
 	mut dc := unsafe { &DateCache(worker_state) }
@@ -115,7 +115,7 @@ const head = 'HTTP/1.1 200 OK\r\n'.bytes()
 const tail = 'Content-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
 
 // handle is a plain sync handler: zero time work — just append the cached Date.
-fn handle(_reqreq []u8, mut out []u8, _client_fdclient_fd int, worker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(_req []u8, mut out []u8, _client_fd int, worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	dc := unsafe { &DateCache(worker_state) }
 	out << head
 	unsafe { out.push_many(&dc.line[0], date_line_len) }

--- a/examples/async_pipe/src/main.v
+++ b/examples/async_pipe/src/main.v
@@ -22,7 +22,7 @@ fn C.close(fd int) int
 const resp_ok = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
 
 // handle parks /async on a pipe read-end and answers everything else immediately.
-fn handle(req []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut event_loop core.EventLoop) core.Step {
 	if req.bytestr().contains('/async') {
 		mut fds := [2]int{}
 		if C.pipe(unsafe { &fds[0] }) != 0 {
@@ -44,7 +44,7 @@ fn handle(req []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_s
 
 // pipe_done runs when the pipe read-end is readable: drain it, close it (the
 // request owns the watched fd), and answer.
-fn pipe_done(mut out []u8, ready_fd int, _ready_fd_errorready_fd_error bool, _watch_payloadwatch_payload voidptr, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn pipe_done(mut out []u8, ready_fd int, _ready_fd_error bool, _watch_payload voidptr, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	mut tmp := [8]u8{}
 	C.read(ready_fd, &tmp[0], 8)
 	C.close(ready_fd)

--- a/examples/async_pipe/src/main.v
+++ b/examples/async_pipe/src/main.v
@@ -22,7 +22,7 @@ fn C.close(fd int) int
 const resp_ok = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
 
 // handle parks /async on a pipe read-end and answers everything else immediately.
-fn handle(req []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut event_loop core.EventLoop) core.Step {
 	if req.bytestr().contains('/async') {
 		mut fds := [2]int{}
 		if C.pipe(unsafe { &fds[0] }) != 0 {
@@ -44,7 +44,7 @@ fn handle(req []u8, mut out []u8, client_fd int, worker_state voidptr, mut event
 
 // pipe_done runs when the pipe read-end is readable: drain it, close it (the
 // request owns the watched fd), and answer.
-fn pipe_done(mut out []u8, ready_fd int, ready_fd_error bool, watch_payload voidptr, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn pipe_done(mut out []u8, ready_fd int, _ready_fd_errorready_fd_error bool, _watch_payloadwatch_payload voidptr, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	mut tmp := [8]u8{}
 	C.read(ready_fd, &tmp[0], 8)
 	C.close(ready_fd)

--- a/examples/auth/src/main.v
+++ b/examples/auth/src/main.v
@@ -229,7 +229,7 @@ fn bearer_token(req request_parser.HttpRequest) []u8 {
 	return unsafe { (&req.buffer[s.start + prefix.len]).vbytes(s.len - prefix.len) }
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/auth/src/main.v
+++ b/examples/auth/src/main.v
@@ -229,7 +229,7 @@ fn bearer_token(req request_parser.HttpRequest) []u8 {
 	return unsafe { (&req.buffer[s.start + prefix.len]).vbytes(s.len - prefix.len) }
 }
 
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/chunked_streaming/src/main.v
+++ b/examples/chunked_streaming/src/main.v
@@ -178,7 +178,7 @@ fn is_chunked(req request_parser.HttpRequest) bool {
 	return true
 }
 
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/chunked_streaming/src/main.v
+++ b/examples/chunked_streaming/src/main.v
@@ -178,7 +178,7 @@ fn is_chunked(req request_parser.HttpRequest) bool {
 	return true
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/compression/src/main.v
+++ b/examples/compression/src/main.v
@@ -132,7 +132,7 @@ fn pick_encoding(buf []u8, start int, len int, brotli_ok bool) Encoding {
 	return .identity
 }
 
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/compression/src/main.v
+++ b/examples/compression/src/main.v
@@ -132,7 +132,7 @@ fn pick_encoding(buf []u8, start int, len int, brotli_ok bool) Encoding {
 	return .identity
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/conformance/src/main.v
+++ b/examples/conformance/src/main.v
@@ -20,7 +20,7 @@ import http_server.http1_1.request_parser
 // parameters (client_fd, worker_state, event_loop) are unused here — this server
 // is stateless and synchronous.
 @[direct_array_access]
-fn handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle_request(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		// Malformed head: emit a self-delimiting 400 and close (RFC 9112 §9.6 —
 		// the byte stream can no longer be trusted).

--- a/examples/conformance/src/main.v
+++ b/examples/conformance/src/main.v
@@ -20,7 +20,7 @@ import http_server.http1_1.request_parser
 // parameters (client_fd, worker_state, event_loop) are unused here — this server
 // is stateless and synchronous.
 @[direct_array_access]
-fn handle_request(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		// Malformed head: emit a self-delimiting 400 and close (RFC 9112 §9.6 —
 		// the byte stream can no longer be trusted).

--- a/examples/cookies_sessions/src/main.v
+++ b/examples/cookies_sessions/src/main.v
@@ -181,7 +181,7 @@ fn slice_eq(buf []u8, s request_parser.Slice, lit string) bool {
 	return true
 }
 
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop, mut store Store) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop, mut store Store) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/cookies_sessions/src/main.v
+++ b/examples/cookies_sessions/src/main.v
@@ -181,7 +181,7 @@ fn slice_eq(buf []u8, s request_parser.Slice, lit string) bool {
 	return true
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop, mut store Store) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop, mut store Store) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/cors/src/main.v
+++ b/examples/cors/src/main.v
@@ -69,7 +69,7 @@ fn slice_eq(buf []u8, s request_parser.Slice, lit string) bool {
 	return true
 }
 
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/cors/src/main.v
+++ b/examples/cors/src/main.v
@@ -69,7 +69,7 @@ fn slice_eq(buf []u8, s request_parser.Slice, lit string) bool {
 	return true
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/csrf/src/main.v
+++ b/examples/csrf/src/main.v
@@ -127,7 +127,7 @@ fn cookie_value(buf []u8, hdr request_parser.Slice, name string) (int, int) {
 	return 0, -1
 }
 
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/csrf/src/main.v
+++ b/examples/csrf/src/main.v
@@ -127,7 +127,7 @@ fn cookie_value(buf []u8, hdr request_parser.Slice, name string) (int, int) {
 	return 0, -1
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/etag/src/controllers.v
+++ b/examples/etag/src/controllers.v
@@ -44,11 +44,11 @@ fn etag_matches(buf []u8, s request_parser.Slice, etag [16]u8) bool {
 	return true
 }
 
-fn home_controller(params []string) ![]u8 {
+fn home_controller(_paramsparams []string) ![]u8 {
 	return http_ok_response
 }
 
-fn get_users_controller(params []string) ![]u8 {
+fn get_users_controller(_paramsparams []string) ![]u8 {
 	return http_ok_response
 }
 
@@ -79,6 +79,6 @@ fn get_user_controller(params []string, req request_parser.HttpRequest) ![]u8 {
 	return sb
 }
 
-fn create_user_controller(params []string) ![]u8 {
+fn create_user_controller(_paramsparams []string) ![]u8 {
 	return http_created_response
 }

--- a/examples/etag/src/controllers.v
+++ b/examples/etag/src/controllers.v
@@ -44,11 +44,11 @@ fn etag_matches(buf []u8, s request_parser.Slice, etag [16]u8) bool {
 	return true
 }
 
-fn home_controller(_paramsparams []string) ![]u8 {
+fn home_controller(_params []string) ![]u8 {
 	return http_ok_response
 }
 
-fn get_users_controller(_paramsparams []string) ![]u8 {
+fn get_users_controller(_params []string) ![]u8 {
 	return http_ok_response
 }
 
@@ -79,6 +79,6 @@ fn get_user_controller(params []string, req request_parser.HttpRequest) ![]u8 {
 	return sb
 }
 
-fn create_user_controller(_paramsparams []string) ![]u8 {
+fn create_user_controller(_params []string) ![]u8 {
 	return http_created_response
 }

--- a/examples/etag/src/main.v
+++ b/examples/etag/src/main.v
@@ -5,7 +5,7 @@ import http_server.core
 import http_server.http1_1.response
 import http_server.http1_1.request_parser
 
-fn handle_request(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/etag/src/main.v
+++ b/examples/etag/src/main.v
@@ -5,7 +5,7 @@ import http_server.core
 import http_server.http1_1.response
 import http_server.http1_1.request_parser
 
-fn handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle_request(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/graceful_shutdown/src/main.v
+++ b/examples/graceful_shutdown/src/main.v
@@ -19,7 +19,7 @@ import http_server
 import http_server.core
 import os
 
-fn handle(_req_bufferreq_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(_req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 	return .done
 }

--- a/examples/graceful_shutdown/src/main.v
+++ b/examples/graceful_shutdown/src/main.v
@@ -19,7 +19,7 @@ import http_server
 import http_server.core
 import os
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(_req_bufferreq_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 	return .done
 }

--- a/examples/ip_block/src/main.v
+++ b/examples/ip_block/src/main.v
@@ -54,7 +54,7 @@ fn (mut b Blocklist) is_blocked(ip string) bool {
 const forbidden_response = 'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const ok_response = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 7\r\nConnection: keep-alive\r\n\r\nallowed'.bytes()
 
-fn handle(_req_bufferreq_buffer []u8, mut out []u8, client_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop, mut blocklist Blocklist) core.Step {
+fn handle(_req_buffer []u8, mut out []u8, client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop, mut blocklist Blocklist) core.Step {
 	ip := socket.peer_addr(client_fd)
 	if blocklist.is_blocked(ip) {
 		eprintln('[ip-block] denied ${ip}')

--- a/examples/ip_block/src/main.v
+++ b/examples/ip_block/src/main.v
@@ -54,7 +54,7 @@ fn (mut b Blocklist) is_blocked(ip string) bool {
 const forbidden_response = 'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const ok_response = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 7\r\nConnection: keep-alive\r\n\r\nallowed'.bytes()
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop, mut blocklist Blocklist) core.Step {
+fn handle(_req_bufferreq_buffer []u8, mut out []u8, client_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop, mut blocklist Blocklist) core.Step {
 	ip := socket.peer_addr(client_fd)
 	if blocklist.is_blocked(ip) {
 		eprintln('[ip-block] denied ${ip}')

--- a/examples/json_api/src/main.v
+++ b/examples/json_api/src/main.v
@@ -412,7 +412,7 @@ fn slice_eq(buf []u8, s request_parser.Slice, lit string) bool {
 
 // Sub-handlers take `mut out` and append directly — nothing is returned just
 // to be copied again (no return-then-copy).
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/json_api/src/main.v
+++ b/examples/json_api/src/main.v
@@ -412,7 +412,7 @@ fn slice_eq(buf []u8, s request_parser.Slice, lit string) bool {
 
 // Sub-handlers take `mut out` and append directly — nothing is returned just
 // to be copied again (no return-then-copy).
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/middleware/src/controllers.v
+++ b/examples/middleware/src/controllers.v
@@ -21,7 +21,7 @@ const home_response = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nCont
 
 // route decodes the request and dispatches by path. This is the handler passed to
 // chain(); the global decorators wrap it.
-fn route(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn route(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/middleware/src/controllers.v
+++ b/examples/middleware/src/controllers.v
@@ -21,7 +21,7 @@ const home_response = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nCont
 
 // route decodes the request and dispatches by path. This is the handler passed to
 // chain(); the global decorators wrap it.
-fn route(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn route(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/per_server_workers/src/main.v
+++ b/examples/per_server_workers/src/main.v
@@ -16,12 +16,12 @@ import http_server
 import http_server.core
 import runtime
 
-fn api_handler(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn api_handler(_req_bufferreq_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 4\r\nConnection: keep-alive\r\n\r\nmain'.bytes()
 	return .done
 }
 
-fn admin_handler(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn admin_handler(_req_bufferreq_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nadmin'.bytes()
 	return .done
 }

--- a/examples/per_server_workers/src/main.v
+++ b/examples/per_server_workers/src/main.v
@@ -16,12 +16,12 @@ import http_server
 import http_server.core
 import runtime
 
-fn api_handler(_req_bufferreq_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn api_handler(_req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 4\r\nConnection: keep-alive\r\n\r\nmain'.bytes()
 	return .done
 }
 
-fn admin_handler(_req_bufferreq_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn admin_handler(_req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	out << 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nadmin'.bytes()
 	return .done
 }

--- a/examples/proxy_aware/src/main.v
+++ b/examples/proxy_aware/src/main.v
@@ -199,7 +199,7 @@ fn wi(mut out []u8, n i64) {
 	}
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/proxy_aware/src/main.v
+++ b/examples/proxy_aware/src/main.v
@@ -199,7 +199,7 @@ fn wi(mut out []u8, n i64) {
 	}
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/rate_limit/src/main.v
+++ b/examples/rate_limit/src/main.v
@@ -141,7 +141,7 @@ fn client_key(req request_parser.HttpRequest, fd int) string {
 	return 'unknown'
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop, mut limiter Limiter) core.Step {
+fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop, mut limiter Limiter) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/rate_limit/src/main.v
+++ b/examples/rate_limit/src/main.v
@@ -141,7 +141,7 @@ fn client_key(req request_parser.HttpRequest, fd int) string {
 	return 'unknown'
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop, mut limiter Limiter) core.Step {
+fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop, mut limiter Limiter) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/redirects/src/main.v
+++ b/examples/redirects/src/main.v
@@ -97,7 +97,7 @@ fn safe_next(next []u8) []u8 {
 	return slash_bytes // reject absolute / protocol-relative / empty targets
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/redirects/src/main.v
+++ b/examples/redirects/src/main.v
@@ -97,7 +97,7 @@ fn safe_next(next []u8) []u8 {
 	return slash_bytes // reject absolute / protocol-relative / empty targets
 }
 
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/request_limits/src/main.v
+++ b/examples/request_limits/src/main.v
@@ -31,7 +31,7 @@ import http_server.core
 // handler ever runs — over-large bodies are rejected (413) from Content-Length
 // WITHOUT buffering them, and oversized header blocks get 431. That's the whole
 // point: limits belong in the read loop, not bolted onto each handler.
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(_req_bufferreq_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 	return .done
 }

--- a/examples/request_limits/src/main.v
+++ b/examples/request_limits/src/main.v
@@ -31,7 +31,7 @@ import http_server.core
 // handler ever runs — over-large bodies are rejected (413) from Content-Length
 // WITHOUT buffering them, and oversized header blocks get 431. That's the whole
 // point: limits belong in the read loop, not bolted onto each handler.
-fn handle(_req_bufferreq_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(_req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	out << 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 	return .done
 }

--- a/examples/security_headers/src/main.v
+++ b/examples/security_headers/src/main.v
@@ -49,7 +49,7 @@ fn with_security_headers(next core.Handler) core.Handler {
 	}
 }
 
-fn app(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn app(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/security_headers/src/main.v
+++ b/examples/security_headers/src/main.v
@@ -49,7 +49,7 @@ fn with_security_headers(next core.Handler) core.Handler {
 	}
 }
 
-fn app(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn app(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/simple/src/controllers.v
+++ b/examples/simple/src/controllers.v
@@ -7,11 +7,11 @@ const http_ok_response = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nC
 
 const http_created_response = 'HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 
-fn home_controller(_paramsparams []string) ![]u8 {
+fn home_controller(_params []string) ![]u8 {
 	return http_ok_response
 }
 
-fn get_users_controller(_paramsparams []string) ![]u8 {
+fn get_users_controller(_params []string) ![]u8 {
 	return http_ok_response
 }
 
@@ -38,6 +38,6 @@ fn get_user_controller(params []string) ![]u8 {
 	return sb
 }
 
-fn create_user_controller(_paramsparams []string) ![]u8 {
+fn create_user_controller(_params []string) ![]u8 {
 	return http_created_response
 }

--- a/examples/simple/src/controllers.v
+++ b/examples/simple/src/controllers.v
@@ -7,11 +7,11 @@ const http_ok_response = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nC
 
 const http_created_response = 'HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 
-fn home_controller(params []string) ![]u8 {
+fn home_controller(_paramsparams []string) ![]u8 {
 	return http_ok_response
 }
 
-fn get_users_controller(params []string) ![]u8 {
+fn get_users_controller(_paramsparams []string) ![]u8 {
 	return http_ok_response
 }
 
@@ -38,6 +38,6 @@ fn get_user_controller(params []string) ![]u8 {
 	return sb
 }
 
-fn create_user_controller(params []string) ![]u8 {
+fn create_user_controller(_paramsparams []string) ![]u8 {
 	return http_created_response
 }

--- a/examples/simple/src/main.v
+++ b/examples/simple/src/main.v
@@ -5,7 +5,7 @@ import http_server.core
 import http_server.http1_1.response
 import http_server.http1_1.request_parser
 
-fn handle_request(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/simple/src/main.v
+++ b/examples/simple/src/main.v
@@ -5,7 +5,7 @@ import http_server.core
 import http_server.http1_1.response
 import http_server.http1_1.request_parser
 
-fn handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle_request(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/simple2/src/main.v
+++ b/examples/simple2/src/main.v
@@ -34,7 +34,7 @@ fn slice_eq(buf []u8, s request_parser.Slice, lit string) bool {
 }
 
 @[direct_array_access]
-fn handle_request(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/simple2/src/main.v
+++ b/examples/simple2/src/main.v
@@ -34,7 +34,7 @@ fn slice_eq(buf []u8, s request_parser.Slice, lit string) bool {
 }
 
 @[direct_array_access]
-fn handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle_request(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/simple3/src/main.v
+++ b/examples/simple3/src/main.v
@@ -13,7 +13,7 @@ pub mut:
 	db_pool ?pool.ConnectionPool
 }
 
-fn (app App) handle_request(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn (app App) handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/simple3/src/main.v
+++ b/examples/simple3/src/main.v
@@ -13,7 +13,7 @@ pub mut:
 	db_pool ?pool.ConnectionPool
 }
 
-fn (app App) handle_request(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn (app App) handle_request(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/static_assets/src/main.v
+++ b/examples/static_assets/src/main.v
@@ -34,7 +34,7 @@ const assets = static_assets.new(static_assets.Config{
 // it hands the file to the worker to stream with sendfile(2) — no userspace
 // copy — and falls back to copying the bytes on backends that can't (TLS,
 // non-Linux). Use respond_into (not respond) to get that fast path.
-fn handle(req []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	assets.respond_into(req, mut out) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/static_assets/src/main.v
+++ b/examples/static_assets/src/main.v
@@ -34,7 +34,7 @@ const assets = static_assets.new(static_assets.Config{
 // it hands the file to the worker to stream with sendfile(2) — no userspace
 // copy — and falls back to copying the bytes on backends that can't (TLS,
 // non-Linux). Use respond_into (not respond) to get that fast path.
-fn handle(req []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	assets.respond_into(req, mut out) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/static_files/src/main.v
+++ b/examples/static_files/src/main.v
@@ -275,7 +275,7 @@ fn parse_range(h []u8, size i64) ?(i64, i64) {
 	return start, end
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/static_files/src/main.v
+++ b/examples/static_files/src/main.v
@@ -275,7 +275,7 @@ fn parse_range(h []u8, size i64) ?(i64, i64) {
 	return start, end
 }
 
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/url_form/src/main.v
+++ b/examples/url_form/src/main.v
@@ -213,7 +213,7 @@ fn write_json_escaped(mut sb strings.Builder, s string) {
 const resp_prefix = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: '.bytes()
 
 @[direct_array_access]
-fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/url_form/src/main.v
+++ b/examples/url_form/src/main.v
@@ -213,7 +213,7 @@ fn write_json_escaped(mut sb strings.Builder, s string) {
 const resp_prefix = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: '.bytes()
 
 @[direct_array_access]
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+fn handle(req_buffer []u8, mut out []u8, _client_fdclient_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << response.tiny_bad_request_response
 		return .close

--- a/examples/video_stream/src/main.v
+++ b/examples/video_stream/src/main.v
@@ -94,7 +94,7 @@ fn route_len(buf []u8, path request_parser.Slice) int {
 	return path.len
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop, mut viewers Viewers) core.Step {
+fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop, mut viewers Viewers) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << bad_request
 		return .done

--- a/examples/video_stream/src/main.v
+++ b/examples/video_stream/src/main.v
@@ -94,7 +94,7 @@ fn route_len(buf []u8, path request_parser.Slice) int {
 	return path.len
 }
 
-fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_stateworker_state voidptr, mut _event_loopevent_loop core.EventLoop, mut viewers Viewers) core.Step {
+fn handle(req_buffer []u8, mut out []u8, client_fd int, _worker_state voidptr, mut _event_loop core.EventLoop, mut viewers Viewers) core.Step {
 	req := request_parser.decode_http_request(req_buffer) or {
 		out << bad_request
 		return .done

--- a/http_server/backend_epoll/async_linux.c.v
+++ b/http_server/backend_epoll/async_linux.c.v
@@ -542,6 +542,19 @@ fn start_body_drain(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, l
 		return 0 // head not complete in the buffer yet — grow/recv more
 	}
 	content_length := total - head_len
+	// max_body_bytes must hold on the STREAMED path too: the framed path rejects
+	// an oversized declared body with 413 (frame_request_length_lim_idx), and a
+	// body large enough to stream must not BYPASS that limit just because it
+	// skips buffering. The length is declared in the head, so reject before the
+	// handler ever runs; close, since the unread body makes the request stream
+	// unrecoverable (same reason the framed 413 closes).
+	if limits.max_body_bytes > 0 && content_length > limits.max_body_bytes {
+		cs.write_buf << response.status_413_response
+		if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+			close_conn(epoll_fd, fd, active_conns, mut st)
+		}
+		return 2
+	}
 	head := buf_view(cs.read_buf, 0, head_len)
 	mut event_loop := core.EventLoop{
 		client_fd: fd

--- a/http_server/http_server_io_uring_async_linux.c.v
+++ b/http_server/http_server_io_uring_async_linux.c.v
@@ -469,6 +469,19 @@ fn iou_start_body_drain(mut env IouEnv, mut conn io_uring.Connection, total int,
 	if head_len <= 0 || head_len > conn.read_buf.len {
 		return false // head not complete in the buffer yet — keep buffering
 	}
+	// max_body_bytes must hold on the STREAMED path too (mirrors the epoll
+	// backend's start_body_drain): the framed path 413s an oversized declared
+	// body, and a body large enough to stream must not bypass that limit just
+	// because it skips buffering. Close: the unread body makes the stream
+	// unrecoverable.
+	if limits.max_body_bytes > 0 && total - head_len > limits.max_body_bytes {
+		conn.response_buffer << response.status_413_response
+		conn.close_after_send = true
+		unsafe {
+			conn.read_buf.len = 0
+		}
+		return true
+	}
 	head := buf_view(conn.read_buf, 0, head_len)
 	core.set_queue_buf_allowed(false)
 	mut event_loop := iou_event_loop(mut env, conn.fd)

--- a/http_server/http_server_windows.c.v
+++ b/http_server/http_server_windows.c.v
@@ -386,6 +386,18 @@ fn win_start_body_drain(h core.Handler, mut cs WinConn, limits core.Limits, stat
 		return 0 // head not complete in the buffer yet — grow/recv more
 	}
 	content_length := total - head_len
+	// max_body_bytes must hold on the STREAMED path too (mirrors the epoll and
+	// io_uring backends): the framed path 413s an oversized declared body, and a
+	// body large enough to stream must not bypass that limit just because it
+	// skips buffering. Close: the unread body makes the stream unrecoverable.
+	if limits.max_body_bytes > 0 && content_length > limits.max_body_bytes {
+		cs.write_buf << response.status_413_response
+		cs.close_after = true
+		unsafe {
+			cs.read_buf.len = 0
+		}
+		return 2
+	}
 	head := win_buf_view(cs.read_buf, 0, head_len)
 	mut event_loop := core.EventLoop{
 		client_fd: cs.fd

--- a/http_server/static_assets/static_assets.v
+++ b/http_server/static_assets/static_assets.v
@@ -857,7 +857,7 @@ fn parse_u64_window(buf []u8, lo int, hi int) i64 {
 
 // Above any int-sized asset (`size` is an `int`, < 2^31) yet far below i64 max,
 // so accumulation never wraps.
-const range_num_ceiling = i64(1) << 40
+const range_num_ceiling = i64(u64(1) << 40)
 
 // glob_match matches `name` against a pattern where `*` matches any run of
 // characters and `[hash]` matches a content-hash segment (>=6 hex chars). All

--- a/tests/backend_behaviors_test.v
+++ b/tests/backend_behaviors_test.v
@@ -290,6 +290,47 @@ fn check_large_upload_drain(backend http_server.IOBackend) ! {
 	assert out.inflight_after == 0
 }
 
+// check_streamed_body_over_max_body_bytes: regression for the streamed-path
+// limit bypass. A body declared ABOVE max_body_bytes but large enough to take
+// the streaming path (> the 1 MiB threshold) must be rejected from the head
+// alone — 413 and close, exactly like the framed path — instead of reaching
+// the handler. Before the fix the streamed gate only checked
+// max_request_bytes, so such a body bypassed max_body_bytes entirely and was
+// answered 200. The 413 bytes themselves are asserted only when they arrived:
+// the server closes with the body unread, so the kernel may RST and discard
+// the response in flight — the hard contract is "no 200, connection ended".
+fn check_streamed_body_over_max_body_bytes(backend http_server.IOBackend) ! {
+	head :=
+		'POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: ${bb_upload_body_len}\r\n\r\n'.bytes()
+	first_chunk := []u8{len: bb_upload_chunk_len, init: u8(0x61)}
+	out := vtest.drive(http_server.ServerConfig{
+		io_multiplexing: backend
+		handler:         bb_upload_handler
+		limits:          http_server.Limits{
+			max_body_bytes:    64 * 1024 // far below the 2 MiB declared body
+			max_request_bytes: 8 * 1024 * 1024
+		}
+	}, [
+		vtest.Script{
+			rounds:   [
+				vtest.Round{
+					send: bb_concat(head, first_chunk) // enough to trip the streaming decision, then stop
+					want: 0
+				},
+			]
+			then_eof: true // completion can only come from the server's 413+close
+		},
+	])!
+	c := out.conns[0]
+	assert c.connect_err == '', c.connect_err
+	assert c.eof, '${backend}: oversized streamed body must end in a server close'
+	raw := c.raw.bytestr()
+	assert !raw.contains('200'), '${backend}: a streamed body over max_body_bytes must never reach the handler, got: ${raw}'
+	if c.raw.len > 0 {
+		assert raw.starts_with('HTTP/1.1 413'), '${backend}: expected the 413 rejection, got: ${raw}'
+	}
+}
+
 // check_half_close_after_request: a client that sends a complete request and
 // then half-closes its WRITE side (shut_wr == shutdown(SHUT_WR)) must still
 // receive the full response on the still-open read side (RFC 9112 §9.6).
@@ -417,6 +458,16 @@ fn test_iouring_large_upload_drain() ! {
 	}
 }
 
+fn test_iouring_streamed_body_over_max_body_bytes() ! {
+	$if linux {
+		if !http_server.iou_backend_available() {
+			eprintln('[test] io_uring_setup blocked (sandboxed runner); skipping')
+			return
+		}
+		check_streamed_body_over_max_body_bytes(.io_uring)!
+	}
+}
+
 fn test_iouring_pipelining_and_framing() ! {
 	$if linux {
 		if !http_server.iou_backend_available() {
@@ -479,6 +530,12 @@ fn test_iocp_large_upload_drain() ! {
 	}
 }
 
+fn test_iocp_streamed_body_over_max_body_bytes() ! {
+	$if windows {
+		check_streamed_body_over_max_body_bytes(unsafe { http_server.IOBackend(0) })!
+	}
+}
+
 fn test_iocp_pipelining_and_framing() ! {
 	$if windows {
 		check_pipelining_and_framing(unsafe { http_server.IOBackend(0) })!
@@ -514,6 +571,12 @@ fn test_iocp_half_close_after_request() ! {
 fn test_epoll_large_upload_drain() ! {
 	$if linux {
 		check_large_upload_drain(.epoll)!
+	}
+}
+
+fn test_epoll_streamed_body_over_max_body_bytes() ! {
+	$if linux {
+		check_streamed_body_over_max_body_bytes(.epoll)!
 	}
 }
 


### PR DESCRIPTION
## Summary

Started as "silence all compiler notices" and found a real bug wearing a notice costume: the `unused parameter: limits` notice on `iou_start_body_drain` existed because **the streamed-body path never enforced `max_body_bytes` — on any backend**.

## The bypass

- The framed path rejects an oversized declared body with 413 (`frame_request_length_lim_idx`).
- The streamed path (declared body > 1 MiB threshold: answered from the head, body drained) gated only on `max_request_bytes`.
- Result: with `Limits{ max_body_bytes: 64 * 1024 }`, a request declaring a 2 MiB body **bypassed the limit entirely** and was answered 200 by the head-only handler. Same hole in epoll (`start_body_drain`), io_uring (`iou_start_body_drain`) and IOCP (`win_start_body_drain`).

The fix rejects from the head's declared Content-Length before the handler runs, mirroring each backend's existing rejection branch: 413 + close (the unread body makes the stream unrecoverable — same reason the framed 413 closes).

**Regression test**: `check_streamed_body_over_max_body_bytes` in the backend behavior matrix (epoll / io_uring / iocp), written as a vtest script (`want: 0` + `then_eof` — completion can only come from the server's own 413+close). Verified to FAIL against the unfixed epoll backend and pass with the fix.

## Zero notices

`v test .` now emits **zero** notices/warnings:

- `limits` in `iou_start_body_drain` — now genuinely used (the fix above).
- `range_num_ceiling` in static_assets — shift computed unsigned: `i64(u64(1) << 40)`.
- 29 example files — unused handler params (`client_fd`, `worker_state`, `event_loop`, …) underscore-prefixed; the `core.Handler` signature is fixed, so examples that don't touch a param now say so explicitly. Rename-only, applied column-precisely from the compiler's own notice list.

## Verification

- `v test .` — 50/50, zero notices, `v fmt -verify` clean.
- A/B on the regression test: fails without the epoll fix (the 200 leaks through), passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)