### PR TITLE
feat: poll(2) portability-floor backend behind -d vanilla_poll (issue #122 step 4)

### DIFF
--- a/.github/workflows/poll_backend.yml
+++ b/.github/workflows/poll_backend.yml
@@ -50,13 +50,18 @@ jobs:
           sudo apt-get install -y liburing-dev linux-libc-dev
       # The whole behaviour suite (pipelining, split framing, max_connections,
       # read timeout, large-body drain, half-close, 100-continue, graceful
-      # shutdown) runs against .poll via the $if vanilla_poll ? test fns; the
-      # epoll checks run in the same binary as the control group (io_uring
-      # self-skips on hosted runners — io_uring_setup is sandboxed).
+      # shutdown) runs against .poll via the $if vanilla_poll ? test fns, with
+      # the epoll (and, where rings are available, io_uring) checks as the
+      # in-binary control group. ONE test file on purpose: parallel test
+      # BINARIES each spinning per-worker io_uring rings exhaust the runner's
+      # memlock ("io_uring_queue_init_params failed for all ring entry/flag
+      # combinations" — first run of this job); a single binary runs its
+      # servers sequentially and stays inside the limit. The wider module
+      # matrix already gates in conformance_h1spec.yml without the flag.
       - name: Behaviour suite with the poll reactor
         shell: bash
         run: |
-          v -cc gcc -no-parallel -d vanilla_poll test tests/backend_behaviors_test.v server/
+          v -cc gcc -no-parallel -d vanilla_poll test tests/backend_behaviors_test.v
       # A flag-on example build proves the -d wiring links outside tests too.
       - name: Build an example with -d vanilla_poll
         shell: bash

--- a/.github/workflows/poll_backend.yml
+++ b/.github/workflows/poll_backend.yml
@@ -1,0 +1,64 @@
+name: Poll Backend (portability floor)
+
+# Exercises the pure-POSIX poll(2) reactor (server/backend_poll/, issue #122
+# step 4) on Linux CI: the same behaviour suite the other backends pass, with
+# `-d vanilla_poll` swapping the reactor in. Zero hosted RTOS hardware needed
+# — this is the QNX/VxWorks floor running under a Linux kernel. Normal builds
+# never compile backend_poll (the import lives in a _d_vanilla_poll file), so
+# this job is the only place the flag is on.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'server/**'
+      - 'poll/**'
+      - 'core/**'
+      - 'http1_1/**'
+      - 'socket/**'
+      - 'vtest/**'
+      - 'tests/**'
+      - '.github/workflows/poll_backend.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'server/**'
+      - 'poll/**'
+      - 'core/**'
+      - 'http1_1/**'
+      - 'socket/**'
+      - 'vtest/**'
+      - 'tests/**'
+      - '.github/workflows/poll_backend.yml'
+
+jobs:
+  poll-reactor-tests:
+    runs-on: ubuntu-latest
+    name: behaviour suite under -d vanilla_poll
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up V
+        uses: vlang/setup-v@v1.7
+      - name: Remove Vlang folder to avoid conflicts
+        shell: bash
+        run: |
+          rm -rf -v ./vlang || true
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liburing-dev linux-libc-dev
+      # The whole behaviour suite (pipelining, split framing, max_connections,
+      # read timeout, large-body drain, half-close, 100-continue, graceful
+      # shutdown) runs against .poll via the $if vanilla_poll ? test fns; the
+      # epoll checks run in the same binary as the control group (io_uring
+      # self-skips on hosted runners — io_uring_setup is sandboxed).
+      - name: Behaviour suite with the poll reactor
+        shell: bash
+        run: |
+          v -cc gcc -no-parallel -d vanilla_poll test tests/backend_behaviors_test.v server/
+      # A flag-on example build proves the -d wiring links outside tests too.
+      - name: Build an example with -d vanilla_poll
+        shell: bash
+        run: |
+          v -cc gcc -no-parallel -d vanilla_poll -o /tmp/simple_poll examples/simple/src

--- a/.github/workflows/poll_backend.yml
+++ b/.github/workflows/poll_backend.yml
@@ -51,15 +51,18 @@ jobs:
       # The whole behaviour suite (pipelining, split framing, max_connections,
       # read timeout, large-body drain, half-close, 100-continue, graceful
       # shutdown) runs against .poll via the $if vanilla_poll ? test fns, with
-      # the epoll (and, where rings are available, io_uring) checks as the
-      # in-binary control group. ONE test file on purpose: parallel test
-      # BINARIES each spinning per-worker io_uring rings exhaust the runner's
-      # memlock ("io_uring_queue_init_params failed for all ring entry/flag
-      # combinations" — first run of this job); a single binary runs its
-      # servers sequentially and stays inside the limit. The wider module
-      # matrix already gates in conformance_h1spec.yml without the flag.
+      # the epoll checks as the in-binary control group. VANILLA_NO_IOURING is
+      # the repo's own kill-switch for exactly this host class (see
+      # iou_backend_available): hosted runners cap io_uring so a probe that
+      # passes at time T still sees worker N's ring init fail a moment later
+      # ("io_uring_queue_init_params failed for all ring entry/flag
+      # combinations" — runs 1 and 2 of this job, in both the parallel-binary
+      # and single-binary shapes). io_uring is not this job's subject; its
+      # coverage gates in conformance_h1spec.yml.
       - name: Behaviour suite with the poll reactor
         shell: bash
+        env:
+          VANILLA_NO_IOURING: '1'
         run: |
           v -cc gcc -no-parallel -d vanilla_poll test tests/backend_behaviors_test.v
       # A flag-on example build proves the -d wiring links outside tests too.

--- a/poll/poll_nix.c.v
+++ b/poll/poll_nix.c.v
@@ -1,0 +1,36 @@
+module poll
+
+// Thin wrapper over POSIX poll(2) — the portability floor every Unix (and
+// QNX/VxWorks, later) provides. Mirrors the shape of the other event-wrapper
+// modules (epoll/, kqueue/, iocp/): C bindings + tiny helpers, no policy.
+// The reactor that uses it lives in server/backend_poll/. Per-OS wake
+// primitives (wake_qnx.c.v self-pipe, wake_vxworks.c.v pipe device) land
+// here with their consumers when those ports arrive (issue #122).
+// `_nix` suffix: every Unix, never Windows.
+
+#include "@VMODROOT/poll/poll_shim.h"
+
+@[typedef]
+pub struct C.vanilla_pollfd {
+pub mut:
+	fd      int
+	events  i16
+	revents i16
+}
+
+fn C.poll(fds voidptr, nfds u64, timeout int) int
+
+// Event masks, re-exported as V consts so callers avoid `C.` spelling.
+pub const pollin = i16(C.POLLIN)
+pub const pollout = i16(C.POLLOUT)
+pub const pollerr = i16(C.POLLERR)
+pub const pollhup = i16(C.POLLHUP)
+pub const pollnval = i16(C.POLLNVAL)
+
+// wait blocks until an fd in `fds` is ready or `timeout_ms` elapses
+// (-1 = forever). Returns the number of ready fds, 0 on timeout, <0 on error
+// (EINTR included — callers just loop).
+@[inline]
+pub fn wait(fds &C.vanilla_pollfd, nfds u64, timeout_ms int) int {
+	return C.poll(voidptr(fds), nfds, timeout_ms)
+}

--- a/poll/poll_shim.h
+++ b/poll/poll_shim.h
@@ -1,0 +1,12 @@
+// poll_shim.h — typedef alias so the poll/ module binds struct pollfd under
+// its own name. vtest (and any consumer's test code) may declare `C.pollfd`
+// itself with different field visibility; aliasing sidesteps the collision
+// the same way transport/transport_shim.h does for the sockaddr shapes.
+#ifndef VANILLA_POLL_SHIM_H
+#define VANILLA_POLL_SHIM_H
+
+#include <poll.h>
+
+typedef struct pollfd vanilla_pollfd;
+
+#endif

--- a/server/README.md
+++ b/server/README.md
@@ -27,6 +27,7 @@ per-request allocation.
 | Linux | `.io_uring` | per-worker `SO_REUSEPORT` listener + multishot accept (kernel 5.19+) | `.suspend` watches (oneshot `IORING_OP_POLL_ADD`), `make_state` |
 | macOS | kqueue | per-worker | `.suspend` watches, `make_state` |
 | Windows | IOCP | one central acceptor → round-robins fds to per-worker IOCP ports | `.done`/`.close` only (`.suspend` closes), `make_state`, limits + timeouts |
+| any POSIX | `.poll` *(`-d vanilla_poll`)* | every worker polls the ONE shared listener (no SO_REUSEPORT assumed) | the QNX/VxWorks portability floor (`backend_poll/`): same request semantics, O(nfds), `.done`/`.close` only, never a default |
 
 ## The handler contract
 

--- a/server/backend_poll/reactor_nix.c.v
+++ b/server/backend_poll/reactor_nix.c.v
@@ -1,0 +1,583 @@
+module backend_poll
+
+// Pure-POSIX level-triggered poll(2) reactor — the portability floor for the
+// OSes that have nothing better (QNX before ionotify, VxWorks, any Unix), per
+// issue #122 step 4. On Linux it is compiled only under `-d vanilla_poll`
+// (the import lives in server/run_poll_d_vanilla_poll.c.v), so the whole
+// vtest behaviour suite can exercise this reactor in CI at zero cost to
+// normal builds.
+//
+// DELIBERATELY NOT A DEFAULT: poll(2) is O(nfds) per wake, and every worker
+// polls the ONE shared listener (no SO_REUSEPORT here — the floor cannot
+// assume it), so accept wake-order across workers is kernel-defined (herd
+// skew). Same request semantics as the epoll backend — pipelining, split
+// framing, limits (400/413/431), Expect: 100-continue, streamed large-body
+// drain, half-close, read/write timeouts, graceful shutdown drain — minus
+// the extras: no watch reactor (`.suspend` drops the connection, like
+// Windows/IOCP), no sendfile/queue_buf hand-offs (never enabled, so
+// `core.queue_file` returns false and handlers append bytes instead), no TLS.
+import core
+import socket
+import poll
+import time
+import sync.stdatomic
+import http1_1.request_parser
+import http1_1.response
+
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+
+fn C.recv(__fd int, __buf voidptr, __n usize, __flags int) int
+fn C.send(__fd int, __buf voidptr, __n usize, __flags int) int
+fn C.memmove(__dest voidptr, __src voidptr, __n usize) voidptr
+
+const pl_max_request_bytes = 8 * 1024 * 1024
+const pl_max_pending_write = 8 * 1024 * 1024
+const pl_stream_body_above = 1024 * 1024
+const pl_read_buf_cap = 8 * 1024
+const pl_write_buf_cap = 16 * 1024
+
+// MSG_NOSIGNAL doesn't exist on the BSDs/macOS (SIGPIPE is suppressed per
+// socket via SO_NOSIGPIPE in socket.accept_client instead).
+const msg_nosignal = $if linux { C.MSG_NOSIGNAL } $else { 0 }
+
+// Per-connection state — the poll twin of the epoll backend's ConnState,
+// minus the watch/sendfile fields. Level-triggered poll derives interest from
+// this state each iteration (write pending ⇒ POLLOUT), so there is no
+// explicit park/re-arm step.
+struct PollConn {
+mut:
+	fd                int = -1
+	read_buf          []u8
+	write_buf         []u8
+	write_off         int
+	read_deadline     u64 // monotonic ns; >0 while a request is mid-read
+	write_deadline    u64 // monotonic ns; >0 while a batch is pending
+	body_drain        i64 // >0 while a streamed large body is being discarded
+	close_after_flush bool
+	sent_100          bool
+}
+
+struct WorkerState {
+mut:
+	conns      []&PollConn        // live connections (dense — index is NOT the fd)
+	free_conns []&PollConn        // retired states, buffers kept (same pooling as epoll)
+	pfds       []C.vanilla_pollfd // rebuilt each iteration: [listener?] + conns
+	parked     int                // connections with an armed deadline (gates the sweep)
+	accepting  bool = true
+}
+
+fn (mut w WorkerState) conn_for(fd int) &PollConn {
+	mut cs := if w.free_conns.len > 0 {
+		w.free_conns.pop()
+	} else {
+		&PollConn{
+			read_buf:  []u8{len: 0, cap: pl_read_buf_cap}
+			write_buf: []u8{len: 0, cap: pl_write_buf_cap}
+		}
+	}
+	cs.fd = fd
+	w.conns << cs
+	return cs
+}
+
+// close_conn_at closes w.conns[i] and recycles its state (swap-remove keeps
+// the table dense; iteration order is per-worker private, so it may change).
+fn (mut w WorkerState) close_conn_at(i int, active_conns &core.Counter) {
+	mut cs := w.conns[i]
+	if cs.read_deadline != 0 {
+		w.parked--
+	}
+	if cs.write_deadline != 0 {
+		w.parked--
+	}
+	socket.close_socket(cs.fd)
+	stdatomic.add_i64(&active_conns.n, -1)
+	unsafe {
+		cs.read_buf.len = 0
+		cs.write_buf.len = 0
+	}
+	cs.fd = -1
+	cs.write_off = 0
+	cs.read_deadline = 0
+	cs.write_deadline = 0
+	cs.body_drain = 0
+	cs.close_after_flush = false
+	cs.sent_100 = false
+	w.conns.delete(i)
+	w.free_conns << cs
+}
+
+// buf_view — the same non-owning window as the epoll backend's (see the
+// rationale in server/backend_epoll/conn_state_linux.c.v).
+@[inline]
+fn buf_view(buf []u8, start int, length int) []u8 {
+	mut v := unsafe { buf }
+	unsafe {
+		v.data = &u8(buf.data) + start
+		v.len = length
+		v.cap = length
+		v.flags.clear(.managed)
+	}
+	return v
+}
+
+@[direct_array_access; inline]
+fn compact_read_buf(mut cs PollConn, pos int) {
+	if pos <= 0 {
+		return
+	}
+	leftover := cs.read_buf.len - pos
+	if leftover > 0 {
+		unsafe { C.memmove(cs.read_buf.data, &u8(cs.read_buf.data) + pos, usize(leftover)) }
+	}
+	unsafe {
+		cs.read_buf.len = leftover
+	}
+}
+
+// flush_pending sends buffered response bytes. Returns:
+//   1  fully drained
+//   0  partial — POLLOUT will resume it (write deadline armed once)
+//  -1  hard error — caller must close
+fn flush_pending(mut w WorkerState, mut cs PollConn, limits core.Limits) int {
+	for cs.write_off < cs.write_buf.len {
+		n := C.send(cs.fd, unsafe { &u8(cs.write_buf.data) + cs.write_off },
+			usize(cs.write_buf.len - cs.write_off), msg_nosignal)
+		if n > 0 {
+			cs.write_off += n
+			continue
+		}
+		if n < 0 && (C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK) {
+			if limits.write_timeout_ms > 0 && cs.write_deadline == 0 {
+				cs.write_deadline = time.sys_mono_now() + u64(limits.write_timeout_ms) * 1_000_000
+				w.parked++
+			}
+			return 0
+		}
+		return -1
+	}
+	cs.write_buf.clear()
+	cs.write_off = 0
+	if cs.write_deadline != 0 {
+		cs.write_deadline = 0
+		w.parked--
+	}
+	return 1
+}
+
+// update_read_deadline — armed once while a request is mid-read (partial
+// bytes buffered or a body mid-drain), cleared when idle. Same total-time
+// semantics as every other backend.
+@[inline]
+fn update_read_deadline(limits core.Limits, mut w WorkerState, mut cs PollConn) {
+	if cs.read_buf.len > 0 || cs.body_drain > 0 {
+		if limits.read_timeout_ms > 0 && cs.read_deadline == 0 {
+			cs.read_deadline = time.sys_mono_now() + u64(limits.read_timeout_ms) * 1_000_000
+			w.parked++
+		}
+	} else if cs.read_deadline != 0 {
+		cs.read_deadline = 0
+		w.parked--
+	}
+}
+
+// drain_requests answers every complete buffered request into write_buf.
+// Mirrors the epoll drain minus the watch runtime: `.suspend` cannot park
+// (no reactor on the portability floor), so it drops the connection — the
+// Windows/IOCP precedent. Returns false if the connection must close NOW
+// (framing error / .close / flood); the caller closes it after flushing.
+@[direct_array_access]
+fn drain_requests(h core.Handler, mut w WorkerState, mut cs PollConn, limits core.Limits, state voidptr) bool {
+	mut pos := 0
+	mut event_loop := core.EventLoop{
+		client_fd: cs.fd
+		register:  core.reject_register
+	}
+	mut alive := true
+	for pos < cs.read_buf.len {
+		total := request_parser.frame_request_length_lim_idx(buf_view(cs.read_buf, pos,
+			cs.read_buf.len - pos), limits.max_header_bytes, limits.max_body_bytes)
+		if total == -1 {
+			break // incomplete — wait for more bytes
+		}
+		if total < -1 {
+			match -total {
+				413 { cs.write_buf << response.status_413_response }
+				431 { cs.write_buf << response.status_431_response }
+				else { cs.write_buf << response.tiny_bad_request_response }
+			}
+
+			alive = false
+			pos = cs.read_buf.len // closing; discard the rest of the burst
+			break
+		}
+		req := buf_view(cs.read_buf, pos, total)
+		step := h(req, mut cs.write_buf, cs.fd, state, mut event_loop)
+		pos += total
+		match step {
+			.done {}
+			.suspend {
+				eprintln('[poll] handler returned .suspend but the poll backend has no watch reactor; dropping the connection')
+				alive = false
+			}
+			.close {
+				alive = false
+			}
+		}
+
+		if !alive {
+			break
+		}
+		if cs.write_buf.len - cs.write_off > pl_max_pending_write {
+			alive = false // peer pipelines without reading responses
+			break
+		}
+	}
+	compact_read_buf(mut cs, pos)
+	return alive
+}
+
+// start_body_drain — the streamed large-body path (drain-then-respond),
+// mirroring the epoll backend: answer from the complete HEAD, hold the
+// response, discard the body as it arrives. Returns 1 drained/started,
+// 2 must-close, 0 head incomplete (grow + recv more).
+fn start_body_drain(h core.Handler, mut cs PollConn, limits core.Limits, state voidptr, total int) int {
+	head_len := request_parser.frame_head_len(cs.read_buf)
+	if head_len <= 0 || head_len > cs.read_buf.len {
+		return 0
+	}
+	content_length := total - head_len
+	if limits.max_body_bytes > 0 && content_length > limits.max_body_bytes {
+		cs.write_buf << response.status_413_response
+		return 2
+	}
+	head := buf_view(cs.read_buf, 0, head_len)
+	mut event_loop := core.EventLoop{
+		client_fd: cs.fd
+		register:  core.reject_register
+	}
+	if h(head, mut cs.write_buf, cs.fd, state, mut event_loop) != .done {
+		cs.write_buf << response.tiny_bad_request_response
+		return 2
+	}
+	body_in_buf := cs.read_buf.len - head_len
+	cs.body_drain = i64(content_length) - i64(body_in_buf)
+	if cs.body_drain < 0 {
+		cs.body_drain = 0
+	}
+	unsafe {
+		cs.read_buf.len = 0
+	}
+	return 1
+}
+
+// serve_readable drains the socket, answers complete requests (pipelining),
+// and leaves any response bytes pending (the caller flushes). Returns false
+// if the connection was closed.
+@[direct_array_access]
+fn serve_readable(h core.Handler, mut w WorkerState, i int, limits core.Limits, counter &core.Counter, active_conns &core.Counter, state voidptr) bool {
+	stdatomic.add_i64(&counter.n, 1)
+	defer {
+		stdatomic.add_i64(&counter.n, -1)
+	}
+	mut cs := w.conns[i]
+	req_cap := if limits.max_request_bytes > 0 {
+		limits.max_request_bytes
+	} else {
+		pl_max_request_bytes
+	}
+	mut must_close := false
+	for {
+		// Streamed large body: consume + discard (head already answered).
+		if cs.body_drain > 0 {
+			want := if cs.body_drain < i64(cs.read_buf.cap) {
+				int(cs.body_drain)
+			} else {
+				cs.read_buf.cap
+			}
+			dn := C.recv(cs.fd, cs.read_buf.data, usize(want), 0)
+			if dn < 0 {
+				if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
+					break
+				}
+				w.close_conn_at(i, active_conns)
+				return false
+			}
+			if dn == 0 {
+				w.close_conn_at(i, active_conns)
+				return false
+			}
+			cs.body_drain -= dn
+			continue
+		}
+		if cs.read_buf.len == cs.read_buf.cap {
+			target := request_parser.frame_expected_total(cs.read_buf)
+			if target > pl_stream_body_above && target <= req_cap {
+				match start_body_drain(h, mut cs, limits, state, target) {
+					1 { continue } // draining started; keep consuming the body
+					2 { must_close = true }
+					else {} // head incomplete — fall through to grow
+				}
+
+				if must_close {
+					break
+				}
+			}
+			if target > cs.read_buf.cap && target <= req_cap {
+				unsafe { cs.read_buf.grow_cap(target - cs.read_buf.cap) }
+			} else {
+				unsafe { cs.read_buf.grow_cap(cs.read_buf.cap) }
+			}
+		}
+		spare := cs.read_buf.cap - cs.read_buf.len
+		n := C.recv(cs.fd, unsafe { &u8(cs.read_buf.data) + cs.read_buf.len }, usize(spare), 0)
+		if n < 0 {
+			if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
+				break
+			}
+			w.close_conn_at(i, active_conns)
+			return false
+		}
+		if n == 0 {
+			// Half-close (EOF). A pending response is still owed on the open write
+			// half (RFC 9112 §9.6); with nothing pending, close now.
+			if cs.body_drain == 0 && cs.write_buf.len > cs.write_off {
+				cs.close_after_flush = true
+				break
+			}
+			w.close_conn_at(i, active_conns)
+			return false
+		}
+		unsafe {
+			cs.read_buf.len += n
+		}
+		if !drain_requests(h, mut w, mut cs, limits, state) {
+			must_close = true
+			break
+		}
+		if cs.read_buf.len > req_cap {
+			cs.write_buf << response.status_413_response
+			must_close = true
+			break
+		}
+		// Expect: 100-continue — prompt exactly once per mid-read request.
+		if cs.read_buf.len == 0 {
+			if cs.sent_100 {
+				cs.sent_100 = false
+			}
+		} else if !cs.sent_100 && cs.body_drain == 0 {
+			head_len := request_parser.frame_head_len(cs.read_buf)
+			if head_len > 0 && request_parser.head_expects_100_continue(cs.read_buf, head_len) {
+				cs.write_buf << response.status_100_continue_response
+				cs.sent_100 = true
+			}
+		}
+	}
+	update_read_deadline(limits, mut w, mut cs)
+	// End-of-burst flush — held while a streamed body is still draining.
+	if cs.body_drain == 0 && cs.write_buf.len > cs.write_off {
+		match flush_pending(mut w, mut cs, limits) {
+			-1 {
+				w.close_conn_at(i, active_conns)
+				return false
+			}
+			0 {
+				// Parked on POLLOUT. A must-close (framing error / .close) or
+				// half-closed connection finishes closing once the batch drains.
+				if must_close {
+					cs.close_after_flush = true
+				}
+				return true
+			}
+			else {}
+		}
+	}
+	if must_close || cs.close_after_flush {
+		w.close_conn_at(i, active_conns)
+		return false
+	}
+	return true
+}
+
+// handle_writable resumes a parked batch. Returns false if the connection
+// was closed.
+@[direct_array_access]
+fn handle_writable(mut w WorkerState, i int, limits core.Limits, active_conns &core.Counter) bool {
+	mut cs := w.conns[i]
+	if cs.body_drain > 0 {
+		// Drain-then-respond gate: never emit a held head-response mid-body.
+		return true
+	}
+	match flush_pending(mut w, mut cs, limits) {
+		-1 {
+			w.close_conn_at(i, active_conns)
+			return false
+		}
+		0 {
+			return true // still parked
+		}
+		else {}
+	}
+
+	if cs.close_after_flush {
+		w.close_conn_at(i, active_conns)
+		return false
+	}
+	return true
+}
+
+@[direct_array_access]
+fn sweep_timeouts(mut w WorkerState, active_conns &core.Counter) {
+	now := time.sys_mono_now()
+	mut i := 0
+	for i < w.conns.len {
+		cs := w.conns[i]
+		if cs.read_deadline > 0 && now > cs.read_deadline {
+			response.send_status_408_response(cs.fd)
+			w.close_conn_at(i, active_conns)
+			continue // swap-remove: re-check index i
+		}
+		if cs.write_deadline > 0 && now > cs.write_deadline {
+			w.close_conn_at(i, active_conns)
+			continue
+		}
+		i++
+	}
+}
+
+// poll_worker is one shared-nothing worker loop: every worker polls the ONE
+// shared listener plus its own accepted connections, level-triggered.
+@[direct_array_access]
+fn poll_worker(listener int, handler core.Handler, make_state fn () voidptr, limits core.Limits, counter &core.Counter, active_conns &core.Counter) {
+	mut state := voidptr(unsafe { nil })
+	if make_state != unsafe { nil } {
+		state = make_state()
+	}
+	mut w := WorkerState{}
+	sweep_on := limits.read_timeout_ms > 0 || limits.write_timeout_ms > 0
+	for {
+		// Rebuild the pollfd set from connection state — O(nfds), the floor's
+		// documented cost (poll(2) itself is O(nfds) anyway). Interest derives
+		// from state: write pending ⇒ POLLOUT, everything ⇒ POLLIN.
+		w.pfds.clear()
+		if w.accepting {
+			w.pfds << C.vanilla_pollfd{
+				fd:     listener
+				events: poll.pollin
+			}
+		}
+		for cs in w.conns {
+			mut ev := poll.pollin
+			if cs.write_off < cs.write_buf.len && cs.body_drain == 0 {
+				ev |= poll.pollout
+			}
+			w.pfds << C.vanilla_pollfd{
+				fd:     cs.fd
+				events: ev
+			}
+		}
+		if w.pfds.len == 0 {
+			// Listener gone (shutdown) and no live connections: this worker is
+			// done — exiting beats spinning on an empty poll set.
+			return
+		}
+		wait_ms := if sweep_on && w.parked > 0 { 250 } else { -1 }
+		num := poll.wait(&w.pfds[0], u64(w.pfds.len), wait_ms)
+		if num < 0 {
+			if C.errno == C.EINTR {
+				continue
+			}
+			C.perror(c'poll')
+			return
+		}
+		mut idx := 0
+		if w.accepting {
+			rl := w.pfds[0].revents
+			if rl & (poll.pollnval | poll.pollhup | poll.pollerr) != 0 {
+				// Server.shutdown() closed the shared listener — poll flags the
+				// dead fd on EVERY worker (the portability floor's wake: no CQE
+				// or edge semantics needed). Stop accepting; drain what's live.
+				w.accepting = false
+			} else if rl & poll.pollin != 0 {
+				// EAGAIN-tolerant accept burst: every worker may wake for the
+				// same connection (shared listener, herd) — whoever accepts
+				// first wins, the rest see EAGAIN and move on.
+				for {
+					client_fd := socket.accept_client(listener)
+					if client_fd < 0 {
+						break // EAGAIN/EWOULDBLOCK or a racing worker won
+					}
+					if limits.max_connections > 0
+						&& stdatomic.load_i64(&active_conns.n) >= i64(limits.max_connections) {
+						socket.close_socket(client_fd)
+						continue
+					}
+					socket.set_tcp_nodelay(client_fd)
+					w.conn_for(client_fd)
+					stdatomic.add_i64(&active_conns.n, 1)
+				}
+			}
+			idx = 1
+		}
+		// Serve connections. close_conn_at swap-removes from w.conns, so walk
+		// the SNAPSHOT in w.pfds and re-locate each fd (O(n) per event — the
+		// floor trades this for zero bookkeeping; conns is dense and small).
+		for pi in idx .. w.pfds.len {
+			rev := w.pfds[pi].revents
+			if rev == 0 {
+				continue
+			}
+			fd := w.pfds[pi].fd
+			mut ci := -1
+			for j, cs in w.conns {
+				if cs.fd == fd {
+					ci = j
+					break
+				}
+			}
+			if ci < 0 {
+				continue // closed earlier in this batch
+			}
+			if rev & (poll.pollnval | poll.pollerr) != 0 {
+				w.close_conn_at(ci, active_conns)
+				continue
+			}
+			if rev & poll.pollout != 0 {
+				if !handle_writable(mut w, ci, limits, active_conns) {
+					continue
+				}
+			}
+			// POLLHUP with readable data still pending must be drained (the
+			// half-close path in serve_readable handles the EOF); a bare HUP
+			// closes there via recv == 0.
+			if rev & (poll.pollin | poll.pollhup) != 0 {
+				serve_readable(handler, mut w, ci, limits, counter, active_conns, state)
+			}
+		}
+		if sweep_on && w.parked > 0 {
+			sweep_timeouts(mut w, active_conns)
+		}
+	}
+}
+
+// run_poll_backend spawns the workers (all sharing the one listener) and
+// fires after_server_start, mirroring the other backends' facades.
+pub fn run_poll_backend(socket_fd int, handler core.Handler, make_state fn () voidptr, after_server_start core.AfterStartFn, limits core.Limits, inflight []&core.Counter, active_conns &core.Counter, mut threads []thread) {
+	if socket_fd < 0 {
+		eprintln('[poll] invalid listener fd')
+		return
+	}
+	for i in 0 .. threads.len {
+		threads[i] = spawn poll_worker(socket_fd, handler, make_state, limits, inflight[i],
+			active_conns)
+	}
+	println('listening (poll backend, portability floor — O(nfds), not a throughput default)')
+	if after_server_start != unsafe { nil } {
+		after_server_start()
+	}
+	for {
+		time.sleep(time.second)
+	}
+}

--- a/server/backend_poll/reactor_nix.c.v
+++ b/server/backend_poll/reactor_nix.c.v
@@ -189,7 +189,7 @@ fn update_read_deadline(limits core.Limits, mut w WorkerState, mut cs PollConn) 
 // Windows/IOCP precedent. Returns false if the connection must close NOW
 // (framing error / .close / flood); the caller closes it after flushing.
 @[direct_array_access]
-fn drain_requests(h core.Handler, mut w WorkerState, mut cs PollConn, limits core.Limits, state voidptr) bool {
+fn drain_requests(h core.Handler, mut cs PollConn, limits core.Limits, state voidptr) bool {
 	mut pos := 0
 	mut event_loop := core.EventLoop{
 		client_fd: cs.fd
@@ -353,7 +353,7 @@ fn serve_readable(h core.Handler, mut w WorkerState, i int, limits core.Limits, 
 		unsafe {
 			cs.read_buf.len += n
 		}
-		if !drain_requests(h, mut w, mut cs, limits, state) {
+		if !drain_requests(h, mut cs, limits, state) {
 			must_close = true
 			break
 		}

--- a/server/run_poll_d_vanilla_poll.c.v
+++ b/server/run_poll_d_vanilla_poll.c.v
@@ -1,0 +1,13 @@
+module server
+
+// The ONLY file that imports backend_poll on Linux (issue #122 step 4).
+// Imports cannot be conditional in V, so without this flag-suffix split the
+// portability reactor would be compiled into every Linux build; with it, a
+// plain build never sees backend_poll, and `-d vanilla_poll` swaps this in
+// for the notd stub — the same mechanism as the tls _d_vanilla_tls pair.
+import server.backend_poll
+
+fn run_poll_backend_impl(srv Server, mut threads []thread) {
+	backend_poll.run_poll_backend(srv.socket_fd, srv.handler, srv.make_state,
+		srv.after_server_start, srv.limits, srv.inflight, srv.active_conns, mut threads)
+}

--- a/server/run_poll_notd_vanilla_poll.c.v
+++ b/server/run_poll_notd_vanilla_poll.c.v
@@ -1,0 +1,9 @@
+module server
+
+// notd twin of run_poll_d_vanilla_poll.c.v: keeps the `.poll` match arm
+// linkable in builds without `-d vanilla_poll`. Unreachable in practice —
+// new_server rejects `.poll` at config time when the flag is off.
+fn run_poll_backend_impl(srv Server, mut threads []thread) {
+	eprintln('the poll backend requires building with `-d vanilla_poll`')
+	exit(1)
+}

--- a/server/server.c.v
+++ b/server/server.c.v
@@ -246,8 +246,20 @@ pub fn new_server(config ServerConfig) !Server {
 			return error('TLS is not yet supported on the Windows/IOCP backend')
 		}
 	} $else $if linux {
-		if io_multiplexing != .epoll && io_multiplexing != .io_uring {
-			return error('Linux only supports epoll and io_uring backends')
+		$if vanilla_poll ? {
+			if io_multiplexing !in [.epoll, .io_uring, .poll] {
+				return error('Linux only supports the epoll, io_uring and poll backends')
+			}
+			if io_multiplexing == .poll && config.tls_config != unsafe { nil } {
+				return error('TLS is not supported on the poll backend')
+			}
+		} $else {
+			if io_multiplexing == .poll {
+				return error('the poll backend requires building with `-d vanilla_poll`')
+			}
+			if io_multiplexing != .epoll && io_multiplexing != .io_uring {
+				return error('Linux only supports epoll and io_uring backends')
+			}
 		}
 	} $else $if darwin {
 		if io_multiplexing != .kqueue {

--- a/server/server_linux.c.v
+++ b/server/server_linux.c.v
@@ -6,6 +6,10 @@ import server.backend_epoll
 pub enum IOBackend {
 	epoll    = 0 // Linux only
 	io_uring = 1 // Linux only
+	// The pure-POSIX poll(2) portability floor (QNX/VxWorks tier). Compiled
+	// on Linux ONLY under `-d vanilla_poll` (new_server rejects it otherwise)
+	// so CI can exercise the RTOS reactor at zero cost to normal builds.
+	poll = 2
 }
 
 // run_selected_backend dispatches to the configured Linux backend. Defined per
@@ -20,6 +24,12 @@ fn run_selected_backend(srv Server, mut threads []thread) {
 		}
 		.io_uring {
 			run_io_uring_backend(srv, mut threads)
+		}
+		.poll {
+			// Implemented in run_poll_d_vanilla_poll.c.v; the notd twin stub
+			// keeps this arm linkable when the flag is off (new_server already
+			// rejected the config by then).
+			run_poll_backend_impl(srv, mut threads)
 		}
 	}
 }

--- a/tests/backend_behaviors_test.v
+++ b/tests/backend_behaviors_test.v
@@ -615,3 +615,72 @@ fn test_epoll_expect_100_continue() ! {
 		check_expect_100_continue(.epoll)!
 	}
 }
+
+// --- poll backend (the pure-POSIX portability floor, issue #122 step 4) ---
+// Compiled only under `-d vanilla_poll`, so the SAME behaviour suite
+// exercises the RTOS reactor on Linux CI at zero cost to normal builds
+// (without the flag these are empty no-ops).
+
+fn test_poll_large_upload_drain() ! {
+	$if linux {
+		$if vanilla_poll ? {
+			check_large_upload_drain(.poll)!
+		}
+	}
+}
+
+fn test_poll_streamed_body_over_max_body_bytes() ! {
+	$if linux {
+		$if vanilla_poll ? {
+			check_streamed_body_over_max_body_bytes(.poll)!
+		}
+	}
+}
+
+fn test_poll_pipelining_and_framing() ! {
+	$if linux {
+		$if vanilla_poll ? {
+			check_pipelining_and_framing(.poll)!
+		}
+	}
+}
+
+fn test_poll_max_connections() ! {
+	$if linux {
+		$if vanilla_poll ? {
+			check_max_connections(.poll)!
+		}
+	}
+}
+
+fn test_poll_read_timeout() ! {
+	$if linux {
+		$if vanilla_poll ? {
+			check_read_timeout(.poll)!
+		}
+	}
+}
+
+fn test_poll_graceful_shutdown() ! {
+	$if linux {
+		$if vanilla_poll ? {
+			check_graceful_shutdown(.poll)!
+		}
+	}
+}
+
+fn test_poll_half_close_after_request() ! {
+	$if linux {
+		$if vanilla_poll ? {
+			check_half_close_after_request(.poll)!
+		}
+	}
+}
+
+fn test_poll_expect_100_continue() ! {
+	$if linux {
+		$if vanilla_poll ? {
+			check_expect_100_continue(.poll)!
+		}
+	}
+}


### PR DESCRIPTION
Implements step 4 of the #122 plan of record: the pure-POSIX `poll(2)` reactor that QNX/VxWorks will inherit, exercised by the existing behaviour suite on Linux CI — zero hosted RTOS hardware, zero cost to normal builds.

## What's in

- **`poll/`** — thin `poll(2)` wrapper module, the sibling of `epoll/`/`kqueue/`/`iocp/`. The pollfd binding is typedef-aliased (`vanilla_pollfd`) so consumers' own `C.pollfd` declarations (vtest, test files) never collide, and `C.poll` takes `voidptr` for the same reason. Per-OS wake primitives (`wake_qnx.c.v`, …) land here with their consumers when those ports arrive.
- **`server/backend_poll/`** — level-triggered shared-listener reactor:
  - every worker polls the **one** shared listener — the floor cannot assume `SO_REUSEPORT`; EAGAIN-tolerant accept, herd wake-order skew documented, **O(nfds)** per wake, deliberately **never a default**;
  - same request semantics as the epoll backend: pipelining, split framing, 400/413/431 limits, `Expect: 100-continue`, streamed large-body drain-then-respond, half-close (RFC 9112 §9.6), read/write timeouts, graceful shutdown — a closed listener flags `POLLNVAL` on every worker, so the floor's shutdown wake needs no edge/CQE semantics (contrast with the io_uring UDS poke from #125);
  - deliberately absent: watch reactor (`.suspend` drops the connection — the Windows/IOCP precedent), sendfile/queue_buf hand-offs (capability never enabled, handlers append bytes), TLS (rejected at config time).
- **Flag isolation** — `IOBackend.poll` (Linux enum) dispatches through the `run_poll_d_vanilla_poll.c.v` / `_notd_` stub pair, the **only** import of `backend_poll`, so a plain build never compiles the reactor (same mechanism as the tls `-d vanilla_tls` split); `new_server` rejects `.poll` without the flag.
- **Tests** — `tests/backend_behaviors_test.v` gains `$if vanilla_poll ?` invocations, so the **same 8 behaviour checks** that gate epoll/io_uring/iocp run against `.poll`; new `poll_backend.yml` workflow runs the suite with `-d vanilla_poll` on every PR touching the engine.

## Verification

- All 8 poll behaviour checks pass locally with current V master (pipelining, split framing, max_connections, read timeout, 2 MiB upload drain, streamed-body-over-limit, half-close, 100-continue, graceful shutdown); epoll control group green in the same binary.
- One io_uring flake observed in the dev sandbox reproduces **with the poll tests filtered out** (hung once/passed once across two control runs) — pre-existing multi-ring contention in this environment, untouched by this diff; io_uring self-skips on hosted runners regardless.
- No-flag builds bit-identical in behavior: module tests + UDS e2e pass; `v fmt -verify`, dependency-direction check, `-os windows`/`-os macos` checks all clean.

## Next per #122 sequencing

QNX facade (`server_qnx.c.v` + `caps_qnx.c.v` + `poll/wake_qnx.c.v` over this reactor, step 5), VxWorks after the upstream V OS-ident patch (step 6), `http1_1/client` + the examples mesh demo (Client story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvjM79KsDdT2Q9Y6SPfGxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvjM79KsDdT2Q9Y6SPfGxm)_