### PR TITLE
Refactor tests and examples onto the issue #122 features

### DIFF
--- a/.github/workflows/build_test_examples_on_linux.yml
+++ b/.github/workflows/build_test_examples_on_linux.yml
@@ -20,9 +20,12 @@ jobs:
           - examples/conformance/src
           - examples/database/src
           - examples/etag/src
+          - examples/graceful_shutdown/src
           - examples/hexagonal/src
           - examples/io_uring_demo/src
+          - examples/mesh/src
           - examples/per_server_workers/src
+          - examples/request_limits/src
           - examples/simple/src
           - examples/simple2/src
           - examples/sse/src
@@ -71,3 +74,31 @@ jobs:
         shell: bash
         run: |
           v -cc gcc -no-parallel test $(pwd)/${{ matrix.folder }}
+
+  # The repo-root e2e suites (tests/): backend behaviours, UDS listeners +
+  # transport dials + peer_cred, vtest smoke. io_uring self-skips where
+  # io_uring_setup is sandboxed; VANILLA_NO_IOURING is the repo's kill-switch
+  # for hosted runners whose per-worker ring init fails after a passing probe
+  # (see poll_backend.yml for the full story).
+  repo-tests:
+    runs-on: ubuntu-latest
+    name: tests/ (behaviours, UDS, vtest)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up V
+        uses: vlang/setup-v@v1.7
+      - name: Remove Vlang folder to avoid conflicts
+        shell: bash
+        run: |
+          rm -rf -v ./vlang || true
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liburing-dev linux-libc-dev
+      - name: Run tests/
+        shell: bash
+        env:
+          VANILLA_NO_IOURING: '1'
+        run: |
+          v -cc gcc -no-parallel test tests/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimalist, high-performance HTTP server written in [V](https://vlang.io).
 - **Modular**: Easy to extend with custom controllers and handlers.
 - **Memory Safety**: No race conditions.
 - **No Magic**: Transparent and straightforward.
-- **E2E Testing**: Test handlers in-process by passing raw requests directly to `handle_request()`, or drive a running server over a real socket with `net.dial_tcp` and a read deadline (see [`tests/backend_behaviors_test.v`](tests/backend_behaviors_test.v)).
+- **E2E Testing**: Test handlers in-process by passing raw requests directly to `handle_request()`, or drive a running server — TCP or unix socket — with the `vtest` scripted client (raw fds via `transport.dial_tcp`/`dial_unix`; see [`tests/backend_behaviors_test.v`](tests/backend_behaviors_test.v)).
 - **SSE Friendly**: Built-in Server-Sent Events support (sync and async).
 - **ETag Friendly**: Conditional GETs with `ETag` and `If-None-Match` headers.
 - **Database Friendly**: Example with PostgreSQL connection pool.
@@ -72,9 +72,10 @@ fn test_handle_request() {
 }
 ```
 
-Or drive a running server over a real client socket — spawn `srv.run()` on a
-thread, then send raw requests with `net.dial_tcp` and read the responses under a
-deadline. This exercises the full framing / keep-alive / suspend-resume path and
+Or drive a running server over a real client socket — the `vtest` module owns
+the whole lifecycle (ephemeral bind or unix socket, readiness, shutdown) and
+dials raw non-blocking fds through `transport`, with scripts as data. This
+exercises the full framing / keep-alive / suspend-resume path and
 never hangs on a stalled stream. See
 [`tests/backend_behaviors_test.v`](tests/backend_behaviors_test.v)
 for the pattern (pipelining, framing across TCP segments, timeouts, graceful
@@ -239,9 +240,11 @@ Two layers, no bespoke test mode on the server:
 - **In-process** — call the handler directly (`handle_request(req, mut out, ...)`)
   and assert on the bytes it appends. Deterministic, no sockets, no threads; ideal
   for routing and response-shape assertions.
-- **Over a real socket** — spawn `srv.run()` on a thread, connect with
-  `net.dial_tcp`, and read responses under a per-read deadline (so a broken stream
-  fails fast instead of hanging). This drives the real backend end to end —
+- **Over a real socket** — drive the server with `vtest` (scripts as data,
+  lifecycle owned by the harness) or dial raw fds yourself with
+  `transport.dial_tcp`/`dial_unix` + `testkit`'s deadline-bounded `fd_*`
+  readers (so a broken stream fails fast instead of hanging). Either way this
+  drives the real backend end to end —
   epoll / io_uring / kqueue — including pipelining, request framing across TCP
   segments, keep-alive, `Expect: 100-continue`, half-close, read timeouts, and the
   async suspend/resume path. See

--- a/docs/VTEST.md
+++ b/docs/VTEST.md
@@ -103,9 +103,18 @@ pub fn repeat(n int, s Script) []Script
   the first connect happens at the readiness instant (listeners are bound+listening
   even earlier — `new_server` is synchronous — so the backlog would absorb earlier
   connects anyway; the hook is the honest signal).
-- Per connection: blocking `connect()` on loopback (instant), then `O_NONBLOCK`
-  for all I/O. State: bytes sent (partial-send loop), accumulated `acc []u8`
-  (noscan, sized 8 KiB, grows), current round index, terminal flag.
+- Per connection: `transport.dial_tcp` / `dial_unix` (raw non-blocking fd — no
+  vlib TcpConn). A TCP connect may still be in flight when the fd enters the
+  reactor (EINPROGRESS); the first round's unsent bytes arm `POLLOUT`, which
+  resolves it, and a refused connect surfaces as `POLLERR`/`POLLHUP` ⇒ `eof`
+  with the script unmet (the refusal asserts accept both shapes). When the
+  server config sets `unix_socket_path`, `fire()` dials the socket file — a
+  UDS e2e is a TCP e2e plus that one config line. State: bytes sent
+  (partial-send loop), accumulated `acc []u8` (noscan, sized 8 KiB, grows),
+  current round index, terminal flag.
+- Sends use `MSG_NOSIGNAL` on Linux and `SO_NOSIGPIPE` (per socket, at dial)
+  on darwin: a peer the server already closed must report an error, not raise
+  SIGPIPE (vlib `net` used to SIG_IGN that process-wide; raw fds do not).
 - Loop: build pollfd set of live conns (`POLLIN`, plus `POLLOUT` while the current
   round's send is unfinished) + the self-pipe (`fire`/`wait`/`stop` wake the loop
   the same way the server's own reactor is woken from outside) → `poll(-1)` →
@@ -116,14 +125,19 @@ pub fn repeat(n int, s Script) []Script
   recorded, never fatal to the run.
 - Frame counting = the Content-Length predicate `testkit` uses today, generalized
   to N and kept as a pure `fn (acc []u8) bool`.
-- Windows: `WSAPoll` behind `$if windows` (same struct; POLLERR-on-connect quirk
-  fixed in Win10 2004+, current runners fine). Winsock init comes free via the
-  socket module.
+- Windows: `WSAPoll` behind `$if windows` (same struct). The WSAPoll
+  POLLERR-on-connect quirk never applies: `transport`'s Windows side connects
+  synchronously (then switches the fd non-blocking), so refusal surfaces as a
+  dial error. Winsock init happens inside `transport.dial_tcp` (WSAStartup is
+  refcounted).
 
 ## The enabler: `port: 0` = kernel-assigned ephemeral port
 
 `drive()` defaults to `port: 0` so parallel test binaries never coordinate ports
-(the old hand-maintained registry 8121–8162/18181–18184 dies).
+(the old hand-maintained registry 8121–8162/18181–18184 dies). A config with
+`unix_socket_path` set sidesteps ports entirely: the server listens on the
+socket file and the harness dials it (`tests/uds_test.v`,
+`test_uds_vtest_scripts`).
 
 Server-side change in `new_server` (cold path only):
 
@@ -143,7 +157,8 @@ Server-side change in `new_server` (cold path only):
 
 ## Where things live (module cycles decide this)
 
-- `vtest/` is a **top-level module** (`import vtest`). It imports `server`,
+- `vtest/` is a **top-level module** (`import vtest`). It imports `server`
+  (plus `transport` for dialing and `socket` for `shutdown_write`/nosigpipe),
   so it can never be imported from files compiled *as part of* module
   `server` — including that module's own `_test.v` files.
 - Therefore socket e2e tests for the server live in **`tests/`** (repo root),

--- a/examples/graceful_shutdown/src/main_test.v
+++ b/examples/graceful_shutdown/src/main_test.v
@@ -1,34 +1,63 @@
 module main
 
-import os
+import time
+import server
+import vtest
 
-// SOLUTION 3 (process-level oracle): drive the real binary, send it a signal,
-// and assert drain behavior. Aspirational — needs Server.shutdown() + an
-// in-flight counter (see ROADMAP.md). Self-skips until then.
+// The lifecycle this example demos, asserted for real on vtest (docs/VTEST.md).
+// This file predates Server.shutdown() — it was a self-skipping curl probe with
+// the wanted behaviour written out as a comment. The API exists now, so the
+// comment became the test:
+//   1. the example's handler serves while the server is up;
+//   2. shutdown() returns promptly on an idle server (the drain is PRECISE —
+//      per-worker in-flight counters, not the full grace);
+//   3. after shutdown, new connections are refused.
+// The signal wiring in main() is the one part not covered here: it is exactly
+// `os.signal_opt(.term, ...) -> srv.shutdown(2000)`, and driving a real
+// SIGTERM needs a spawned process — the process-level oracle stays in the
+// example's README narrative.
 
-fn test_graceful_drain_oracle() {
-	if os.execute('which curl').exit_code != 0 {
-		eprintln('[skip] curl not installed')
-		return
+const gs_req = 'GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes()
+
+fn test_graceful_drain() ! {
+	mut h := vtest.start(server.ServerConfig{ handler: handle })!
+	defer {
+		h.stop()
 	}
-	res := os.execute('curl -s --max-time 2 http://localhost:3000/')
-	if res.exit_code != 0 {
-		eprintln('[skip] no server on :3000')
-		return
+	// 1. Served while up.
+	first := h.fire([
+		vtest.Script{
+			rounds: [
+				vtest.Round{
+					send: gs_req
+				},
+			]
+		},
+	])!
+	assert first.conns[0].connect_err == '', first.conns[0].connect_err
+	assert first.conns[0].frames.len == 1
+	assert first.conns[0].frames[0].bytestr().starts_with('HTTP/1.1 200')
+
+	// 2. Idle shutdown returns in ~ms; the 2s grace is only the cap. The
+	// stopwatch MEASURES the drain after it completed — it is not a deadline.
+	sw := time.new_stopwatch()
+	h.server_ref().shutdown(2000)
+	elapsed := sw.elapsed().milliseconds()
+	assert elapsed < 1000, 'idle shutdown should be prompt (precise drain), took ${elapsed}ms'
+
+	// 3. Every listener is closed: fresh connects must be refused — a connect
+	// error, or an immediate close with no response ever arriving.
+	probes := h.fire(vtest.repeat(4, vtest.Script{
+		rounds:   [
+			vtest.Round{
+				send: gs_req
+				want: 0
+			},
+		]
+		then_eof: true
+	}))!
+	for i, c in probes.conns {
+		refused := c.connect_err != '' || (c.eof && c.frames.len == 0)
+		assert refused, 'post-shutdown connect ${i} must be refused, got ${c.frames.len} responses'
 	}
-	assert res.output.len >= 0
 }
-
-/*
-The behavior to assert once the lifecycle API exists:
-
-  pid := spawn_server()                         // start the example binary
-  inflight := spawn slow_request(port)          // a request that takes ~1s
-  os.kill(pid, .term)                           // SIGTERM mid-flight
-  assert inflight.wait().contains('200 OK')     // in-flight request COMPLETES
-  assert net.dial_tcp('127.0.0.1:${port}') fails // new connections REFUSED
-  assert server_process_exits_within(grace)     // and the process exits cleanly
-
-This is the difference between a deploy that returns a burst of 502s and one
-that is invisible to users.
-*/

--- a/examples/mesh/src/server_end_to_end_test.v
+++ b/examples/mesh/src/server_end_to_end_test.v
@@ -2,51 +2,16 @@ module main
 
 // End-to-end: edge (TCP, ephemeral port) → backend (UDS) over the per-worker
 // connection pool, twice — the second request proves the keep-alive pool
-// reuses a connection instead of redialing. Linux-only invocation (the
+// reuses a connection instead of redialing. Client plumbing is
+// transport.dial_tcp + testkit's fd_* deadline loops (the raw-fd pattern
+// every transport e2e in the tree shares). Linux-only invocation (the
 // .epoll enum value); the wiring mirrors main() with ephemeral everything.
 import os
-import time
 import server
+import testkit
 import transport
 
-#include <poll.h>
-
-struct C.pollfd {
-mut:
-	fd      int
-	events  i16
-	revents i16
-}
-
-fn C.poll(fds &C.pollfd, nfds u64, timeout int) int
-fn C.read(fd int, buf voidptr, count usize) int
-fn C.write(fd int, buf voidptr, count usize) int
-
 const e2e_req = 'GET /mesh HTTP/1.1\r\nHost: e\r\nConnection: keep-alive\r\n\r\n'.bytes()
-
-fn e2e_read_until(fd int, needle string, timeout_ms int) string {
-	mut acc := []u8{cap: 1024}
-	mut buf := [1024]u8{}
-	sw := time.new_stopwatch()
-	for sw.elapsed().milliseconds() < timeout_ms {
-		mut pfd := C.pollfd{
-			fd:     fd
-			events: i16(C.POLLIN)
-		}
-		if C.poll(&pfd, 1, 50) <= 0 {
-			continue
-		}
-		n := C.read(fd, voidptr(&buf[0]), usize(1024))
-		if n <= 0 {
-			break
-		}
-		unsafe { acc.push_many(&buf[0], n) }
-		if acc.bytestr().contains(needle) {
-			break
-		}
-	}
-	return acc.bytestr()
-}
 
 fn test_mesh_end_to_end() {
 	$if linux {
@@ -86,15 +51,20 @@ fn test_mesh_end_to_end() {
 		}()
 		_ := <-edge_ready
 
-		fd := socket_connect_loopback(edge.port) or {
+		fd := transport.dial_tcp('127.0.0.1', edge.port) or {
 			assert false, err.msg()
 			return
 		}
+		defer {
+			transport.close_fd(fd)
+		}
+		// Non-blocking connect: writable == connected (loopback).
+		assert testkit.fd_wait_writable(fd, 2000), 'connect to edge did not complete'
 		// Two mesh calls on one client conn: the second reuses the pooled
 		// worker→backend connection (and the edge's own keep-alive).
 		for round in 0 .. 2 {
-			assert C.write(fd, voidptr(&e2e_req[0]), usize(e2e_req.len)) == e2e_req.len
-			got := e2e_read_until(fd, 'hello from the mesh', 3000)
+			assert testkit.fd_write_all(fd, e2e_req, 2000)
+			got := testkit.fd_read_until(fd, 'hello from the mesh', 3000)
 			assert got.starts_with('HTTP/1.1 200'), 'round ${round}: ${got}'
 			assert got.contains('"via":"edge"'), 'round ${round}: ${got}'
 			assert got.contains('"svc":"backend"'), 'round ${round}: ${got}'
@@ -102,19 +72,4 @@ fn test_mesh_end_to_end() {
 		edge.shutdown(500)
 		backend.shutdown(500)
 	}
-}
-
-// socket_connect_loopback dials 127.0.0.1:port non-blocking and waits for
-// the connect to complete (writability — the readiness path).
-fn socket_connect_loopback(port int) !int {
-	fd := transport.dial_tcp('127.0.0.1', port)!
-	mut pfd := C.pollfd{
-		fd:     fd
-		events: i16(C.POLLOUT)
-	}
-	if C.poll(&pfd, 1, 2000) != 1 {
-		transport.close_fd(fd)
-		return error('connect to edge did not complete')
-	}
-	return fd
 }

--- a/examples/request_limits/src/main_test.v
+++ b/examples/request_limits/src/main_test.v
@@ -1,12 +1,17 @@
 module main
 
+import time
 import core
+import server
+import vtest
 
-// Size limits are now enforced by the CORE (the read loop), not the handler —
-// so the handler stays trivial and the limit behavior is tested where it lives:
-// `frame_request_length_lim` in request_parser_test.v (413 from Content-Length
-// before buffering; 431 for oversized header blocks). This file just confirms
-// the handler is a plain 200 and the timeout protections still to come.
+// Size limits are enforced by the CORE (the read loop), not the handler — so
+// the handler stays trivial (asserted below) and every limit is tested where
+// it lives: end-to-end against a real server, on vtest (docs/VTEST.md). This
+// file's earlier revision carried these e2e cases as an ASPIRATIONAL comment
+// (they needed Limits + timeout support in the core); the support exists now,
+// so the comment became the tests. The only clocks are the server's own
+// Limits — vtest has none.
 
 fn test_handler_is_trivial_200() {
 	req := 'POST /u HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\n0123456789'.bytes()
@@ -22,28 +27,110 @@ fn serve(req []u8) []u8 {
 	return out
 }
 
-/*
-ASPIRATIONAL — Solution 2 (programmable raw client) + Solution 4 (fake clock).
-These verify CORE behavior that no handler test can reach. Requires the
-`Limits`/timeout support in the core (see ROADMAP.md); the client side is
-net.dial_tcp + testkit.read_response:
+// --- the limits, end-to-end (the CORE's work, driven through this example's
+// own handler) ---------------------------------------------------------------
 
-  fn test_slowloris_times_out() {
-      mut c := net.dial_tcp('127.0.0.1:${port}')!
-      c.write('GET / HTTP/1.1\r\n'.bytes())!    // partial request line...
-      fake_clock.advance(read_header_timeout + 1)   // ...and then stall
-      assert testkit.read_response(mut c, 2000).bytestr().contains('408 Request Timeout')
-  }
+// Slowloris: a client that opens a connection and dribbles a partial request
+// must be ENDED by the server's read_timeout reaper — never served a 200.
+// then_eof means completion can ONLY come from the server's clock; the
+// stopwatch MEASURES how long that took after the fact, it is not a deadline.
+fn test_slowloris_reaped_by_read_timeout() ! {
+	mut h := vtest.start(server.ServerConfig{
+		handler: handle
+		limits:  server.Limits{
+			read_timeout_ms: 400
+		}
+	})!
+	defer {
+		h.stop()
+	}
+	sw := time.new_stopwatch()
+	out := h.fire([
+		vtest.Script{
+			rounds:   [
+				vtest.Round{
+					send: 'GET / HTTP/1.1\r\nX-Dribble: a'.bytes() // ...and then stall
+					want: 0
+				},
+			]
+			then_eof: true
+		},
+	])!
+	elapsed := sw.elapsed().milliseconds()
+	c := out.conns[0]
+	assert c.connect_err == '', c.connect_err
+	assert c.eof, 'read_timeout must end a stalled connection'
+	assert !c.raw.bytestr().contains('200 OK'), 'a stalled partial request must not be served, got: ${c.raw.bytestr()}'
+	assert elapsed < 1500, 'the reaper should fire around read_timeout_ms=400, took ${elapsed}ms'
+}
 
-  fn test_header_flood_rejected() {
-      mut c := net.dial_tcp('127.0.0.1:${port}')!
-      c.write('GET / HTTP/1.1\r\n'.bytes())!
-      for _ in 0 .. 100_000 { c.write(('X-Pad: ' + 'a'.repeat(100) + '\r\n').bytes())! }
-      assert testkit.read_response(mut c, 2000).bytestr().contains('431')   // before buffering it all
-  }
+// Header flood: a header block over max_header_bytes gets 431 and a close —
+// the server stops buffering attacker bytes at the limit, long before the
+// flood ends. The 431 bytes themselves are asserted only when they arrived:
+// the server closes with part of the flood unread, so the kernel may RST and
+// discard the response in flight — the hard contract is "no 200, ended".
+fn test_header_flood_rejected() ! {
+	mut flood := []u8{cap: 16 * 1024}
+	flood << 'GET / HTTP/1.1\r\nHost: x\r\n'.bytes()
+	for i := 0; flood.len < 12 * 1024; i++ {
+		flood << 'X-Pad-'.bytes()
+		flood << i.str().bytes() // test scaffolding — not request-serving code
+		flood << ': aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n'.bytes()
+	}
+	// No terminating blank line: the flood is still "headers" when it trips.
+	out := vtest.drive(server.ServerConfig{
+		handler: handle
+		limits:  server.Limits{
+			max_header_bytes: 4 * 1024
+			read_timeout_ms:  2000 // backstop so a regression fails instead of hanging
+		}
+	}, [
+		vtest.Script{
+			rounds:   [
+				vtest.Round{
+					send: flood
+					want: 0
+				},
+			]
+			then_eof: true
+		},
+	])!
+	c := out.conns[0]
+	assert c.connect_err == '', c.connect_err
+	assert c.eof, 'an oversized header block must end in a server close'
+	raw := c.raw.bytestr()
+	assert !raw.contains('200'), 'an oversized header block must never reach the handler, got: ${raw}'
+	if c.raw.len > 0 {
+		assert raw.starts_with('HTTP/1.1 431'), 'expected the 431 rejection, got: ${raw}'
+	}
+}
 
-  fn test_oversized_body_rejected_before_buffering() {
-      // CORE must 413 from the Content-Length alone, WITHOUT reading the body —
-      // proving it doesn't buffer attacker-controlled bytes first.
-  }
-*/
+// Oversized body: a Content-Length over max_body_bytes is rejected 413 from
+// the DECLARED length alone — the client here never sends a single body byte,
+// so the response arriving at all proves the server did not wait for (or
+// buffer) attacker-controlled body bytes first.
+fn test_oversized_body_rejected_before_buffering() ! {
+	out := vtest.drive(server.ServerConfig{
+		handler: handle
+		limits:  server.Limits{
+			max_body_bytes:  1024
+			read_timeout_ms: 2000 // backstop so a regression fails instead of hanging
+		}
+	}, [
+		vtest.Script{
+			rounds:   [
+				vtest.Round{
+					send: 'POST /u HTTP/1.1\r\nHost: x\r\nContent-Length: 100000\r\n\r\n'.bytes()
+					want: 0
+				},
+			]
+			then_eof: true
+		},
+	])!
+	c := out.conns[0]
+	assert c.connect_err == '', c.connect_err
+	assert c.eof, 'an over-limit Content-Length must end in a server close'
+	raw := c.raw.bytestr()
+	assert !raw.contains('200'), 'an over-limit body must never reach the handler, got: ${raw}'
+	assert raw.starts_with('HTTP/1.1 413'), 'expected 413 from the Content-Length alone (no body was ever sent), got: ${raw}'
+}

--- a/testkit/fd_nix.c.v
+++ b/testkit/fd_nix.c.v
@@ -1,0 +1,108 @@
+module testkit
+
+// Raw-fd companions to the TcpConn readers in testkit.v: end-to-end tests
+// that dial through `transport` (or any raw socket) get the same
+// deadline-bounded loops without redeclaring poll(2)/read(2)/write(2) per
+// test file — before these landed, tests/uds_test.v and the mesh example's
+// e2e test each carried their own copy. Same charter as testkit.v: NO vanilla
+// imports (raw libc through the shim typedef keeps the dependency script
+// honest), and every loop is deadline-bounded so a stalled peer fails the
+// test fast instead of hanging it.
+//
+// `_nix` suffix: the consumers (UDS / transport e2e tests) are unix-only;
+// Windows test binaries compile testkit without this file.
+import time
+
+#include <poll.h>
+#include <errno.h>
+#include "@VMODROOT/testkit/testkit_shim.h"
+
+@[typedef]
+struct C.testkit_pollfd {
+mut:
+	fd      int
+	events  i16
+	revents i16
+}
+
+fn C.poll(fds voidptr, nfds u64, timeout int) int
+
+fn C.read(fd int, buf voidptr, count usize) int
+
+fn C.write(fd int, buf voidptr, count usize) int
+
+// poll bit values from <poll.h> (linux/darwin agree on these).
+const fd_pollin = i16(0x001)
+const fd_pollout = i16(0x004)
+
+// fd_wait_writable polls fd for writability within deadline_ms. For a
+// non-blocking dial this is the connect-completion barrier: writable means
+// connected (transport.dial_tcp returns with the connect still in flight).
+pub fn fd_wait_writable(fd int, deadline_ms int) bool {
+	mut pfd := C.testkit_pollfd{
+		fd:     fd
+		events: fd_pollout
+	}
+	return C.poll(voidptr(&pfd), 1, deadline_ms) == 1
+}
+
+// fd_write_all writes the whole buffer to a (possibly non-blocking) fd,
+// polling for writability between short writes; false when the deadline
+// elapses (or the peer dies) with bytes still unwritten.
+pub fn fd_write_all(fd int, data []u8, deadline_ms int) bool {
+	mut off := 0
+	sw := time.new_stopwatch()
+	for off < data.len {
+		if sw.elapsed().milliseconds() >= deadline_ms {
+			return false
+		}
+		n := C.write(fd, unsafe { &data[off] }, usize(data.len - off))
+		if n > 0 {
+			off += n
+			continue
+		}
+		if n < 0 && C.errno != C.EAGAIN && C.errno != C.EINTR {
+			return false
+		}
+		mut pfd := C.testkit_pollfd{
+			fd:     fd
+			events: fd_pollout
+		}
+		C.poll(voidptr(&pfd), 1, 50)
+	}
+	return true
+}
+
+// fd_read_until accumulates bytes from a (possibly non-blocking) fd until
+// `needle` appears, the peer closes, or deadline_ms elapses — poll(2)-paced,
+// so a stalled stream fails the caller's assert instead of hanging the test
+// binary. Returns everything read.
+pub fn fd_read_until(fd int, needle string, deadline_ms int) string {
+	mut acc := []u8{cap: 1024}
+	mut buf := [4096]u8{}
+	sw := time.new_stopwatch()
+	for sw.elapsed().milliseconds() < deadline_ms {
+		mut pfd := C.testkit_pollfd{
+			fd:     fd
+			events: fd_pollin
+		}
+		if C.poll(voidptr(&pfd), 1, 50) <= 0 {
+			continue
+		}
+		n := C.read(fd, voidptr(&buf[0]), usize(buf.len))
+		if n == 0 {
+			break // EOF
+		}
+		if n < 0 {
+			if C.errno == C.EAGAIN || C.errno == C.EINTR {
+				continue
+			}
+			break // reset counts as close for test purposes
+		}
+		unsafe { acc.push_many(&buf[0], n) }
+		if acc.bytestr().contains(needle) {
+			break
+		}
+	}
+	return acc.bytestr()
+}

--- a/testkit/testkit.v
+++ b/testkit/testkit.v
@@ -15,7 +15,9 @@
 // EOF) — none reads "until a marker / a byte count / a full Content-Length-framed
 // message, bounded by a deadline". Connecting is just `net.dial_tcp` and counting
 // occurrences is `string.count`, so those are used inline at the call sites rather
-// than wrapped here.
+// than wrapped here. Tests that dial raw fds through `transport` instead of
+// TcpConn use the fd_* family in fd_nix.c.v (same deadline discipline, raw
+// poll(2) — still no vanilla imports).
 module testkit
 
 import net

--- a/testkit/testkit_shim.h
+++ b/testkit/testkit_shim.h
@@ -1,0 +1,13 @@
+// testkit_shim.h — module-local typedef alias for poll(2)'s pollfd. Other
+// modules in a test binary (vtest, server/backend_poll) declare their own V
+// bindings for pollfd-shaped structs; aliasing under a testkit_ name keeps
+// this module clash-free without importing anything (V C-struct declarations
+// are program-wide, so two modules must not bind the same C tag).
+#ifndef VANILLA_TESTKIT_SHIM_H
+#define VANILLA_TESTKIT_SHIM_H
+
+#include <poll.h>
+
+typedef struct pollfd testkit_pollfd;
+
+#endif

--- a/tests/uds_test.v
+++ b/tests/uds_test.v
@@ -5,26 +5,18 @@
 // idle shutdown (the io_uring path exercises the dummy-connect wake poke —
 // shutdown(2) on an AF_UNIX listener yields NO CQE), assert the socket file
 // is unlinked on shutdown, and prove the path is immediately rebindable.
+// Client plumbing is transport.dial_* + testkit's fd_* deadline loops; the
+// scripted protocol behaviour over UDS is vtest's job (test_uds_vtest_scripts
+// below — a UDS e2e is a TCP e2e plus one config line).
 // Linux-only invocations: the .epoll/.io_uring enum values exist only there.
 import os
 import time
 import server
 import core
 import socket
+import testkit
 import transport
-
-#include <poll.h>
-
-struct C.pollfd {
-mut:
-	fd      int
-	events  i16
-	revents i16
-}
-
-fn C.poll(fds &C.pollfd, nfds u64, timeout int) int
-fn C.read(fd int, buf voidptr, count usize) int
-fn C.write(fd int, buf voidptr, count usize) int
+import vtest
 
 const uds_req = 'GET / HTTP/1.1\r\nHost: local\r\nConnection: close\r\n\r\n'.bytes()
 const uds_ok = 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok'.bytes()
@@ -32,35 +24,6 @@ const uds_ok = 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\
 fn uds_handler(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
 	res << uds_ok
 	return .close
-}
-
-// read_until_deadline reads from a (possibly non-blocking) fd until `needle`
-// appears in the accumulated bytes or `timeout_ms` elapses — poll(2)-paced,
-// so a stalled stream fails the assert instead of hanging the test binary.
-fn read_until_deadline(fd int, needle string, timeout_ms int) string {
-	mut acc := []u8{cap: 512}
-	mut buf := [512]u8{}
-	sw := time.new_stopwatch()
-	for sw.elapsed().milliseconds() < timeout_ms {
-		mut pfd := C.pollfd{
-			fd:     fd
-			events: i16(C.POLLIN)
-		}
-		if C.poll(&pfd, 1, 50) <= 0 {
-			continue
-		}
-		n := C.read(fd, voidptr(&buf[0]), usize(512))
-		if n == 0 {
-			break // EOF
-		}
-		if n > 0 {
-			unsafe { acc.push_many(&buf[0], n) }
-			if acc.bytestr().contains(needle) {
-				break
-			}
-		}
-	}
-	return acc.bytestr()
 }
 
 fn uds_socket_path(tag string) string {
@@ -91,8 +54,8 @@ fn serve_once_over_uds(backend server.IOBackend, tag string) !(server.Server, st
 	defer {
 		transport.close_fd(fd)
 	}
-	assert C.write(fd, voidptr(&uds_req[0]), usize(uds_req.len)) == uds_req.len
-	got := read_until_deadline(fd, 'HTTP/1.1 200', 3000)
+	assert testkit.fd_write_all(fd, uds_req, 2000)
+	got := testkit.fd_read_until(fd, 'HTTP/1.1 200', 3000)
 	assert got.starts_with('HTTP/1.1 200'), '${backend}: expected a 200 over unix:${path}, got: ${got}'
 	return srv, path
 }
@@ -163,15 +126,76 @@ fn test_dial_tcp() {
 			transport.close_fd(fd)
 		}
 		// Non-blocking connect: wait for writability = connected (loopback).
-		mut pfd := C.pollfd{
-			fd:     fd
-			events: i16(C.POLLOUT)
-		}
-		assert C.poll(&pfd, 1, 2000) == 1, 'dial_tcp connect did not complete'
-		assert C.write(fd, voidptr(&uds_req[0]), usize(uds_req.len)) == uds_req.len
-		got := read_until_deadline(fd, 'HTTP/1.1 200', 3000)
+		assert testkit.fd_wait_writable(fd, 2000), 'dial_tcp connect did not complete'
+		assert testkit.fd_write_all(fd, uds_req, 2000)
+		got := testkit.fd_read_until(fd, 'HTTP/1.1 200', 3000)
 		assert got.starts_with('HTTP/1.1 200'), 'dial_tcp request failed, got: ${got}'
 		srv.shutdown(2000)
+	}
+}
+
+// --- scripted protocol behaviour over UDS (vtest) --------------------------
+
+const uds_keep_ok = 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
+
+fn uds_keep_handler(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+	res << uds_keep_ok
+	return .done
+}
+
+// The issue-#122 step-2 promise made concrete: vtest drives UDS exactly like
+// TCP — the ONLY difference from a TCP script test is the unix_socket_path
+// config line (fire() dials through transport.dial_unix instead of dial_tcp).
+// Two concurrent connections against the single shared UDS listener: one
+// pipelines 4 requests in one write then keeps the connection alive for a
+// 5th, the other is a plain request — and drive()'s shutdown must leave
+// nothing in flight and unlink the socket file.
+fn test_uds_vtest_scripts() {
+	$if linux {
+		path := uds_socket_path('vtest')
+		mut pipelined := []u8{cap: uds_req.len * 4}
+		for _ in 0 .. 4 {
+			pipelined << 'GET / HTTP/1.1\r\nHost: local\r\n\r\n'.bytes()
+		}
+		out := vtest.drive(server.ServerConfig{
+			unix_socket_path: path
+			io_multiplexing:  .epoll
+			handler:          uds_keep_handler
+		}, [
+			vtest.Script{
+				rounds: [
+					vtest.Round{
+						send: pipelined
+						want: 4
+					},
+					vtest.Round{
+						send: 'GET / HTTP/1.1\r\nHost: local\r\n\r\n'.bytes()
+						want: 1
+					},
+				]
+			},
+			vtest.Script{
+				rounds: [
+					vtest.Round{
+						send: 'GET / HTTP/1.1\r\nHost: local\r\n\r\n'.bytes()
+					},
+				]
+			},
+		]) or {
+			assert false, err.msg()
+			return
+		}
+		pipe := out.conns[0]
+		assert pipe.connect_err == '', pipe.connect_err
+		assert pipe.frames.len == 5, 'UDS pipelining + keep-alive expected 5 responses, got ${pipe.frames.len}'
+		for f in pipe.frames {
+			assert f == uds_keep_ok
+		}
+		single := out.conns[1]
+		assert single.connect_err == '', single.connect_err
+		assert single.frames.len == 1
+		assert out.inflight_after == 0
+		assert !os.exists(path), 'drive() shutdown must unlink the socket file'
 	}
 }
 
@@ -183,7 +207,7 @@ const cred_forbidden = 'HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnectio
 // cred_handler authorizes by kernel-verified identity instead of anything in
 // the request: the caller must be THIS uid and THIS pid (the test client
 // lives in the same process). That is the §6 trust model end-to-end — the
-// gates who may connect, peer_cred says who each connection is.
+// path gates who may connect, peer_cred says who each connection is.
 fn cred_handler(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
 	cred := socket.peer_cred(client_fd) or {
 		res << cred_forbidden
@@ -225,10 +249,9 @@ fn test_uds_peer_cred() {
 		defer {
 			transport.close_fd(fd)
 		}
-		assert C.write(fd, voidptr(&uds_req[0]), usize(uds_req.len)) == uds_req.len
-		got := read_until_deadline(fd, 'cred-ok', 3000)
+		assert testkit.fd_write_all(fd, uds_req, 2000)
+		got := testkit.fd_read_until(fd, 'cred-ok', 3000)
 		assert got.contains('cred-ok'), 'peer_cred must identify this process over UDS, got: ${got}'
-		// A TCP connection has no unix peer: peer_cred must answer none.
 		srv.shutdown(500)
 	}
 }
@@ -258,13 +281,10 @@ fn test_peer_cred_none_on_tcp() {
 		defer {
 			transport.close_fd(fd)
 		}
-		mut pfd := C.pollfd{
-			fd:     fd
-			events: i16(C.POLLOUT)
-		}
-		assert C.poll(&pfd, 1, 2000) == 1
-		assert C.write(fd, voidptr(&uds_req[0]), usize(uds_req.len)) == uds_req.len
-		got := read_until_deadline(fd, 'HTTP/1.1 403', 3000)
+		assert testkit.fd_wait_writable(fd, 2000)
+		assert testkit.fd_write_all(fd, uds_req, 2000)
+		// A TCP connection has no unix peer: peer_cred must answer none (403).
+		got := testkit.fd_read_until(fd, 'HTTP/1.1 403', 3000)
 		assert got.starts_with('HTTP/1.1 403'), 'peer_cred over TCP must be none (403 here), got: ${got}'
 		srv.shutdown(500)
 	}

--- a/transport/transport_nix.c.v
+++ b/transport/transport_nix.c.v
@@ -10,8 +10,9 @@ module transport
 // Protocol clients (request serializers / response parsers) live inside
 // their protocol module (http1_1/client later), not here.
 //
-// `_nix` suffix: every Unix, never Windows (dial_windows lands with a
-// consumer, per docs/ARCHITECTURE.md).
+// `_nix` suffix: every Unix. The Windows side lives in
+// transport_windows.c.v (landed with its consumer, vtest — per
+// docs/ARCHITECTURE.md's "lands with a consumer" rule).
 
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/transport/transport_shim.h
+++ b/transport/transport_shim.h
@@ -6,11 +6,18 @@
 #ifndef VANILLA_TRANSPORT_SHIM_H
 #define VANILLA_TRANSPORT_SHIM_H
 
+#ifdef _WIN32
+#include <winsock2.h>
+
+typedef struct in_addr transport_in_addr;
+typedef struct sockaddr_in transport_sockaddr_in;
+#else
 #include <netinet/in.h>
 #include <sys/un.h>
 
 typedef struct in_addr transport_in_addr;
 typedef struct sockaddr_in transport_sockaddr_in;
 typedef struct sockaddr_un transport_sockaddr_un;
+#endif
 
 #endif

--- a/transport/transport_windows.c.v
+++ b/transport/transport_windows.c.v
@@ -1,0 +1,101 @@
+module transport
+
+// Client-side dialing — Windows side. The consumer that made it land (per the
+// "dial_windows lands with a consumer" note in transport_nix.c.v) is vtest:
+// every end-to-end suite now dials through transport on all three OSes, and
+// the Windows CI matrix runs the vtest-driven tests against the IOCP backend.
+// Same contract as the unix side: hand back a NON-BLOCKING int fd (the
+// program-wide int-fd convention socket/ documents); SCOPE GUARD unchanged —
+// bytes + non-blocking fds ONLY.
+//
+// One deliberate divergence: the connect itself is SYNCHRONOUS here, and the
+// fd switches to non-blocking right after. WSAPoll cannot report a failed
+// non-blocking connect on Windows builds before the 10/2004 POLLERR fix, so a
+// synchronous connect is the only shape that surfaces refusal deterministically
+// — and loopback connects (the test consumer's case) complete in microseconds
+// either way.
+
+#flag windows -lws2_32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include "@VMODROOT/transport/transport_shim.h"
+
+@[typedef]
+struct C.transport_in_addr {
+	s_addr u32
+}
+
+@[typedef]
+struct C.transport_sockaddr_in {
+mut:
+	sin_family u16
+	sin_port   u16
+	sin_addr   C.transport_in_addr
+}
+
+// Empty decl names the C struct tag (defined by winsock2.h) so WSAStartup has
+// real storage — same form as socket/socket_windows.c.v.
+struct C.WSAData {}
+
+// Signatures match socket/'s decls exactly (V registers C fn signatures
+// program-wide, vlang/v#27791).
+fn C.WSAStartup(wVersionRequired u16, lpWSAData voidptr) int
+
+fn C.WSAGetLastError() int
+
+fn C.closesocket(s int) int
+
+fn C.ioctlsocket(s int, cmd int, argptr &u32) int
+
+fn C.socket(int, int, int) int
+
+fn C.connect(int, voidptr, u32) int
+
+fn C.htons(u16) u16
+
+fn C.inet_pton(int, &char, voidptr) int
+
+fn C.memset(voidptr, int, usize) voidptr
+
+// max_unix_path mirrors the unix side so cross-platform config validation
+// stays uniform even where dial_unix itself is unsupported.
+pub const max_unix_path = 103
+
+// dial_tcp connects to ipv4:port and returns a NON-BLOCKING socket. See the
+// module header for why the connect itself is synchronous on Windows.
+pub fn dial_tcp(ipv4 string, port int) !int {
+	mut wsa := C.WSAData{}
+	if C.WSAStartup(0x202, &wsa) != 0 {
+		return error('dial_tcp: WSAStartup failed')
+	}
+	mut addr := C.transport_sockaddr_in{}
+	C.memset(voidptr(&addr), 0, sizeof(C.transport_sockaddr_in))
+	addr.sin_family = u16(C.AF_INET)
+	addr.sin_port = C.htons(u16(port))
+	if C.inet_pton(C.AF_INET, &char(ipv4.str), voidptr(&addr.sin_addr)) != 1 {
+		return error('dial_tcp: invalid IPv4 address ${ipv4}')
+	}
+	fd := C.socket(C.AF_INET, C.SOCK_STREAM, 0)
+	if fd < 0 {
+		return error('dial_tcp: socket creation failed (WSA ${C.WSAGetLastError()})')
+	}
+	if C.connect(fd, voidptr(&addr), sizeof(C.transport_sockaddr_in)) != 0 {
+		e := C.WSAGetLastError()
+		C.closesocket(fd)
+		return error('dial_tcp: connect to ${ipv4}:${port} failed (WSA ${e})')
+	}
+	mut nb := u32(1)
+	C.ioctlsocket(fd, int(C.FIONBIO), &nb)
+	return fd
+}
+
+// dial_unix: AF_UNIX dialing is not wired on Windows (the engine rejects UDS
+// listeners there too) — fail loudly rather than half-support it.
+pub fn dial_unix(path string) !int {
+	return error('dial_unix: AF_UNIX dialing is not supported on Windows (unix:${path})')
+}
+
+// close_fd closes a dialed fd — here so callers need no C declarations.
+pub fn close_fd(fd int) {
+	C.closesocket(fd)
+}

--- a/vtest/vtest.c.v
+++ b/vtest/vtest.c.v
@@ -3,9 +3,10 @@ module vtest
 // vtest — event-driven end-to-end test client for vanilla servers.
 // Design + contract: docs/VTEST.md. The short version:
 //
-//   - drive()/start() own the whole lifecycle: bind (always port 0/ephemeral),
-//     spawn run(), and the client work begins the instant after_server_start
-//     fires. The test author never sees readiness.
+//   - drive()/start() own the whole lifecycle: bind (always port 0/ephemeral —
+//     or the config's `unix_socket_path`), spawn run(), and the client work
+//     begins the instant after_server_start fires. The test author never sees
+//     readiness.
 //   - There is NO timeout anywhere in this module. The reactor blocks in
 //     poll(-1); progress comes from the server (bytes or close), so the only
 //     clocks in a test are the server's own configs (Limits). A server that
@@ -20,13 +21,28 @@ module vtest
 // kernel socket buffers hold anything that arrives in between), which is what
 // makes multi-step choreography (SSE subscribe → publish → expect) work with
 // completion-based ordering instead of sleeps.
-import net
+//
+// Connections dial through transport/ (raw non-blocking fds — no vlib
+// TcpConn): TCP to 127.0.0.1:port normally, or the unix socket when the
+// config set `unix_socket_path` — a UDS e2e IS a TCP e2e plus that one
+// config line (issue #122 step 2). A TCP connect may still be in flight
+// when fire() returns the fd (EINPROGRESS); the reactor resolves it — the
+// first round's unsent bytes arm POLLOUT, and a refused connect surfaces as
+// POLLERR/POLLHUP ⇒ eof with the script unmet.
 import sync.stdatomic
 import server
 import socket
+import transport
 
 fn C.send(__fd int, __buf voidptr, __n usize, __flags int) int
 fn C.recv(__fd int, __buf voidptr, __n usize, __flags int) int
+
+// A send to a peer the server already closed (refused-connect probes, races
+// around shutdown) must report an error, not kill the test binary: Linux
+// suppresses SIGPIPE per send with MSG_NOSIGNAL, darwin per socket with
+// SO_NOSIGPIPE (socket.set_nosigpipe at dial), Windows has no SIGPIPE.
+// (vlib net used to SIG_IGN this process-wide; raw transport fds do not.)
+const msg_nosignal = $if linux { C.MSG_NOSIGNAL } $else { 0 }
 
 // Round is one send-then-expect step of a connection's life. Round k+1's bytes
 // go out only after round k's expectation held.
@@ -79,8 +95,7 @@ pub:
 
 struct HConn {
 mut:
-	tcp         &net.TcpConn = unsafe { nil }
-	fd          int          = -1
+	fd          int = -1
 	rounds      []Round
 	then_eof    bool
 	shut_wr     bool
@@ -109,6 +124,8 @@ pub mut:
 // the listeners synchronously, and the returned Harness only exists after
 // after_server_start fired on the run() thread. Always binds port 0 — the
 // resolved port is h.port() / h.server.port; tests never coordinate ports.
+// A config with `unix_socket_path` set listens there instead (the forced
+// port 0 is ignored on the UDS path) and fire() dials the socket file.
 pub fn start(config server.ServerConfig) !&Harness {
 	ready := chan bool{cap: 1}
 	user_hook := config.after_server_start
@@ -157,7 +174,7 @@ pub fn (mut h Harness) fire(scripts []Script) !Outcome {
 			shut_wr:  s.shut_wr
 			acc:      []u8{cap: 8192}
 		}
-		mut tcp := net.dial_tcp('127.0.0.1:${h.server.port}') or {
+		hc.fd = h.dial() or {
 			hc.connect_err = err.msg()
 			hc.eof = true
 			hc.done = true
@@ -165,17 +182,23 @@ pub fn (mut h Harness) fire(scripts []Script) !Outcome {
 			group << h.conns.len - 1
 			continue
 		}
-		hc.tcp = tcp
-		// TcpConn carries two handle fields; dial_tcp only fills sock.handle
-		// (the outer .handle stays 0 — vlib itself reads sock.handle everywhere).
-		hc.fd = tcp.sock.handle
-		socket.set_blocking(hc.fd, false)
+		socket.set_nosigpipe(hc.fd) // no-op outside darwin
 		hc.arm_round()
 		h.conns << hc
 		group << h.conns.len - 1
 	}
 	h.pump(group)
 	return h.results(group)
+}
+
+// dial connects to whatever the harness's server listens on: the unix socket
+// when the config set one, 127.0.0.1:port otherwise. transport hands back a
+// non-blocking fd; the connect may still be in flight (module header).
+fn (h &Harness) dial() !int {
+	if h.server.unix_socket_path != '' {
+		return transport.dial_unix(h.server.unix_socket_path)
+	}
+	return transport.dial_tcp('127.0.0.1', h.server.port)
 }
 
 // wait blocks until `until` holds on every connection of the group (or the
@@ -205,7 +228,7 @@ pub fn (mut h Harness) stop() {
 	h.stopped = true
 	for mut c in h.conns {
 		if c.fd >= 0 {
-			c.tcp.close() or {}
+			transport.close_fd(c.fd)
 			c.fd = -1
 		}
 	}
@@ -293,7 +316,7 @@ fn (mut c HConn) write_some() {
 	if c.sent >= r.send.len {
 		return
 	}
-	n := C.send(c.fd, unsafe { &r.send[c.sent] }, usize(r.send.len - c.sent), 0)
+	n := C.send(c.fd, unsafe { &r.send[c.sent] }, usize(r.send.len - c.sent), msg_nosignal)
 	if n > 0 {
 		c.sent += n
 	}


### PR DESCRIPTION
Follow-up to #122: now that transport/, the UDS listeners, the client codec and peer_cred are all merged, the tests and examples get rebuilt on top of them.

## vtest dials through transport/ (and speaks UDS)

- `vtest` no longer uses vlib's `net.TcpConn`: `fire()` dials raw non-blocking fds via `transport.dial_tcp` — or `transport.dial_unix` when the server config sets `unix_socket_path`. **A UDS e2e is now a TCP e2e plus one config line**, which was the deferred promise from #122 step 2.
- A TCP connect may still be in flight when the fd enters the reactor (EINPROGRESS); the existing `POLLOUT` arming resolves it, and a refused connect surfaces as `POLLERR`/`POLLHUP` ⇒ `eof` — the refusal asserts in the behaviour suite already accept both shapes.
- Client sends now carry `MSG_NOSIGNAL` (Linux) / per-socket `SO_NOSIGPIPE` (darwin): vlib `net` used to `SIG_IGN` SIGPIPE process-wide, raw fds don't get that for free.
- `transport/transport_windows.c.v` lands with this consumer (per the "dial_windows lands with a consumer" note): synchronous connect + `FIONBIO`, because WSAPoll cannot report a failed non-blocking connect on older Windows builds. This keeps the Windows CI matrix (auth/simple/sse e2e + server module tests) on the same code path.

## testkit gains raw-fd deadline loops

- `testkit/fd_nix.c.v`: `fd_read_until` / `fd_write_all` / `fd_wait_writable` — poll(2)-paced, deadline-bounded, `pollfd` bound through a module-local shim typedef. Still **zero vanilla imports** (the dependency-direction script stays honest).
- `tests/uds_test.v` and `examples/mesh/src/server_end_to_end_test.v` drop their per-file copies of the same `C.pollfd`/read-loop helpers.

## New coverage

- `tests/uds_test.v` adds `test_uds_vtest_scripts`: pipelining (4-in-one-write) + keep-alive scripts over the unix socket, two concurrent connections against the single shared UDS listener, drain (`inflight_after == 0`) and socket-file unlink asserted through `vtest.drive`.
- `examples/graceful_shutdown` replaces its self-skipping curl stub (written before `Server.shutdown()` existed) with the real lifecycle test: serve → prompt precise drain (measured, not slept) → fresh connects refused.
- `examples/request_limits` turns its "aspirational" comment block into tests: slowloris reaped by `read_timeout_ms` (the only clock is the server's), header flood → 431, and a Content-Length over `max_body_bytes` → 413 **with no body byte ever sent** — proving the reject-before-buffering claim.

## CI + docs

- Linux workflow: the three refactored example folders join the matrix, plus a new `repo-tests` job for `tests/` (backend behaviours, UDS, vtest smoke — previously not exercised by CI at all) with the established `VANILLA_NO_IOURING` kill-switch.
- `docs/VTEST.md` (dialing mechanics, UDS, SIGPIPE note), README e2e sections, and module headers updated to match.

Verified locally: `tests/` 6/6, server module tests, all vtest-consuming example suites (simple, simple3, sse, async_pipe, auth, mesh, graceful_shutdown, request_limits), behaviour suite under `-d vanilla_poll` (30/30), `-os windows/macos -check` on the touched consumers, `v fmt -verify`, dependency-direction check.

Closes the test/example refactor portion of #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvjM79KsDdT2Q9Y6SPfGxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvjM79KsDdT2Q9Y6SPfGxm)_