### PR TITLE
feat: unix domain socket listeners + transport/ dial helpers (issue #122 steps 0 & 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A minimalist, high-performance HTTP server written in [V](https://vlang.io).
 - **Database Friendly**: Example with PostgreSQL connection pool.
 - **Graceful Shutdown**: Drain in-flight requests on `SIGTERM`/`SIGINT` via `srv.shutdown(grace_ms)`.
 - **Multiple Backends**: epoll, io_uring (Linux), kqueue (macOS), IOCP (Windows).
+- **Local IPC**: listen on a unix domain socket (`ServerConfig.unix_socket_path`) instead of TCP — ≈3× lower RTT than TCP loopback, filesystem permissions as access control; dial other local services with `transport.dial_unix`/`dial_tcp`.
 - **One Handler Contract**: a single `handler` signature covers every use case, with every input as an explicit, self-describing parameter — append the response and return `.done`, suspend/resume on any fd (DB sockets, timers, upstream proxies) with `event_loop.watch_fd(...)` + `.suspend`, and reach lock-free per-worker state (e.g. a per-thread DB connection — no shared pool, no mutex) via the `worker_state` parameter.
 - **Compliant with HTTP standards**: Follows [RFC 9112](https://datatracker.ietf.org/doc/rfc9112/) and the [IANA Field Name Registry](https://www.iana.org/assignments/http-fields/http-fields.xhtml). A dedicated [`examples/conformance/`](examples/conformance/) handler is probed in CI by [h1spec](https://github.com/dropseed/h1spec) and [Http11Probe](https://github.com/MDA2AV/Http11Probe) — see [Conformance Testing](#conformance-testing).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ import and says nothing). Protocols are **siblings** over one engine:
 | `http2/` | frame/hpack/types grow in place: stream mux, flow control, settings. |
 | `websocket/` `grpc/` | reserved siblings (RFC 6455 framing; length-prefixed messages over http2). Future protocols land as siblings here. |
 | `static_assets/` `testkit/` `vtest/` `pg_async/` | reusable handler-side and test-side modules. |
-| `transport/` | reserved: client-side dialing (`dial_tcp`, `dial_unix`) — bytes + non-blocking fds ONLY; protocol clients compose it, they don't live in it. |
+| `transport/` | client-side dialing (`dial_tcp`, `dial_unix`) — bytes + non-blocking fds ONLY; protocol clients compose it (handler → `dial_*` → `event_loop.watch_fd` → `.suspend`), they don't live in it. |
 
 ## Dependency rule (grep-enforceable, one direction)
 

--- a/server/server.c.v
+++ b/server/server.c.v
@@ -20,6 +20,10 @@ pub:
 	socket_fd       int
 	limits          Limits
 	tls_config      &tls.Config = unsafe { nil } // nil ⇒ plain HTTP; set ⇒ HTTPS
+	// Non-empty ⇒ the listener is an AF_UNIX stream socket at this filesystem
+	// path (issue #122 §5) and `port` is meaningless. shutdown() uses it for
+	// the io_uring wake poke and to unlink the socket file.
+	unix_socket_path string
 pub mut:
 	threads []thread     = []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
 	handler core.Handler = unsafe { nil }
@@ -72,6 +76,20 @@ pub fn (s Server) shutdown(grace_ms int) {
 	// Tell the io_uring accept handlers to stop re-arming BEFORE the listeners are
 	// shut, so the resulting accept-error completion already observes the flag.
 	stdatomic.store_i64(&s.draining.n, 1)
+	// UDS + io_uring wake poke (issue #122 §5): shutdown(2) on an AF_UNIX
+	// listener produces NO CQE for armed multishot accepts (unlike TCP), so a
+	// parked worker would never observe `draining`. Wake each worker with a
+	// dummy connect BEFORE the listeners are shut (afterwards connect() fails
+	// and still generates no CQE): every armed accept completes with the dummy
+	// connection, whose handler sees the flag and stops re-arming.
+	$if linux {
+		if s.unix_socket_path != '' && s.io_multiplexing == .io_uring {
+			for _ in 0 .. s.inflight.len {
+				fd := socket.connect_to_unix_server(s.unix_socket_path) or { continue }
+				socket.close_socket(fd)
+			}
+		}
+	}
 	if s.listener_fds.len > 0 {
 		for fd in s.listener_fds {
 			if fd >= 0 {
@@ -97,6 +115,14 @@ pub fn (s Server) shutdown(grace_ms int) {
 		time.sleep(time.millisecond)
 		waited++
 	}
+	// The socket file outlives the process unless removed; clean it up so the
+	// path is free for the next run (create_unix_server_socket also unlinks a
+	// stale one defensively).
+	$if !windows {
+		if s.unix_socket_path != '' {
+			socket.unlink_socket_path(s.unix_socket_path)
+		}
+	}
 }
 
 pub struct Certificates {
@@ -110,6 +136,13 @@ pub struct ServerConfig {
 pub:
 	port            int       = 3000
 	io_multiplexing IOBackend = unsafe { IOBackend(0) }
+	// unix_socket_path, when set, makes the server listen on an AF_UNIX stream
+	// socket at this filesystem path INSTEAD of TCP (`port` is then ignored;
+	// max length socket.max_unix_path). Local IPC: ≈3× lower RTT than TCP
+	// loopback, filesystem permissions as access control. Works on the epoll,
+	// io_uring (single shared listener across workers — no SO_REUSEPORT for
+	// UDS) and kqueue backends; not on Windows/IOCP.
+	unix_socket_path string
 	// handler is THE request handler — one contract for every use case, with
 	// every input as an explicit parameter (see core.Handler): it appends the
 	// raw response to `response` and returns .done, parks the request on an fd
@@ -169,15 +202,34 @@ pub fn new_server(config ServerConfig) !Server {
 		}
 	}
 
-	socket_fd := socket.create_server_socket(config.port)
+	if config.unix_socket_path != '' {
+		$if windows {
+			return error('unix_socket_path is not supported on Windows/IOCP')
+		}
+		if config.tls_config != unsafe { nil } {
+			return error('TLS over a unix socket is not supported')
+		}
+	}
+
+	mut socket_fd := 0
+	$if !windows {
+		if config.unix_socket_path != '' {
+			socket_fd = socket.create_unix_server_socket(config.unix_socket_path)!
+		} else {
+			socket_fd = socket.create_server_socket(config.port)
+		}
+	} $else {
+		socket_fd = socket.create_server_socket(config.port)
+	}
 
 	// port: 0 = ephemeral. The kernel picked a free port at bind time; read it back
 	// ONCE so (a) the io_uring per-worker listeners below bind the SAME port and
 	// actually join the SO_REUSEPORT group (each create_server_socket(0) would pick
 	// a DIFFERENT port), and (b) Server.port tells every consumer — tests dialing
-	// back, co-hosted servers, the startup banners — the real port.
+	// back, co-hosted servers, the startup banners — the real port. A UDS
+	// listener has no port; the address is unix_socket_path.
 	mut port := config.port
-	if port == 0 {
+	if port == 0 && config.unix_socket_path == '' {
 		port = socket.local_port(socket_fd)
 		if port <= 0 {
 			return error('could not resolve ephemeral port for listener fd ${socket_fd}')
@@ -215,9 +267,12 @@ pub fn new_server(config ServerConfig) !Server {
 	// so create the rest up front (worker 0 reuses socket_fd): then shutdown() can
 	// stop them ALL, and there is no extra never-accepted listener. epoll and the
 	// other backends accept on the single socket_fd.
+	// For a UDS listener there is no SO_REUSEPORT group: every io_uring worker
+	// arms its accept on the ONE shared listener (the kernel wakes one armed
+	// accept per connection), so listener_fds stays [socket_fd].
 	mut listener_fds := [socket_fd]
 	$if linux {
-		if io_multiplexing == .io_uring {
+		if io_multiplexing == .io_uring && config.unix_socket_path == '' {
 			for _ in 1 .. n_workers {
 				listener_fds << socket.create_server_socket(port)
 			}
@@ -228,6 +283,7 @@ pub fn new_server(config ServerConfig) !Server {
 		port:               port
 		io_multiplexing:    config.io_multiplexing
 		socket_fd:          socket_fd
+		unix_socket_path:   config.unix_socket_path
 		handler:            config.handler
 		make_state:         config.make_state
 		on_worker_start:    config.on_worker_start

--- a/server/server_io_uring_linux.c.v
+++ b/server/server_io_uring_linux.c.v
@@ -677,7 +677,10 @@ pub fn run_io_uring_backend(srv Server, mut threads []thread) {
 		// kernel load-balances accepts across them; none is left un-accepted.
 		// (Listeners aren't ring-bound, so they live on the main thread — only the
 		// ring itself must stay on its worker thread.)
-		listener := srv.listener_fds[i]
+		// UDS has no SO_REUSEPORT group: listener_fds is then just [socket_fd]
+		// and every worker arms its accept on that ONE shared listener (issue
+		// #122 §5) — the modulo collapses to it.
+		listener := srv.listener_fds[i % srv.listener_fds.len]
 		if listener < 0 {
 			eprintln('Failed to create listener for worker ${i}')
 			exit(1)
@@ -686,7 +689,11 @@ pub fn run_io_uring_backend(srv Server, mut threads []thread) {
 			srv.limits, srv.active_conns, srv.inflight[i], srv.draining)
 	}
 
-	println('listening on http://localhost:${srv.port}/ (io_uring)')
+	if srv.unix_socket_path != '' {
+		println('listening on unix:${srv.unix_socket_path} (io_uring)')
+	} else {
+		println('listening on http://localhost:${srv.port}/ (io_uring)')
+	}
 	// Server is accepting (per-worker listeners + rings up); fire the one-shot
 	// lifecycle hook on this (main) thread right before we block.
 	if srv.after_server_start != unsafe { nil } {

--- a/socket/socket_tcp.c.v
+++ b/socket/socket_tcp.c.v
@@ -184,6 +184,11 @@ pub fn peer_addr(fd int) string {
 	if C.getpeername(fd, voidptr(&a), &l) != 0 {
 		return ''
 	}
+	// Family guard: on an AF_UNIX socket the bytes at sin_addr are path data,
+	// not an IPv4 address — there is no peer IP to report.
+	if int(a.sin_family) != C.AF_INET {
+		return ''
+	}
 	mut buf := [46]u8{} // INET6_ADDRSTRLEN
 	if C.inet_ntop(C.AF_INET, voidptr(&a.sin_addr), &char(&buf[0]), 46) == 0 {
 		return ''
@@ -208,6 +213,11 @@ pub fn local_port(fd int) int {
 	mut a := C.sockaddr_in{}
 	mut l := u32(sizeof(a))
 	if C.getsockname(fd, voidptr(&a), &l) != 0 {
+		return -1
+	}
+	// Family guard: an AF_UNIX listener has no port — the bytes at sin_port
+	// would be the first two path characters.
+	if int(a.sin_family) != C.AF_INET {
 		return -1
 	}
 	return int(C.ntohs(a.sin_port))

--- a/socket/socket_unix_nix.c.v
+++ b/socket/socket_unix_nix.c.v
@@ -1,0 +1,93 @@
+module socket
+
+// AF_UNIX stream listeners (docs/ARCHITECTURE.md: the listen side of local
+// IPC, issue #122 §5). The engine treats the returned fd exactly like a TCP
+// listener — accept_client/accept4 are family-agnostic — so the only UDS-
+// specific code in the whole tree is creating, connecting to and unlinking
+// the socket path. `_nix` suffix: every Unix, never Windows.
+
+#include <sys/un.h>
+
+// sun_path is 108 bytes on Linux and 104 on the BSDs/macOS; cap at the
+// smaller one (minus the NUL) so a config that builds on Linux also builds
+// on macOS. This is a comptime capability const with a consumer at birth:
+// create_unix_server_socket/connect_unix below guard against it.
+pub const max_unix_path = 103
+
+// The C compiler lays this out from <sys/un.h>, so the BSD `sun_len` byte on
+// macOS is handled for free (memset leaves it 0, which the kernel ignores);
+// only the fields V touches need declaring.
+struct C.sockaddr_un {
+mut:
+	sun_family u16
+	sun_path   [104]char
+}
+
+fn C.memset(voidptr, int, usize) voidptr
+fn C.memcpy(voidptr, voidptr, usize) voidptr
+fn C.unlink(&char) int
+
+// fill_sockaddr_un zeroes and fills an AF_UNIX address, or errors when the
+// path cannot fit (a filesystem path, not abstract-namespace: no NUL-prefix).
+fn fill_sockaddr_un(path string, mut a C.sockaddr_un) ! {
+	if path.len == 0 {
+		return error('unix socket path is empty')
+	}
+	if path.len > max_unix_path {
+		return error('unix socket path exceeds ${max_unix_path} bytes: ${path}')
+	}
+	C.memset(voidptr(&a), 0, sizeof(C.sockaddr_un))
+	a.sun_family = u16(C.AF_UNIX)
+	C.memcpy(voidptr(&a.sun_path[0]), path.str, usize(path.len))
+}
+
+// unlink_socket_path removes a socket file, ignoring errors (the path may
+// never have existed). Called before bind (stale socket from a previous run
+// would make bind fail with EADDRINUSE) and after shutdown (cleanup).
+pub fn unlink_socket_path(path string) {
+	C.unlink(&char(path.str))
+}
+
+// create_unix_server_socket binds and listens on an AF_UNIX stream socket at
+// `path`, non-blocking, and returns the listener fd. A stale socket file at
+// the path is unlinked first (standard for UDS servers: the file outlives the
+// process). Unlike create_server_socket (TCP, exits on failure at startup),
+// path problems are user config errors — surface them as `!` so new_server
+// can report them.
+pub fn create_unix_server_socket(path string) !int {
+	mut addr := C.sockaddr_un{}
+	fill_sockaddr_un(path, mut addr)!
+	server_fd := C.socket(C.AF_UNIX, C.SOCK_STREAM, 0)
+	if server_fd < 0 {
+		return error('unix socket creation failed')
+	}
+	set_blocking(server_fd, false)
+	unlink_socket_path(path)
+	println('[socket] Binding to unix:${path}')
+	if C.bind(server_fd, voidptr(&addr), sizeof(C.sockaddr_un)) < 0 {
+		close_socket(server_fd)
+		return error('bind failed for unix:${path}')
+	}
+	if C.listen(server_fd, listen_backlog) < 0 {
+		close_socket(server_fd)
+		return error('listen failed for unix:${path}')
+	}
+	return server_fd
+}
+
+// connect_to_unix_server opens a BLOCKING client connection to a UDS listener
+// — the test/shutdown-poke helper, mirroring connect_to_server (TCP). The
+// non-blocking client dial for handlers lives in `transport.dial_unix`.
+pub fn connect_to_unix_server(path string) !int {
+	mut addr := C.sockaddr_un{}
+	fill_sockaddr_un(path, mut addr)!
+	client_fd := C.socket(C.AF_UNIX, C.SOCK_STREAM, 0)
+	if client_fd < 0 {
+		return error('unix socket creation failed')
+	}
+	if C.connect(client_fd, voidptr(&addr), sizeof(C.sockaddr_un)) < 0 {
+		close_socket(client_fd)
+		return error('connect failed for unix:${path}')
+	}
+	return client_fd
+}

--- a/tests/uds_test.v
+++ b/tests/uds_test.v
@@ -1,0 +1,175 @@
+// End-to-end coverage for unix-domain-socket listeners (issue #122 step 0)
+// and the transport/ dial helpers (step 2): serve HTTP/1.1 over
+// `unix_socket_path` on epoll and io_uring (io_uring self-skips where
+// io_uring_setup is sandboxed, e.g. GitHub's hosted runners), assert prompt
+// idle shutdown (the io_uring path exercises the dummy-connect wake poke —
+// shutdown(2) on an AF_UNIX listener yields NO CQE), assert the socket file
+// is unlinked on shutdown, and prove the path is immediately rebindable.
+// Linux-only invocations: the .epoll/.io_uring enum values exist only there.
+import os
+import time
+import server
+import core
+import transport
+
+#include <poll.h>
+
+struct C.pollfd {
+mut:
+	fd      int
+	events  i16
+	revents i16
+}
+
+fn C.poll(fds &C.pollfd, nfds u64, timeout int) int
+fn C.read(fd int, buf voidptr, count usize) int
+fn C.write(fd int, buf voidptr, count usize) int
+
+const uds_req = 'GET / HTTP/1.1\r\nHost: local\r\nConnection: close\r\n\r\n'.bytes()
+const uds_ok = 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok'.bytes()
+
+fn uds_handler(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+	res << uds_ok
+	return .close
+}
+
+// read_until_deadline reads from a (possibly non-blocking) fd until `needle`
+// appears in the accumulated bytes or `timeout_ms` elapses — poll(2)-paced,
+// so a stalled stream fails the assert instead of hanging the test binary.
+fn read_until_deadline(fd int, needle string, timeout_ms int) string {
+	mut acc := []u8{cap: 512}
+	mut buf := [512]u8{}
+	sw := time.new_stopwatch()
+	for sw.elapsed().milliseconds() < timeout_ms {
+		mut pfd := C.pollfd{
+			fd:     fd
+			events: i16(C.POLLIN)
+		}
+		if C.poll(&pfd, 1, 50) <= 0 {
+			continue
+		}
+		n := C.read(fd, voidptr(&buf[0]), usize(512))
+		if n == 0 {
+			break // EOF
+		}
+		if n > 0 {
+			unsafe { acc.push_many(&buf[0], n) }
+			if acc.bytestr().contains(needle) {
+				break
+			}
+		}
+	}
+	return acc.bytestr()
+}
+
+fn uds_socket_path(tag string) string {
+	return os.join_path(os.temp_dir(), 'vanilla_uds_${tag}_${os.getpid()}.sock')
+}
+
+// serve_once_over_uds starts a server on a fresh socket path, drives one
+// request through transport.dial_unix, and returns (server, path) with the
+// server still running so the caller owns the shutdown assertions.
+fn serve_once_over_uds(backend server.IOBackend, tag string) !(server.Server, string) {
+	path := uds_socket_path(tag)
+	ready := chan bool{cap: 1}
+	mut srv := server.new_server(server.ServerConfig{
+		unix_socket_path:   path
+		io_multiplexing:    backend
+		handler:            uds_handler
+		after_server_start: fn [ready] () {
+			ready <- true
+		}
+	})!
+	assert srv.unix_socket_path == path
+	assert srv.listener_fds.len == 1, 'UDS must use ONE shared listener (no SO_REUSEPORT group), got ${srv.listener_fds.len}'
+	spawn fn [mut srv] () {
+		srv.run()
+	}()
+	_ := <-ready
+	fd := transport.dial_unix(path)!
+	defer {
+		transport.close_fd(fd)
+	}
+	assert C.write(fd, voidptr(&uds_req[0]), usize(uds_req.len)) == uds_req.len
+	got := read_until_deadline(fd, 'HTTP/1.1 200', 3000)
+	assert got.starts_with('HTTP/1.1 200'), '${backend}: expected a 200 over unix:${path}, got: ${got}'
+	return srv, path
+}
+
+fn check_uds_serve_shutdown_rebind(backend server.IOBackend) ! {
+	srv, path := serve_once_over_uds(backend, 'a')!
+	// Idle shutdown must return in ~ms (precise drain), not eat the grace: on
+	// io_uring this passes only because the dummy-connect poke wakes workers
+	// parked on an AF_UNIX accept that listener shutdown alone never completes.
+	sw := time.new_stopwatch()
+	srv.shutdown(2000)
+	elapsed := sw.elapsed().milliseconds()
+	assert elapsed < 1500, '${backend}: idle UDS shutdown should be prompt, took ${elapsed}ms'
+	assert !os.exists(path), '${backend}: shutdown must unlink the socket file'
+	// The path must be immediately rebindable — a second server, same path.
+	srv2, path2 := serve_once_over_uds(backend, 'a')!
+	srv2.shutdown(2000)
+	assert !os.exists(path2)
+}
+
+fn test_uds_epoll() {
+	$if linux {
+		check_uds_serve_shutdown_rebind(.epoll) or { assert false, err.msg() }
+	}
+}
+
+fn test_uds_io_uring() {
+	$if linux {
+		if !server.iou_backend_available() {
+			eprintln('io_uring unavailable in this sandbox — skipping')
+			return
+		}
+		check_uds_serve_shutdown_rebind(.io_uring) or { assert false, err.msg() }
+	}
+}
+
+fn test_dial_unix_absent_path_errors() {
+	$if linux {
+		if _ := transport.dial_unix('/nonexistent/vanilla_${os.getpid()}.sock') {
+			assert false, 'dial_unix to an absent path must error'
+		}
+	}
+}
+
+fn test_dial_tcp() {
+	$if linux {
+		ready := chan bool{cap: 1}
+		mut srv := server.new_server(server.ServerConfig{
+			port:               0
+			io_multiplexing:    .epoll
+			handler:            uds_handler
+			after_server_start: fn [ready] () {
+				ready <- true
+			}
+		}) or {
+			assert false, err.msg()
+			return
+		}
+		spawn fn [mut srv] () {
+			srv.run()
+		}()
+		_ := <-ready
+		fd := transport.dial_tcp('127.0.0.1', srv.port) or {
+			assert false, err.msg()
+			return
+		}
+		defer {
+			transport.close_fd(fd)
+		}
+		// Non-blocking connect: wait for writability = connected (loopback).
+		mut pfd := C.pollfd{
+			fd:     fd
+			events: i16(C.POLLOUT)
+		}
+		assert C.poll(&pfd, 1, 2000) == 1, 'dial_tcp connect did not complete'
+		assert C.write(fd, voidptr(&uds_req[0]), usize(uds_req.len)) == uds_req.len
+		got := read_until_deadline(fd, 'HTTP/1.1 200', 3000)
+		assert got.starts_with('HTTP/1.1 200'), 'dial_tcp request failed, got: ${got}'
+		srv.shutdown(2000)
+	}
+}

--- a/transport/transport_nix.c.v
+++ b/transport/transport_nix.c.v
@@ -1,0 +1,128 @@
+module transport
+
+// Client-side dialing (issue #122 step 2): non-blocking connects that hand
+// back a bare fd for the caller to compose with the engine's watch API
+// (`event_loop.watch_fd(fd, .writable, ...)` + `.suspend` — the existing
+// DB/upstream pattern; pg_async is the in-repo precedent).
+//
+// SCOPE GUARD: bytes + non-blocking fds ONLY. The day this module grows its
+// own event loop or an HTTP client, it has become a second framework.
+// Protocol clients (request serializers / response parsers) live inside
+// their protocol module (http1_1/client later), not here.
+//
+// `_nix` suffix: every Unix, never Windows (dial_windows lands with a
+// consumer, per docs/ARCHITECTURE.md).
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <errno.h>
+#include "@VMODROOT/transport/transport_shim.h"
+
+// Deliberately no vanilla imports: transport sits in the same band as
+// socket/ (dependency rule, docs/ARCHITECTURE.md). The shim header typedefs
+// the sockaddr shapes under transport_* names so this module can bind them
+// without redeclaring the same C type name socket/ already declares.
+@[typedef]
+struct C.transport_in_addr {
+	s_addr u32
+}
+
+@[typedef]
+struct C.transport_sockaddr_in {
+mut:
+	sin_family u16
+	sin_port   u16
+	sin_addr   C.transport_in_addr
+}
+
+@[typedef]
+struct C.transport_sockaddr_un {
+mut:
+	sun_family u16
+	sun_path   [104]char
+}
+
+fn C.socket(int, int, int) int
+fn C.connect(int, voidptr, u32) int
+fn C.close(int) int
+fn C.fcntl(int, int, int) int
+fn C.htons(u16) u16
+fn C.inet_pton(int, &char, voidptr) int
+fn C.memset(voidptr, int, usize) voidptr
+fn C.memcpy(voidptr, voidptr, usize) voidptr
+
+// max_unix_path mirrors socket.max_unix_path (104-byte sun_path minus the
+// NUL — the smaller BSD size, so Linux configs stay portable).
+pub const max_unix_path = 103
+
+fn set_nonblocking(fd int) {
+	flags := C.fcntl(fd, C.F_GETFL, 0)
+	if flags != -1 {
+		C.fcntl(fd, C.F_SETFL, flags | C.O_NONBLOCK)
+	}
+}
+
+// dial_tcp starts a NON-BLOCKING IPv4 connect and returns the fd immediately.
+// The connect is usually still in flight (EINPROGRESS): park on the fd with
+// `event_loop.watch_fd(fd, .writable, ...)` + `.suspend`; when it fires, the
+// socket is connected (or carries the error in `ready_fd_error`). Close the
+// fd with C.close when done.
+pub fn dial_tcp(ipv4 string, port int) !int {
+	mut addr := C.transport_sockaddr_in{}
+	C.memset(voidptr(&addr), 0, sizeof(C.transport_sockaddr_in))
+	addr.sin_family = u16(C.AF_INET)
+	addr.sin_port = C.htons(u16(port))
+	if C.inet_pton(C.AF_INET, &char(ipv4.str), voidptr(&addr.sin_addr)) != 1 {
+		return error('dial_tcp: invalid IPv4 address ${ipv4}')
+	}
+	fd := C.socket(C.AF_INET, C.SOCK_STREAM, 0)
+	if fd < 0 {
+		return error('dial_tcp: socket creation failed')
+	}
+	set_nonblocking(fd)
+	if C.connect(fd, voidptr(&addr), sizeof(C.transport_sockaddr_in)) < 0 {
+		if C.errno != C.EINPROGRESS {
+			C.close(fd)
+			return error('dial_tcp: connect to ${ipv4}:${port} failed (errno ${C.errno})')
+		}
+	}
+	return fd
+}
+
+// dial_unix connects NON-BLOCKING to an AF_UNIX stream listener. Unlike TCP
+// (where a SYN queues), a UDS connect on a FULL listen backlog fails
+// immediately with EAGAIN (issue #122 §8) — surfaced as its own message so
+// callers can tell "server overloaded, retry" from "server absent"
+// (ENOENT/ECONNREFUSED). On success the fd is connected right away (local
+// connects don't go through EINPROGRESS).
+pub fn dial_unix(path string) !int {
+	if path.len == 0 || path.len > max_unix_path {
+		return error('dial_unix: invalid socket path (1..${max_unix_path} bytes): ${path}')
+	}
+	mut addr := C.transport_sockaddr_un{}
+	C.memset(voidptr(&addr), 0, sizeof(C.transport_sockaddr_un))
+	addr.sun_family = u16(C.AF_UNIX)
+	C.memcpy(voidptr(&addr.sun_path[0]), path.str, usize(path.len))
+	fd := C.socket(C.AF_UNIX, C.SOCK_STREAM, 0)
+	if fd < 0 {
+		return error('dial_unix: socket creation failed')
+	}
+	set_nonblocking(fd)
+	if C.connect(fd, voidptr(&addr), sizeof(C.transport_sockaddr_un)) < 0 {
+		e := C.errno
+		C.close(fd)
+		if e == C.EAGAIN {
+			return error('dial_unix: listener backlog full at unix:${path} (EAGAIN) — retry')
+		}
+		return error('dial_unix: connect to unix:${path} failed (errno ${e})')
+	}
+	return fd
+}
+
+// close_fd closes a dialed fd — here so callers need no C declarations.
+pub fn close_fd(fd int) {
+	C.close(fd)
+}

--- a/transport/transport_shim.h
+++ b/transport/transport_shim.h
@@ -1,0 +1,16 @@
+// transport_shim.h — module-local typedef aliases for the sockaddr shapes
+// transport/ dials with. The socket/ module already declares V bindings for
+// `struct sockaddr_in`/`sockaddr_un` under their real C names; aliasing here
+// keeps transport/ free of any vanilla import (dependency rule,
+// docs/ARCHITECTURE.md) without redeclaring the same C type name twice.
+#ifndef VANILLA_TRANSPORT_SHIM_H
+#define VANILLA_TRANSPORT_SHIM_H
+
+#include <netinet/in.h>
+#include <sys/un.h>
+
+typedef struct in_addr transport_in_addr;
+typedef struct sockaddr_in transport_sockaddr_in;
+typedef struct sockaddr_un transport_sockaddr_un;
+
+#endif


### PR DESCRIPTION
Implements steps 0 and 2 of the #122 plan of record, as two self-contained commits (each compiles and passes the test suite on its own).

## Step 0 — `feat(server)`: unix domain socket listeners

- **`ServerConfig.unix_socket_path`**: when set, the engine listens on an AF_UNIX stream socket at that filesystem path instead of TCP (`port` is ignored). Local IPC: lower RTT than TCP loopback, filesystem permissions as access control. Supported on epoll, io_uring and kqueue; rejected on Windows/IOCP and in combination with TLS. Path problems surface as `!` config errors, not startup aborts.
- **`socket/socket_unix_nix.c.v`**: `create_unix_server_socket` (stale-socket-file unlink, non-blocking), `connect_to_unix_server` (blocking helper for tests and the shutdown poke), `unlink_socket_path`, `max_unix_path = 103` (the BSD `sun_path` floor; `<sys/un.h>` lays the struct out, so the macOS `sun_len` byte needs no `$if`).
- **io_uring shared listener**: UDS has no SO_REUSEPORT group, so `listener_fds` stays `[socket_fd]` and every worker arms its accept on the ONE shared listener (the facade indexes it modulo).
- **Shutdown wake poke (§5)**: `shutdown(2)` on an AF_UNIX listener produces **no CQE** for armed multishot accepts — unlike TCP — so a parked worker would never observe `draining`. `Server.shutdown()` now dummy-connects once per worker **before** shutting the listeners (afterwards `connect()` fails and still wakes nothing), then unlinks the socket file after the drain.
- **Family guards** in `socket.local_port`/`peer_addr`: on an AF_UNIX fd those `sockaddr_in` fields would read path bytes as a port/address.

## Step 2 — `feat(transport)`: client-side dialing

- **`transport.dial_tcp`**: non-blocking IPv4 connect, `EINPROGRESS` expected — complete it by parking on writability (`event_loop.watch_fd` + `.suspend`, the existing DB/upstream pattern).
- **`transport.dial_unix`**: non-blocking AF_UNIX connect; a **full listen backlog fails immediately with EAGAIN** (unlike TCP's SYN queue — §8), surfaced as a distinct retryable error.
- Scope guard written at the top of the module: **bytes + non-blocking fds only** — protocol clients compose transport, they don't live in it (`http1_1/client` is a separate follow-up). No vanilla imports; a tiny shim header typedefs the sockaddr shapes so the module binds them without redeclaring the C type names `socket/` already declares.
- **`tests/uds_test.v`** e2e: serves HTTP/1.1 over `unix_socket_path` on epoll **and io_uring**, asserts prompt idle shutdown (<1500 ms — on io_uring this passes only because of the step-0 poke), socket-file cleanup on shutdown, immediate rebind of the same path, `dial_unix` error on an absent path, and a `dial_tcp` e2e against an ephemeral TCP listener.

## Verification

- 8/8 test files pass with current V master (module suites + the new e2e).
- io_uring is available in the dev environment (`iou_backend_available() == true`), so the UDS accept/poke/drain paths ran for real rather than self-skipping.
- `v fmt -verify .` clean, dependency-direction check clean, `-os windows` / `-os macos` checker passes clean.

## Out of scope (next steps per #122 sequencing)

Step 3 (conn-mode seam) stays deferred until a second protocol lands; step 4 (`poll/` + `backend_poll`), `http1_1/client`, SO_PEERCRED (§6) and fd passing (§7) are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvjM79KsDdT2Q9Y6SPfGxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvjM79KsDdT2Q9Y6SPfGxm)_