### PR TITLE
Conn-mode seam (#136): protocol-neutral connection takeover + RFC 6455 WebSocket sibling

### DIFF
--- a/.github/workflows/build_test_examples_on_linux.yml
+++ b/.github/workflows/build_test_examples_on_linux.yml
@@ -29,6 +29,7 @@ jobs:
           - examples/simple/src
           - examples/simple2/src
           - examples/sse/src
+          - examples/websocket_echo/src
     steps:
       - uses: actions/checkout@v4
       - name: Set up V

--- a/.github/workflows/build_test_examples_on_windows.yml
+++ b/.github/workflows/build_test_examples_on_windows.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Test server modules
         shell: bash
         run: |
-          v test server core http1_1 http2 socket epoll io_uring kqueue iocp tls static_assets testkit
+          v test server core http1_1 http2 websocket socket epoll io_uring kqueue iocp tls static_assets testkit
 
   examples-building-and-testing:
     runs-on: windows-latest
@@ -47,6 +47,9 @@ jobs:
           - examples/simple/src
           - examples/simple2/src
           - examples/sse/src
+          # websocket_echo: the takeover seam is epoll-only, but the example must
+          # degrade cleanly elsewhere — the 501-fallback + codec tests run here.
+          - examples/websocket_echo/src
     steps:
       - uses: actions/checkout@v4
       - name: Set up V

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ fn main() {
 | `examples/static_files/` | Static file serving (MIME, Range, ETag, traversal safety) |
 | `examples/url_form/` | Query-string and URL-encoded form parsing |
 | `examples/veb_like/` | veb-style declarative routing |
+| `examples/websocket_echo/` | RFC 6455 WebSocket echo over the connection-takeover seam (`core.queue_takeover` — one engine, two protocols on one connection) |
 | `examples/video_stream/` | HTTP video streaming |
 | `examples/async_sse/` | SSE via async handler (suspend/resume on fd) |
 | `examples/async_db_pg/` | PostgreSQL queries via async handler |

--- a/core/takeover_slot.c.v
+++ b/core/takeover_slot.c.v
@@ -1,0 +1,86 @@
+module core
+
+// V interface to the per-thread connection-takeover hand-off slot (see
+// takeover_slot.h) — the conn-mode seam of issue #136.
+//
+// This is how "one engine, N protocols" happens without the engine importing
+// any protocol: a request handler that decides the connection now speaks a
+// different protocol (RFC 6455 `Upgrade: websocket` today, the http2 preface
+// later) appends its switching response (the 101), queues a ConnHandler here,
+// and returns .done. The worker sends the response and flips the connection's
+// mode; from then on every readable burst is fed to the ConnHandler instead
+// of the HTTP/1.1 state machine. Only a takeover-capable worker (the epoll
+// plain worker) calls enable_takeover(); everywhere else queue_takeover()
+// returns false and the handler must answer an error instead of upgrading.
+
+#include "@VMODROOT/core/takeover_slot.h"
+
+fn C.vanilla_to_enable()
+fn C.vanilla_to_queue(cont voidptr, state voidptr) bool
+fn C.vanilla_to_take(out_cont &voidptr, out_state &voidptr) bool
+
+// ConnHandler drives a taken-over connection: it runs on every readable burst,
+// consumes complete protocol frames from `buf` (a view of the connection's
+// read buffer — copy anything that must outlive the call) and appends response
+// bytes to `out` (the same persistent, batch-flushed write buffer handlers
+// use). It returns how many bytes of `buf` it consumed plus the next Step:
+//
+//   .done  — keep the connection open and wait for more bytes
+//   .close — flush whatever is in `out`, then close the connection
+//
+// A partial frame is expressed by consuming fewer bytes than `buf.len` (or 0):
+// the engine keeps the tail buffered, compacts it to the front, and calls
+// again when more bytes arrive. Consuming nothing while returning .done on a
+// full buffer would spin the connection — the engine closes it if the buffer
+// can no longer grow. `.suspend` is not supported for takeover connections in
+// v1 (treated as .close); push/backpressure choreography composes with the
+// watch primitive as a follow-up (issue #136).
+//
+//   takeover_state — the value passed to queue_takeover (per-connection
+//                    protocol state, e.g. fragmentation reassembly); the
+//                    engine never inspects or frees it
+//   worker_state   — this worker thread's make_state value (nil if unset)
+pub type ConnHandler = fn (buf []u8, mut out []u8, client_fd int, takeover_state voidptr, worker_state voidptr, mut event_loop EventLoop) (int, Step)
+
+// QueuedTakeover is the (handler, state) pair a request handler queued for the
+// connection whose request was just handled.
+pub struct QueuedTakeover {
+pub:
+	cont  ConnHandler = unsafe { nil }
+	state voidptr
+}
+
+// enable_takeover marks the calling worker thread as able to flip a
+// connection's mode. Call once per capable worker (the epoll plain worker).
+@[inline]
+pub fn enable_takeover() {
+	C.vanilla_to_enable()
+}
+
+// queue_takeover hands the current connection over to `cont`: after the
+// handler returns .done, the worker sends whatever the handler appended (the
+// switching response) and routes every subsequent readable burst on this
+// connection to `cont`. Returns false when the running backend cannot take
+// connections over (not the epoll plain worker, or a tcc dev build) — the
+// caller MUST then answer an error (e.g. 501) instead of upgrading, because
+// the peer would otherwise speak a protocol nobody parses.
+@[inline]
+pub fn queue_takeover(cont ConnHandler, takeover_state voidptr) bool {
+	return C.vanilla_to_queue(voidptr(cont), takeover_state)
+}
+
+// take_queued_takeover returns the takeover a handler queued during the
+// request just handled, or none. Always clears the slot, so it never leaks
+// into the next request.
+@[inline]
+pub fn take_queued_takeover() ?QueuedTakeover {
+	mut cont := unsafe { nil }
+	mut state := unsafe { nil }
+	if C.vanilla_to_take(&cont, &state) {
+		return QueuedTakeover{
+			cont:  unsafe { ConnHandler(cont) }
+			state: state
+		}
+	}
+	return none
+}

--- a/core/takeover_slot.h
+++ b/core/takeover_slot.h
@@ -1,0 +1,88 @@
+#ifndef VANILLA_TAKEOVER_SLOT_H
+#define VANILLA_TAKEOVER_SLOT_H
+
+/*
+ * Per-thread hand-off slot for connection takeover (issue #136 — the
+ * conn-mode seam).
+ *
+ * A request handler only receives the socket fd and the write buffer — it has
+ * no reference to the worker's connection state. This slot is the backend-
+ * agnostic channel a handler uses to hand the CONNECTION itself over to a
+ * different state machine (a core.ConnHandler): append the switching response
+ * (e.g. HTTP/1.1 101), queue the takeover, return .done — the worker flips the
+ * connection's mode right after the handler returns. Thread-local like the
+ * sendfile slot: the single-threaded worker owning the connection is the only
+ * reader/writer — no locking.
+ *
+ * The two pointers are opaque to C: `cont` is a V fn pointer (core.ConnHandler)
+ * and `state` is the caller's per-connection protocol state. Both are only
+ * stored and handed back.
+ */
+
+#include <stdbool.h>
+
+#if defined(__TINYC__)
+// tcc cannot codegen thread-local storage (see sendfile_slot.h). Under tcc the
+// slot is compiled INERT: enable is a no-op and queue reports "not taken", so
+// a handler's upgrade attempt degrades to its own fallback (an error response)
+// — correct, just without protocol takeover. -prod keeps the real path.
+static inline void vanilla_to_enable(void) {}
+
+static inline bool vanilla_to_queue(void* cont, void* state) {
+	(void)cont;
+	(void)state;
+	return false;
+}
+
+static inline bool vanilla_to_take(void** out_cont, void** out_state) {
+	(void)out_cont;
+	(void)out_state;
+	return false;
+}
+#else
+
+#if defined(_MSC_VER)
+#define VANILLA_TO_THREAD_LOCAL __declspec(thread)
+#else
+#define VANILLA_TO_THREAD_LOCAL _Thread_local
+#endif
+
+typedef struct vanilla_to_slot {
+	bool  enabled; // worker can flip a connection's mode (set once per capable worker)
+	bool  queued;  // a takeover is waiting to be installed
+	void* cont;    // the core.ConnHandler fn pointer
+	void* state;   // caller-owned per-connection protocol state
+} vanilla_to_slot;
+
+static VANILLA_TO_THREAD_LOCAL vanilla_to_slot vanilla_to = {0};
+
+static inline void vanilla_to_enable(void) {
+	vanilla_to.enabled = true;
+}
+
+static inline bool vanilla_to_queue(void* cont, void* state) {
+	if (!vanilla_to.enabled) {
+		return false;
+	}
+	vanilla_to.cont = cont;
+	vanilla_to.state = state;
+	vanilla_to.queued = true;
+	return true;
+}
+
+// Reads and clears a queued takeover. Returns false (leaving outputs
+// untouched) when nothing is queued. Always clears `queued`, so the slot
+// holds at most one request's hand-off and never leaks into the next request.
+static inline bool vanilla_to_take(void** out_cont, void** out_state) {
+	if (!vanilla_to.queued) {
+		return false;
+	}
+	*out_cont = vanilla_to.cont;
+	*out_state = vanilla_to.state;
+	vanilla_to.queued = false;
+	return true;
+}
+
+#endif // __TINYC__
+
+#endif // VANILLA_TAKEOVER_SLOT_H

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,10 +15,11 @@ import and says nothing). Protocols are **siblings** over one engine:
 | `socket/` | listen side: TCP listeners, Windows sockets; UDS listeners and `peer_cred` (kernel-verified pid/uid/gid, §6); fd passing lands here (§7). |
 | `tls/` | mbedTLS split (`-d vanilla_tls` / stub) — server today, client transports later. |
 | `epoll/` `io_uring/` `kqueue/` `iocp/` | thin per-mechanism syscall wrappers, one dir-module each (`poll/` joins them as the portability floor). |
-| `server/` | **the engine** (was `http_server`) — one engine, N protocols via conn modes. OS facades (`server_linux.c.v`, …) select an `IOBackend`; `server/backend_*` are the reactors. |
+| `server/` | **the engine** (was `http_server`) — one engine, N protocols via conn modes: the takeover seam (issue #136) lets a handler hand a connection to a `core.ConnHandler` (`core.queue_takeover`, epoll-first), so upgrades change the framing authority without changing buffers or backpressure. OS facades (`server_linux.c.v`, …) select an `IOBackend`; `server/backend_*` are the reactors. |
 | `http1_1/` | HTTP/1.1 codecs: `request_parser/`, `response/`; `client/` is the client codec (request serializer + response parser). |
 | `http2/` | frame/hpack/types grow in place: stream mux, flow control, settings. |
-| `websocket/` `grpc/` | reserved siblings (RFC 6455 framing; length-prefixed messages over http2). Future protocols land as siblings here. |
+| `websocket/` | RFC 6455 codec (accept-key, frame head parse, unmask, server frame writers) — pure bytes, zero vanilla imports; an app's `ConnHandler` composes it over the takeover seam (`examples/websocket_echo`). |
+| `grpc/` | reserved sibling (length-prefixed messages over http2). Future protocols land as siblings here. |
 | `static_assets/` `testkit/` `vtest/` `pg_async/` | reusable handler-side and test-side modules. |
 | `transport/` | client-side dialing (`dial_tcp`, `dial_unix`) — bytes + non-blocking fds ONLY; protocol clients compose it (handler → `dial_*` → `event_loop.watch_fd` → `.suspend`), they don't live in it. |
 

--- a/examples/websocket_echo/src/main.v
+++ b/examples/websocket_echo/src/main.v
@@ -1,0 +1,172 @@
+module main
+
+// WebSocket echo — the first consumer of the conn-mode seam (issue #136):
+// one engine, two protocols on the same connection.
+//
+// The HTTP handler stays a pure function of the request. On `GET /ws` with a
+// well-formed RFC 6455 upgrade it appends the `101 Switching Protocols`
+// response, hands the CONNECTION over via core.queue_takeover, and returns
+// `.done` — from that point every readable burst is fed to `ws_echo_conn`
+// (a core.ConnHandler) instead of the HTTP/1.1 state machine. The websocket
+// module is a pure codec: framing/handshake bytes only, composed here.
+//
+// Byte discipline (docs/BEST_PRACTICES.md): const response prefixes,
+// append_accept_key writes base64 straight into the buffer, zero-copy views
+// over the request — no `${}`/`+` anywhere on the serving path.
+import core
+import http1_1.request_parser
+import http1_1.response
+import server
+import websocket
+
+const switching_prefix = 'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: '.bytes()
+const head_end = '\r\n\r\n'.bytes()
+
+const home_response = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 47\r\nConnection: keep-alive\r\n\r\nWebSocket echo: connect a ws:// client to /ws\r\n'.bytes()
+const not_found_response = 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+// 501: this worker/backend cannot take connections over (queue_takeover
+// returned false) — upgrading would leave the peer speaking unparsed frames.
+const cannot_upgrade_response = 'HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
+const bad_upgrade_response = 'HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
+
+// slice_eq compares a request Slice against a small const byte pattern.
+@[direct_array_access]
+fn slice_eq(buf []u8, s request_parser.Slice, want []u8) bool {
+	if s.len != want.len {
+		return false
+	}
+	for i in 0 .. want.len {
+		if buf[s.start + i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+const get_method = 'GET'.bytes()
+const ws_path = '/ws'.bytes()
+const root_path = '/'.bytes()
+const upgrade_websocket = 'websocket'.bytes()
+
+// handle is the HTTP side: routes, validates the upgrade, performs the
+// takeover hand-off. Pure function of the request — testable in-process.
+fn handle(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+	hr := request_parser.decode_http_request(req) or {
+		res << response.tiny_bad_request_response
+		return .close
+	}
+	if !slice_eq(hr.buffer, hr.method, get_method) {
+		res << not_found_response
+		return .done
+	}
+	if slice_eq(hr.buffer, hr.path, root_path) {
+		res << home_response
+		return .done
+	}
+	if !slice_eq(hr.buffer, hr.path, ws_path) {
+		res << not_found_response
+		return .done
+	}
+	// GET /ws — validate the RFC 6455 §4.2.1 client handshake: an Upgrade:
+	// websocket token and a Sec-WebSocket-Key to sign. (A production server
+	// would also check Sec-WebSocket-Version: 13; the echo demo keeps the
+	// checks to what the response depends on.)
+	upgrade := hr.get_header_value_slice('Upgrade') or {
+		res << bad_upgrade_response
+		return .close
+	}
+	if !slice_eq(hr.buffer, upgrade, upgrade_websocket) {
+		res << bad_upgrade_response
+		return .close
+	}
+	key := hr.get_header_value_slice('Sec-WebSocket-Key') or {
+		res << bad_upgrade_response
+		return .close
+	}
+	// The takeover FIRST: only append the 101 if this worker can actually flip
+	// the connection's mode (queue_takeover is false on non-epoll backends and
+	// tcc dev builds — the peer must then get a clear error, not a dead 101).
+	if !core.queue_takeover(ws_echo_conn, unsafe { nil }) {
+		res << cannot_upgrade_response
+		return .close
+	}
+	res << switching_prefix
+	websocket.append_accept_key(mut res, unsafe { tos(&hr.buffer[key.start], key.len) })
+	res << head_end
+	return .done
+}
+
+// ws_echo_conn drives the connection after the upgrade: a core.ConnHandler fed
+// every readable burst. Echoes text/binary frames, answers pings with pongs,
+// completes the close handshake. Also a pure function — unit-tested with raw
+// frame bytes in main_test.v.
+fn ws_echo_conn(buf []u8, mut out []u8, client_fd int, takeover_state voidptr, worker_state voidptr, mut event_loop core.EventLoop) (int, core.Step) {
+	mut consumed := 0
+	for consumed < buf.len {
+		mut rest := unsafe { (&buf[consumed]).vbytes(buf.len - consumed) }
+		h := websocket.frame_head(rest)
+		if h.total == websocket.incomplete {
+			break // partial frame — the engine buffers the tail and re-calls
+		}
+		if h.total == websocket.err_malformed || !h.masked {
+			// Framing violation, or an unmasked client frame (RFC 6455 §5.1
+			// requires the server to fail the connection).
+			websocket.write_close(mut out, websocket.close_protocol_error)
+			return consumed, core.Step.close
+		}
+		websocket.unmask_in_place(mut rest, h)
+		payload := if h.payload_len > 0 {
+			unsafe { (&rest[h.payload_off]).vbytes(h.payload_len) }
+		} else {
+			[]u8{}
+		}
+		match h.opcode {
+			websocket.op_text, websocket.op_binary {
+				if !h.fin {
+					// The demo echoes whole messages only; reassembling
+					// fragmented messages is an application concern (the codec
+					// exposes fin/opcode for it).
+					websocket.write_close(mut out, websocket.close_unsupported)
+					return consumed, core.Step.close
+				}
+				websocket.write_frame_header(mut out, h.opcode, h.payload_len)
+				out << payload
+			}
+			websocket.op_ping {
+				websocket.write_pong(mut out, payload)
+			}
+			websocket.op_pong {
+				// unsolicited pong — ignored (RFC 6455 §5.5.3 allows it)
+			}
+			websocket.op_close {
+				websocket.write_close(mut out, websocket.close_normal)
+				return consumed + h.total, core.Step.close
+			}
+			else {
+				// op_cont with no message in flight (the fin=false path above
+				// already closed) — protocol error.
+				websocket.write_close(mut out, websocket.close_protocol_error)
+				return consumed, core.Step.close
+			}
+		}
+
+		consumed += h.total
+	}
+	return consumed, core.Step.done
+}
+
+fn main() {
+	// The takeover seam is epoll-first (issue #136): elsewhere queue_takeover
+	// reports false and /ws answers 501 instead of a dead upgrade.
+	mut backend := unsafe { server.IOBackend(0) }
+	$if linux {
+		backend = server.IOBackend.epoll
+	}
+	mut srv := server.new_server(server.ServerConfig{
+		port:            3000
+		io_multiplexing: backend
+		handler:         handle
+	})!
+	println('WebSocket echo on ws://localhost:3000/ws')
+	srv.run()
+}

--- a/examples/websocket_echo/src/main_test.v
+++ b/examples/websocket_echo/src/main_test.v
@@ -1,0 +1,126 @@
+module main
+
+import core
+import websocket
+
+// Both halves of the example are pure functions, so both are unit-testable
+// with raw bytes and no sockets: `handle` (the HTTP side — routing, upgrade
+// validation, the 501 fallback when no takeover-capable worker runs) and
+// `ws_echo_conn` (the post-upgrade ConnHandler — echo, ping/pong, close,
+// partial-frame and protocol-violation behaviour). The full upgrade hand-off
+// through a real epoll worker is covered in server_end_to_end_test.v.
+
+fn serve(req string) string {
+	mut out := []u8{}
+	mut event_loop := core.EventLoop{}
+	handle(req.bytes(), mut out, -1, unsafe { nil }, mut event_loop)
+	return out.bytestr()
+}
+
+fn test_routes() {
+	assert serve('GET / HTTP/1.1\r\nHost: x\r\n\r\n').contains('200 OK')
+	assert serve('GET /nope HTTP/1.1\r\nHost: x\r\n\r\n').contains('404')
+	assert serve('POST /ws HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n').contains('404')
+}
+
+fn test_upgrade_needs_wellformed_handshake() {
+	// No Upgrade header / no key -> 400, connection closed.
+	assert serve('GET /ws HTTP/1.1\r\nHost: x\r\n\r\n').contains('400')
+	assert serve('GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\n\r\n').contains('400')
+	assert serve('GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: h2c\r\nSec-WebSocket-Key: aaaa\r\n\r\n').contains('400')
+}
+
+fn test_upgrade_without_capable_worker_is_501() {
+	// This test binary never calls core.enable_takeover(), so queue_takeover
+	// reports false — exactly the situation on a non-epoll backend. The
+	// handler must answer an explicit 501, never a dead 101.
+	got :=
+		serve('GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n')
+	assert got.contains('501'), got
+	assert !got.contains('101'), 'must not promise an upgrade nobody will serve: ${got}'
+}
+
+// --- ws_echo_conn (the post-upgrade ConnHandler) ---------------------------
+
+fn echo_step(frame []u8) (int, core.Step, []u8) {
+	mut out := []u8{}
+	mut event_loop := core.EventLoop{}
+	mut buf := frame.clone() // the handler unmasks in place
+	consumed, step := ws_echo_conn(buf, mut out, -1, unsafe { nil }, unsafe { nil }, mut event_loop)
+	return consumed, step, out
+}
+
+// RFC 6455 §5.7's masked "Hello" text frame.
+const rfc_hello_masked = [u8(0x81), 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58]
+
+fn test_echo_text_frame() {
+	consumed, step, out := echo_step(rfc_hello_masked)
+	assert consumed == rfc_hello_masked.len
+	assert step == .done
+	// Echo comes back as an UNMASKED server frame: 0x81 0x05 "Hello".
+	assert out == [u8(0x81), 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
+}
+
+fn test_two_frames_one_burst_and_partial_tail() {
+	mut buf := rfc_hello_masked.clone()
+	buf << rfc_hello_masked
+	buf << rfc_hello_masked[..4] // a partial third frame stays unconsumed
+	consumed, step, out := echo_step(buf)
+	assert consumed == 2 * rfc_hello_masked.len
+	assert step == .done
+	assert out.len == 2 * 7
+}
+
+fn test_ping_answered_with_pong() {
+	// Masked ping carrying "ka": pong must echo the payload (RFC 6455 §5.5.3).
+	key := [u8(0x11), 0x22, 0x33, 0x44]
+	mut ping := [u8(0x89), 0x82]
+	ping << key
+	ping << [u8(`k`) ^ key[0], u8(`a`) ^ key[1]]
+	consumed, step, out := echo_step(ping)
+	assert consumed == ping.len
+	assert step == .done
+	assert out == [u8(0x8a), 0x02, `k`, `a`]
+}
+
+fn test_close_handshake() {
+	// Masked close frame (code 1000) -> close reply + .close.
+	key := [u8(0x01), 0x02, 0x03, 0x04]
+	mut close_frame := [u8(0x88), 0x82]
+	close_frame << key
+	close_frame << [u8(0x03) ^ key[0], u8(0xe8) ^ key[1]]
+	consumed, step, out := echo_step(close_frame)
+	assert consumed == close_frame.len
+	assert step == .close
+	assert out == [u8(0x88), 0x02, 0x03, 0xe8]
+}
+
+fn test_unmasked_client_frame_fails_connection() {
+	// RFC 6455 §5.1: server MUST fail the connection on an unmasked frame.
+	consumed, step, out := echo_step([u8(0x81), 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f])
+	assert consumed == 0
+	assert step == .close
+	h := websocket.frame_head(out)
+	assert h.opcode == websocket.op_close
+	assert int(out[h.payload_off]) << 8 | int(out[h.payload_off + 1]) == 1002
+}
+
+fn test_partial_frame_consumes_nothing() {
+	consumed, step, out := echo_step(rfc_hello_masked[..3])
+	assert consumed == 0
+	assert step == .done
+	assert out.len == 0
+}
+
+fn test_fragmented_message_rejected_by_demo() {
+	// fin=0 text frame: the demo answers close 1003 (whole-message echo only).
+	key := [u8(0x0a), 0x0b, 0x0c, 0x0d]
+	mut frag := [u8(0x01), 0x81]
+	frag << key
+	frag << [u8(`x`) ^ key[0]]
+	_, step, out := echo_step(frag)
+	assert step == .close
+	h := websocket.frame_head(out)
+	assert h.opcode == websocket.op_close
+	assert int(out[h.payload_off]) << 8 | int(out[h.payload_off + 1]) == 1003
+}

--- a/examples/websocket_echo/src/server_end_to_end_test.v
+++ b/examples/websocket_echo/src/server_end_to_end_test.v
@@ -1,0 +1,149 @@
+module main
+
+// End-to-end proof of the conn-mode seam (issue #136) through a real epoll
+// worker, on vtest: the same connection speaks HTTP/1.1 (the upgrade
+// request), then RFC 6455 frames — including the seam's trickiest ordering,
+// frames pipelined in the SAME segment as the upgrade request. Raw bytes in
+// scripts, until-predicates over raw bytes out (WebSocket frames are not
+// Content-Length-framed, so `want` counting never applies here).
+// Linux-only invocation: the takeover seam is epoll-first.
+import server
+import vtest
+
+const hs = 'GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n'.bytes()
+
+// The RFC 6455 §1.3 accept value for the key above — seeing it in the 101
+// asserts the whole handshake end-to-end.
+const rfc_accept = 's3pPLMBiTxaQ9kYGzzhZRbK+xOo='
+
+// masked_frame builds a client frame (test scaffolding — clients mask).
+fn masked_frame(opcode u8, payload string) []u8 {
+	key := [u8(0x37), 0xfa, 0x21, 0x3d]
+	mut f := []u8{cap: 6 + payload.len}
+	f << (u8(0x80) | opcode)
+	f << u8(0x80 | payload.len) // test payloads are always < 126
+	f << key
+	for i, c in payload.bytes() {
+		f << (c ^ key[i & 3])
+	}
+	return f
+}
+
+fn index_bytes(acc []u8, needle []u8) int {
+	if needle.len == 0 || acc.len < needle.len {
+		return -1
+	}
+	for i := 0; i <= acc.len - needle.len; i++ {
+		mut hit := true
+		for j in 0 .. needle.len {
+			if acc[i + j] != needle[j] {
+				hit = false
+				break
+			}
+		}
+		if hit {
+			return i
+		}
+	}
+	return -1
+}
+
+// until_bytes packages "this exact byte sequence arrived" as a Round predicate.
+fn until_bytes(needle []u8) fn (acc []u8) bool {
+	return fn [needle] (acc []u8) bool {
+		return index_bytes(acc, needle) >= 0
+	}
+}
+
+// hs_with_pipelined_frame is the seam's ordering probe: the upgrade request
+// and a websocket frame in ONE client write.
+fn hs_with_pipelined_frame() []u8 {
+	mut b := []u8{cap: hs.len + 16}
+	b << hs
+	b << masked_frame(0x1, 'pipelined')
+	return b
+}
+
+// Server close frames the demo sends: normal (1000) and protocol-error (1002).
+const close_normal_frame = [u8(0x88), 0x02, 0x03, 0xe8]
+const close_protocol_frame = [u8(0x88), 0x02, 0x03, 0xea]
+
+fn test_websocket_echo_end_to_end() {
+	$if linux {
+		out := vtest.drive(server.ServerConfig{
+			io_multiplexing: .epoll
+			handler:         handle
+		}, [
+			// Conn 0 — the full choreography, one round per protocol step:
+			// handshake -> echo -> ping/pong -> close handshake -> server EOF.
+			vtest.Script{
+				rounds:   [
+					vtest.Round{
+						send:  hs
+						until: vtest.count(rfc_accept, 1)
+					},
+					vtest.Round{
+						send:  masked_frame(0x1, 'hello over the seam')
+						until: until_bytes([u8(0x81), 0x13]) // unmasked echo header, len 19
+					},
+					vtest.Round{
+						send:  masked_frame(0x9, 'ka')
+						until: until_bytes([u8(0x8a), 0x02, `k`, `a`]) // the pong
+					},
+					vtest.Round{
+						send:  masked_frame(0x8, '\x03\xe8') // close, code 1000
+						until: until_bytes(close_normal_frame)
+					},
+				]
+				then_eof: true
+			},
+			// Conn 1 — handshake AND a frame in ONE write: the frame bytes sit
+			// behind the upgrade request in the same segment, so they MUST be
+			// consumed by the takeover drain, not the HTTP parser (the seam's
+			// ordering rule).
+			vtest.Script{
+				rounds: [
+					vtest.Round{
+						send:  hs_with_pipelined_frame()
+						until: until_bytes([u8(0x81), 0x09, `p`, `i`, `p`, `e`, `l`, `i`, `n`,
+							`e`, `d`])
+					},
+				]
+			},
+			// Conn 2 — an UNMASKED client frame after the handshake: the server
+			// must fail the connection (close 1002 + EOF), RFC 6455 §5.1.
+			vtest.Script{
+				rounds:   [
+					vtest.Round{
+						send:  hs
+						until: vtest.count(rfc_accept, 1)
+					},
+					vtest.Round{
+						send:  [u8(0x81), 0x02, `h`, `i`] // unmasked — a violation
+						until: until_bytes(close_protocol_frame)
+					},
+				]
+				then_eof: true
+			},
+		]) or {
+			assert false, err.msg()
+			return
+		}
+		full := out.conns[0]
+		assert full.connect_err == '', full.connect_err
+		assert !full.unmet, 'choreography ended early: ${full.raw.bytestr()}'
+		assert full.eof, 'server must close after the close handshake'
+		echoed := index_bytes(full.raw, 'hello over the seam'.bytes())
+		assert echoed >= 0, 'echo payload missing'
+
+		pipelined := out.conns[1]
+		assert pipelined.connect_err == '', pipelined.connect_err
+		assert !pipelined.unmet, 'pipelined-behind-upgrade frame lost: ${pipelined.raw.bytestr()}'
+
+		violated := out.conns[2]
+		assert violated.connect_err == '', violated.connect_err
+		assert !violated.unmet
+		assert violated.eof, 'an unmasked client frame must end the connection'
+		assert out.inflight_after == 0
+	}
+}

--- a/server/backend_epoll/async_linux.c.v
+++ b/server/backend_epoll/async_linux.c.v
@@ -346,6 +346,13 @@ fn handle_readable(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, li
 		}
 		return
 	}
+	// The conn-mode seam (issue #136): a taken-over connection's bytes belong to
+	// its ConnHandler, not the HTTP/1.1 state machine. nil for every connection
+	// that never upgraded — one predictable branch on the hot path.
+	if cs.takeover != unsafe { nil } {
+		serve_takeover_conn(mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs, state)
+		return
+	}
 	serve_conn(h, mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs, state)
 }
 
@@ -381,6 +388,19 @@ fn serve_conn(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, limits 
 			if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
 				flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
 			}
+			return
+		}
+		if cs.takeover != unsafe { nil } {
+			// A buffered request upgraded the connection (issue #136): flush the
+			// switching response, then the takeover drain owns the leftover bytes
+			// and the socket.
+			if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
+				if !flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+					return
+				}
+			}
+			serve_takeover_conn(mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs,
+				state)
 			return
 		}
 	}
@@ -458,6 +478,9 @@ fn serve_conn(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, limits 
 		if cs.awaiting_fd >= 0 {
 			break // a request parked on a watch — stop reading until it resumes
 		}
+		if cs.takeover != unsafe { nil } {
+			break // upgraded mid-burst — flush the 101 below, then hand the socket off
+		}
 		if cs.read_buf.len > req_cap {
 			cs.write_buf << response.status_413_response
 			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
@@ -500,10 +523,18 @@ fn serve_conn(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, limits 
 		// send nothing more.
 		if cs.close_after_flush && cs.write_off >= cs.write_buf.len && cs.file_remaining <= 0 {
 			close_conn(epoll_fd, fd, active_conns, mut st)
+			return
 		}
 	} else if cs.close_after_flush {
 		// EOF with nothing left to flush (already sent) — close.
 		close_conn(epoll_fd, fd, active_conns, mut st)
+		return
+	}
+	// Upgraded mid-burst (the takeover break above): the switching response just
+	// flushed; the takeover drain now consumes any bytes pipelined behind the
+	// upgrade request and reads the socket to EAGAIN (edge-triggered contract).
+	if cs.takeover != unsafe { nil } {
+		serve_takeover_conn(mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs, state)
 	}
 }
 
@@ -527,6 +558,128 @@ fn update_read_deadline(limits core.Limits, mut st PlainState, mut cs ConnState)
 		cs.read_deadline = 0
 		st.parked--
 	}
+}
+
+// serve_takeover_conn drives a taken-over connection (issue #136): drain any
+// buffered bytes through the ConnHandler, then recv to EAGAIN (edge-triggered
+// contract), draining as bytes arrive, and flush the batch at the end. The
+// same persistent buffers, EPOLLOUT backpressure parking and timeout sweep as
+// the HTTP path — only the framing authority changed.
+@[direct_array_access; manualfree]
+fn serve_takeover_conn(mut reactor Reactor, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState, state voidptr) {
+	req_cap := if limits.max_request_bytes > 0 {
+		limits.max_request_bytes
+	} else {
+		sm_max_request_bytes
+	}
+	// Bytes pipelined behind the upgrade request (or left from the previous
+	// burst) first — no readable edge is coming for them (vanilla#100 lesson).
+	if cs.read_buf.len > 0 {
+		if !drain_takeover(mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs, state) {
+			return
+		}
+	}
+	for {
+		if cs.read_buf.len == cs.read_buf.cap {
+			// A single frame larger than the request-buffer ceiling can never
+			// complete — the engine's own bound, mirroring the HTTP 413 path.
+			if cs.read_buf.cap >= req_cap {
+				close_conn(epoll_fd, fd, active_conns, mut st)
+				return
+			}
+			growth := if cs.read_buf.cap > req_cap - cs.read_buf.cap {
+				req_cap - cs.read_buf.cap
+			} else {
+				cs.read_buf.cap
+			}
+			unsafe { cs.read_buf.grow_cap(growth) }
+		}
+		spare := cs.read_buf.cap - cs.read_buf.len
+		n := C.recv(fd, unsafe { &u8(cs.read_buf.data) + cs.read_buf.len }, usize(spare), 0)
+		if n < 0 {
+			if C.errno == C.EAGAIN || C.errno == C.EWOULDBLOCK {
+				break
+			}
+			close_conn(epoll_fd, fd, active_conns, mut st)
+			return
+		}
+		if n == 0 {
+			// Peer EOF. A taken-over protocol has its own close choreography (the
+			// ConnHandler answers close frames with .close); a bare EOF means the
+			// peer is gone — nothing left to say, close.
+			close_conn(epoll_fd, fd, active_conns, mut st)
+			return
+		}
+		unsafe {
+			cs.read_buf.len += n
+		}
+		if !drain_takeover(mut reactor, epoll_fd, fd, limits, active_conns, mut st, mut cs, state) {
+			return
+		}
+	}
+	// A partial frame arms the read deadline; an idle (empty-buffer) connection
+	// clears it — so read_timeout_ms reaps a peer stalled MID-FRAME but never a
+	// quiet long-lived connection between messages.
+	update_read_deadline(limits, mut st, mut cs)
+	if cs.write_buf.len > cs.write_off {
+		flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
+	}
+}
+
+// drain_takeover feeds the buffered bytes to the connection's ConnHandler until
+// it stops consuming (partial frame) or the buffer empties. Mirrors
+// drain_requests' shape: consumed bytes are compacted away, responses batch in
+// write_buf, and the pending-write cap bounds a peer that floods frames without
+// reading. Returns false if the connection was closed.
+@[direct_array_access; manualfree]
+fn drain_takeover(mut reactor Reactor, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState, state voidptr) bool {
+	mut event_loop := core.EventLoop{
+		client_fd: fd
+		loop_fd:   epoll_fd
+		reactor:   unsafe { voidptr(&reactor) }
+		register:  register_watch
+	}
+	for cs.read_buf.len > 0 {
+		event_loop.last_watched = -1
+		mut consumed, step := cs.takeover(buf_view(cs.read_buf, 0, cs.read_buf.len), mut
+			cs.write_buf, fd, cs.takeover_state, state, mut event_loop)
+		if event_loop.last_watched >= 0 {
+			// v1: takeover connections cannot park (.suspend unsupported, issue
+			// #136) — any watch a ConnHandler armed is a contract violation; tear
+			// it down before it can fire against a reused client_fd.
+			detach_rejected_watch(mut reactor, epoll_fd, event_loop.last_watched, fd)
+		}
+		if consumed > cs.read_buf.len {
+			consumed = cs.read_buf.len // defensive: never compact past the buffer
+		}
+		if consumed > 0 {
+			compact_read_buf(mut cs, consumed)
+		}
+		match step {
+			.done {
+				if consumed == 0 {
+					return true // partial frame — wait for more bytes
+				}
+				// consumed > 0: more complete frames may still be buffered — loop.
+			}
+			else {
+				// .close — and .suspend (unsupported in v1) degrades to it: flush
+				// what the handler appended (e.g. its close frame), then close.
+				if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+					close_conn(epoll_fd, fd, active_conns, mut st)
+				}
+				return false
+			}
+		}
+
+		if cs.write_buf.len - cs.write_off > sm_max_pending_write {
+			if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+				close_conn(epoll_fd, fd, active_conns, mut st)
+			}
+			return false
+		}
+	}
+	return true
 }
 
 // start_body_drain answers a large-body request from its HEAD alone, then
@@ -562,7 +715,16 @@ fn start_body_drain(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, l
 		reactor:   unsafe { voidptr(&reactor) }
 		register:  register_watch
 	}
-	if h(head, mut cs.write_buf, fd, state, mut event_loop) != .done {
+	head_step := h(head, mut cs.write_buf, fd, state, mut event_loop)
+	// A takeover queued on the streamed large-body path is unsupported (the body
+	// is still in flight — there is no clean byte at which the protocol could
+	// change): drain the thread-local slot and treat it like the suspend case
+	// below — 400 and drop, never a half-upgraded connection.
+	mut streamed_takeover := false
+	if _ := core.take_queued_takeover() {
+		streamed_takeover = true
+	}
+	if head_step != .done || streamed_takeover {
 		// suspend/close on a streamed-body request is unsupported in v1 — answer
 		// 400 and drop, rather than leave a half-drained connection parked. The
 		// handler may ALREADY have registered a watch (and submitted a query)
@@ -653,6 +815,11 @@ fn drain_requests(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, lim
 			// later fire against this (soon-reused) client_fd.
 			detach_rejected_watch(mut reactor, epoll_fd, event_loop.last_watched, fd)
 		}
+		// Drain the takeover slot on EVERY step, not just .done: it is
+		// thread-local, so a handler that queued and then suspended/closed
+		// (a contract violation) must not leak its takeover into the next
+		// request this worker serves. nil cont = nothing was queued.
+		qt := core.take_queued_takeover() or { core.QueuedTakeover{} }
 		match step {
 			.done {
 				// Handler may have appended headers + handed its body off for
@@ -661,6 +828,15 @@ fn drain_requests(h core.Handler, mut reactor Reactor, epoll_fd int, fd int, lim
 					cs.file_fd = qf.file_fd
 					cs.file_off = qf.off
 					cs.file_remaining = qf.len
+				}
+				// ...or handed the CONNECTION off (issue #136): from here on the
+				// bytes are no longer HTTP — stop parsing this burst as requests.
+				// The leftover stays buffered (compacted below) for the takeover
+				// drain, which runs after the switching response flushes.
+				if qt.cont != unsafe { nil } {
+					cs.takeover = qt.cont
+					cs.takeover_state = qt.state
+					break
 				}
 			}
 			.suspend {
@@ -751,6 +927,10 @@ fn on_watch_ready(h core.Handler, mut reactor Reactor, epoll_fd int, ext_fd int,
 			register:  register_watch
 		}
 		step := cont(mut scratch, ext_fd, ready_err, entry_udata, state, mut bg_loop)
+		// A clientless watch has no connection to take over — drain the
+		// thread-local slot so a misbehaving continuation can't leak one.
+		if _ := core.take_queued_takeover() {
+		}
 		if step == .suspend && bg_loop.last_watched == ext_fd {
 			return
 		}
@@ -785,8 +965,27 @@ fn on_watch_ready(h core.Handler, mut reactor Reactor, epoll_fd int, ext_fd int,
 		// tear the stray watch down before the connection moves on / is closed.
 		detach_rejected_watch(mut reactor, epoll_fd, event_loop.last_watched, client_fd)
 	}
+	// Drain the takeover slot on every step (thread-local — a queued takeover
+	// must never leak into another request). On .done this is the ASYNC upgrade
+	// path: a handler that parked (e.g. an auth check against an upstream) and
+	// whose continuation appended the 101 + queued the takeover.
+	qt := core.take_queued_takeover() or { core.QueuedTakeover{} }
 	match cont_step {
 		.done {
+			if qt.cont != unsafe { nil } {
+				cs.takeover = qt.cont
+				cs.takeover_state = qt.state
+				// Flush the switching response, then the takeover drain owns the
+				// leftover buffered bytes and the socket.
+				if cs.write_buf.len > cs.write_off {
+					if !flush_batch(epoll_fd, client_fd, limits, active_conns, mut st, mut cs) {
+						return
+					}
+				}
+				serve_takeover_conn(mut reactor, epoll_fd, client_fd, limits, active_conns, mut st, mut
+					cs, state)
+				return
+			}
 			// Send this response and drain any requests that were pipelined behind it
 			// (and read anything that arrived while parked) — one batched flush.
 			serve_conn(h, mut reactor, epoll_fd, client_fd, limits, active_conns, mut st, mut cs,
@@ -846,6 +1045,9 @@ fn drain_pipelined(h core.Handler, mut reactor Reactor, epoll_fd int, ext_fd int
 			reactor.rearming_dead = true
 			dead_step := slot.cont(mut scratch, ext_fd, ready_err, slot.udata, state, mut dead_loop)
 			reactor.rearming_dead = false
+			// A dead client cannot be taken over — drain the thread-local slot.
+			if _ := core.take_queued_takeover() {
+			}
 			if dead_step == .suspend {
 				break // result not ready yet — the tombstone stays at the head
 			}
@@ -870,6 +1072,8 @@ fn drain_pipelined(h core.Handler, mut reactor Reactor, epoll_fd int, ext_fd int
 			// this same queue slot, which the .done/.close arms below then pop.)
 			detach_rejected_watch(mut reactor, epoll_fd, event_loop.last_watched, client_fd)
 		}
+		// Same slot discipline as on_watch_ready: drain per step, install on .done.
+		qt := core.take_queued_takeover() or { core.QueuedTakeover{} }
 		match pipelined_step {
 			.done {
 				// Pop BEFORE serving: serve_conn may read a request pipelined behind
@@ -881,6 +1085,18 @@ fn drain_pipelined(h core.Handler, mut reactor Reactor, epoll_fd int, ext_fd int
 				// its watch and stranding the request forever (vanilla#100 hazard 1).
 				reactor.watches[ext_fd].queue.delete(0)
 				reactor.reactor_clear_if_drained(ext_fd)
+				if qt.cont != unsafe { nil } {
+					cs.takeover = qt.cont
+					cs.takeover_state = qt.state
+					if cs.write_buf.len > cs.write_off {
+						if !flush_batch(epoll_fd, client_fd, limits, active_conns, mut st, mut cs) {
+							continue
+						}
+					}
+					serve_takeover_conn(mut reactor, epoll_fd, client_fd, limits, active_conns, mut
+						st, mut cs, state)
+					continue
+				}
 				serve_conn(h, mut reactor, epoll_fd, client_fd, limits, active_conns, mut st, mut
 					cs, state)
 			}

--- a/server/backend_epoll/conn_state_linux.c.v
+++ b/server/backend_epoll/conn_state_linux.c.v
@@ -127,6 +127,16 @@ mut:
 	// connection (a keep-alive connection may carry several Expect requests, but
 	// only one is ever mid-read at a time, and close_conn clears it).
 	sent_100 bool
+	// The conn-mode seam (issue #136): nil (the default) means the HTTP/1.1
+	// state machine drives this connection — the hot path pays exactly one
+	// predictable nil-check in handle_readable. Set (via core.queue_takeover
+	// from an upgrade handler, e.g. RFC 6455 `Upgrade: websocket`) it is the
+	// ConnHandler every subsequent readable burst is fed to instead; the read
+	// buffer, batched flush, EPOLLOUT backpressure and timeout machinery are
+	// all reused unchanged. takeover_state is the caller's per-connection
+	// protocol state, handed back on every call, never inspected here.
+	takeover       core.ConnHandler = unsafe { nil }
+	takeover_state voidptr
 }
 
 // PlainState is the per-worker connection table. `parked` counts connections
@@ -398,7 +408,11 @@ fn sweep_timeouts(epoll_fd int, active_conns &core.Counter, mut st PlainState) {
 			continue
 		}
 		if cs.read_deadline > 0 && now > cs.read_deadline {
-			response.send_status_408_response(fd) // couldn't finish the request in time
+			// A taken-over connection no longer speaks HTTP — the 408 bytes
+			// would be protocol garbage to its peer; just close.
+			if cs.takeover == unsafe { nil } {
+				response.send_status_408_response(fd) // couldn't finish the request in time
+			}
 			close_conn(epoll_fd, fd, active_conns, mut st)
 		} else if cs.write_deadline > 0 && now > cs.write_deadline {
 			close_conn(epoll_fd, fd, active_conns, mut st)
@@ -444,6 +458,8 @@ fn close_conn(epoll_fd int, fd int, active_conns &core.Counter, mut st PlainStat
 			cs.awaiting_fd = -1
 			cs.close_after_flush = false
 			cs.sent_100 = false
+			cs.takeover = unsafe { nil }
+			cs.takeover_state = unsafe { nil }
 			st.conns[fd] = unsafe { nil }
 			st.free_conns << cs
 		}

--- a/server/backend_epoll/worker_linux.c.v
+++ b/server/backend_epoll/worker_linux.c.v
@@ -135,6 +135,9 @@ fn process_events_plain(worker_id int, epoll_fd int, handler core.Handler, make_
 	// This worker can stream file bodies with sendfile(2): let handlers hand a
 	// file off via core.queue_file instead of copying it through write_buf.
 	core.enable_sendfile()
+	// ...and it can hand a connection over to another protocol's state machine
+	// (the conn-mode seam, issue #136): handlers upgrade via core.queue_takeover.
+	core.enable_takeover()
 	mut events := [socket.max_connection_size]C.epoll_event{}
 	mut st := new_plain_state()
 	// Arm clientless background watches (timerfd refresh, signalfd, ...) on THIS

--- a/websocket/websocket.v
+++ b/websocket/websocket.v
@@ -1,0 +1,220 @@
+module websocket
+
+// RFC 6455 WebSocket codec — pure functions over bytes, nothing else (the
+// protocol-sibling promised in docs/ARCHITECTURE.md, landed with issue #136's
+// connection-takeover seam). No vanilla imports, no I/O, no state: the frame
+// parser mirrors http1_1.client.frame_response (complete-message framing with
+// int sentinels), the writers append straight into the caller's `out` buffer,
+// and per-connection concerns (fragmentation reassembly, close handshakes)
+// belong to the ConnHandler composing this codec.
+//
+// Server-side reminders the codec exposes but does NOT enforce (they are
+// direction-specific, and this codec also serves future client use):
+//   - a server MUST fail the connection on an UNMASKED client frame
+//     (RFC 6455 §5.1) — check FrameHead.masked;
+//   - server→client frames are sent UNMASKED — the writers below do that.
+import crypto.sha1
+import encoding.base64
+
+// Frame opcodes (RFC 6455 §5.2).
+pub const op_cont = u8(0x0)
+pub const op_text = u8(0x1)
+pub const op_binary = u8(0x2)
+pub const op_close = u8(0x8)
+pub const op_ping = u8(0x9)
+pub const op_pong = u8(0xa)
+
+// Close status codes (RFC 6455 §7.4.1) — the ones a minimal server sends.
+pub const close_normal = u16(1000)
+pub const close_protocol_error = u16(1002)
+pub const close_unsupported = u16(1003)
+pub const close_too_big = u16(1009)
+
+// frame_head sentinels (FrameHead.total), matching http1_1.client's idiom.
+pub const incomplete = -1
+pub const err_malformed = -2
+
+// A single frame's payload is capped server-side: bigger is err_malformed. A
+// peer needing more sends fragments (fin=0 + continuations). Bounds what one
+// frame can force the connection to buffer.
+pub const max_frame_payload = 16 * 1024 * 1024
+
+const ws_guid = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+
+// FrameHead describes one complete frame at the start of a buffer. Offsets
+// index into that same buffer — the payload is a view, never a copy.
+pub struct FrameHead {
+pub:
+	total       int // whole frame length (header + payload); incomplete / err_malformed
+	payload_off int
+	payload_len int
+	opcode      u8
+	fin         bool
+	masked      bool
+	mask_off    int // offset of the 4-byte masking key (valid only when masked)
+}
+
+// frame_head parses the frame starting at buf[0]. total == incomplete while
+// the FULL frame (header + payload) has not arrived yet — accumulate and call
+// again; err_malformed on a protocol violation (RSV bits without a negotiated
+// extension, reserved opcode, fragmented or oversized control frame,
+// non-minimal or oversized length encoding — RFC 6455 §5.2): fail the
+// connection, these are unrecoverable framing errors.
+@[direct_array_access]
+pub fn frame_head(buf []u8) FrameHead {
+	if buf.len < 2 {
+		return FrameHead{
+			total: incomplete
+		}
+	}
+	b0 := buf[0]
+	if b0 & 0x70 != 0 {
+		return FrameHead{
+			total: err_malformed
+		} // RSV set, no extension negotiated
+	}
+	opcode := b0 & 0x0f
+	if (opcode > 0x2 && opcode < 0x8) || opcode > 0xa {
+		return FrameHead{
+			total: err_malformed
+		} // reserved opcode
+	}
+	fin := b0 & 0x80 != 0
+	is_control := opcode & 0x8 != 0
+	masked := buf[1] & 0x80 != 0
+	len7 := int(buf[1] & 0x7f)
+	mut off := 2
+	mut payload_len := len7
+	if is_control && (!fin || len7 > 125) {
+		return FrameHead{
+			total: err_malformed
+		} // control frames: unfragmented, <= 125 (RFC 6455 §5.5)
+	}
+	if len7 == 126 {
+		if buf.len < off + 2 {
+			return FrameHead{
+				total: incomplete
+			}
+		}
+		payload_len = int(buf[off]) << 8 | int(buf[off + 1])
+		if payload_len < 126 {
+			return FrameHead{
+				total: err_malformed
+			} // non-minimal encoding
+		}
+		off += 2
+	} else if len7 == 127 {
+		if buf.len < off + 8 {
+			return FrameHead{
+				total: incomplete
+			}
+		}
+		mut len64 := u64(0)
+		for i in 0 .. 8 {
+			len64 = len64 << 8 | u64(buf[off + i])
+		}
+		if len64 < 65536 || len64 > u64(max_frame_payload) {
+			// non-minimal encoding, MSB set, or beyond what we will buffer
+			return FrameHead{
+				total: err_malformed
+			}
+		}
+		payload_len = int(len64)
+		off += 8
+	}
+	if payload_len > max_frame_payload {
+		return FrameHead{
+			total: err_malformed
+		}
+	}
+	mask_off := off
+	if masked {
+		off += 4
+	}
+	if buf.len < off || i64(buf.len) < i64(off) + i64(payload_len) {
+		return FrameHead{
+			total: incomplete
+		}
+	}
+	return FrameHead{
+		total:       off + payload_len
+		payload_off: off
+		payload_len: payload_len
+		opcode:      opcode
+		fin:         fin
+		masked:      masked
+		mask_off:    mask_off
+	}
+}
+
+// unmask_in_place XORs the frame's payload with its masking key, in the same
+// buffer frame_head parsed — after it, buf[payload_off .. payload_off +
+// payload_len] is the plain payload view. No-op on an unmasked frame.
+@[direct_array_access]
+pub fn unmask_in_place(mut buf []u8, h FrameHead) {
+	if !h.masked {
+		return
+	}
+	for i in 0 .. h.payload_len {
+		buf[h.payload_off + i] ^= buf[h.mask_off + (i & 3)]
+	}
+}
+
+// write_frame_header appends a server→client frame header (FIN set, unmasked
+// — RFC 6455 §5.1 forbids masking server frames) for a payload of
+// `payload_len` bytes; append the payload right after. Fragmented sends are a
+// caller concern (write op_cont headers yourself) — v1 keeps the writer to
+// the whole-message case.
+@[direct_array_access]
+pub fn write_frame_header(mut out []u8, opcode u8, payload_len int) {
+	out << (u8(0x80) | opcode)
+	if payload_len <= 125 {
+		out << u8(payload_len)
+	} else if payload_len <= 0xffff {
+		out << u8(126)
+		out << u8(payload_len >> 8)
+		out << u8(payload_len & 0xff)
+	} else {
+		out << u8(127)
+		mut shift := 56
+		for _ in 0 .. 8 {
+			out << u8((u64(payload_len) >> shift) & 0xff)
+			shift -= 8
+		}
+	}
+}
+
+// write_close appends a complete close frame carrying `code` (RFC 6455 §5.5.1).
+pub fn write_close(mut out []u8, code u16) {
+	write_frame_header(mut out, op_close, 2)
+	out << u8(code >> 8)
+	out << u8(code & 0xff)
+}
+
+// write_pong appends a complete pong frame echoing a ping's payload
+// (RFC 6455 §5.5.3: the pong carries the ping's application data).
+pub fn write_pong(mut out []u8, payload []u8) {
+	write_frame_header(mut out, op_pong, payload.len)
+	out << payload
+}
+
+// append_accept_key appends the Sec-WebSocket-Accept value for `client_key`
+// (RFC 6455 §4.2.2: base64(SHA-1(key + GUID))) straight into the response
+// buffer — the handshake-path form, no intermediate string.
+pub fn append_accept_key(mut out []u8, client_key string) {
+	mut input := []u8{cap: client_key.len + ws_guid.len}
+	unsafe { input.push_many(client_key.str, client_key.len) }
+	unsafe { input.push_many(ws_guid.str, ws_guid.len) }
+	digest := sha1.sum(input)
+	start := out.len
+	unsafe { out.grow_len(28) } // base64 of 20 bytes = 28 chars
+	base64.encode_in_buffer(digest, unsafe { &u8(out.data) + start })
+}
+
+// accept_key is append_accept_key's convenience form (allocates the string) —
+// for tests and non-hot-path callers.
+pub fn accept_key(client_key string) string {
+	mut out := []u8{cap: 28}
+	append_accept_key(mut out, client_key)
+	return out.bytestr()
+}

--- a/websocket/websocket_test.v
+++ b/websocket/websocket_test.v
@@ -1,0 +1,117 @@
+module websocket
+
+// Codec vectors straight from RFC 6455 (§1.3 handshake, §5.7 framing
+// examples) plus the malformed-input matrix frame_head must reject. Pure
+// codec tests — the connection-level behaviour (upgrade, echo, close) is
+// end-to-end tested in examples/websocket_echo.
+
+fn test_accept_key_rfc_vector() {
+	// RFC 6455 §1.3: the sample nonce and its expected accept value.
+	assert accept_key('dGhlIHNhbXBsZSBub25jZQ==') == 's3pPLMBiTxaQ9kYGzzhZRbK+xOo='
+	mut out := []u8{}
+	out << 'Sec-WebSocket-Accept: '.bytes()
+	append_accept_key(mut out, 'dGhlIHNhbXBsZSBub25jZQ==')
+	assert out.bytestr() == 'Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo='
+}
+
+fn test_masked_hello_rfc_vector() {
+	// RFC 6455 §5.7: a single-frame masked text message containing "Hello".
+	mut buf := [u8(0x81), 0x85, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f, 0x4d, 0x51, 0x58]
+	h := frame_head(buf)
+	assert h.total == buf.len
+	assert h.opcode == op_text
+	assert h.fin
+	assert h.masked
+	assert h.payload_len == 5
+	unmask_in_place(mut buf, h)
+	assert buf[h.payload_off..h.payload_off + h.payload_len].bytestr() == 'Hello'
+}
+
+fn test_unmasked_hello_rfc_vector() {
+	// RFC 6455 §5.7: the same message unmasked (a server→client frame).
+	buf := [u8(0x81), 0x05, 0x48, 0x65, 0x6c, 0x6c, 0x6f]
+	h := frame_head(buf)
+	assert h.total == buf.len
+	assert !h.masked
+	assert buf[h.payload_off..h.payload_off + h.payload_len].bytestr() == 'Hello'
+}
+
+fn test_extended_16bit_length() {
+	// 256-byte unmasked binary frame: 126 marker + 2-byte big-endian length.
+	mut buf := [u8(0x82), 126, 0x01, 0x00]
+	buf << []u8{len: 256, init: u8(0x61)}
+	h := frame_head(buf)
+	assert h.total == 4 + 256
+	assert h.opcode == op_binary
+	assert h.payload_len == 256
+	assert h.payload_off == 4
+}
+
+fn test_extended_64bit_length() {
+	// 65536-byte frame: 127 marker + 8-byte big-endian length.
+	mut buf := [u8(0x82), 127, 0, 0, 0, 0, 0, 1, 0, 0]
+	buf << []u8{len: 65536, init: u8(0x62)}
+	h := frame_head(buf)
+	assert h.total == 10 + 65536
+	assert h.payload_len == 65536
+	assert h.payload_off == 10
+}
+
+fn test_incomplete_frames() {
+	assert frame_head([]u8{}).total == incomplete
+	assert frame_head([u8(0x81)]).total == incomplete
+	// Header complete, payload still in flight.
+	assert frame_head([u8(0x81), 0x05, 0x48]).total == incomplete
+	// Masked header promises 4 key bytes that have not arrived.
+	assert frame_head([u8(0x81), 0x85, 0x37, 0xfa]).total == incomplete
+	// 16-bit length marker with only one extended byte so far.
+	assert frame_head([u8(0x82), 126, 0x01]).total == incomplete
+}
+
+fn test_malformed_frames() {
+	// RSV bits set without a negotiated extension.
+	assert frame_head([u8(0xc1), 0x00]).total == err_malformed
+	// Reserved opcodes 0x3 and 0xb.
+	assert frame_head([u8(0x83), 0x00]).total == err_malformed
+	assert frame_head([u8(0x8b), 0x00]).total == err_malformed
+	// Fragmented control frame (ping without FIN).
+	assert frame_head([u8(0x09), 0x00]).total == err_malformed
+	// Control frame with a 126-marker length (> 125 forbidden).
+	assert frame_head([u8(0x89), 126, 0x01, 0x00]).total == err_malformed
+	// Non-minimal encodings: 16-bit form carrying 125, 64-bit form carrying 300.
+	assert frame_head([u8(0x82), 126, 0x00, 0x7d]).total == err_malformed
+	assert frame_head([u8(0x82), 127, 0, 0, 0, 0, 0, 0, 0x01, 0x2c]).total == err_malformed
+	// 64-bit length beyond max_frame_payload.
+	assert frame_head([u8(0x82), 127, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]).total == err_malformed
+}
+
+fn test_writer_roundtrip() {
+	for payload_len in [0, 1, 125, 126, 300, 0xffff, 0x10000] {
+		mut out := []u8{}
+		write_frame_header(mut out, op_text, payload_len)
+		out << []u8{len: payload_len, init: u8(0x2e)}
+		h := frame_head(out)
+		assert h.total == out.len, 'payload_len ${payload_len}'
+		assert h.payload_len == payload_len
+		assert h.fin
+		assert !h.masked
+		assert h.opcode == op_text
+	}
+}
+
+fn test_close_and_pong_writers() {
+	mut out := []u8{}
+	write_close(mut out, close_normal)
+	h := frame_head(out)
+	assert h.total == out.len
+	assert h.opcode == op_close
+	assert h.payload_len == 2
+	assert int(out[h.payload_off]) << 8 | int(out[h.payload_off + 1]) == 1000
+
+	mut pong := []u8{}
+	write_pong(mut pong, 'ka'.bytes())
+	hp := frame_head(pong)
+	assert hp.total == pong.len
+	assert hp.opcode == op_pong
+	assert pong[hp.payload_off..hp.payload_off + hp.payload_len].bytestr() == 'ka'
+}


### PR DESCRIPTION
Implements #136 — the first of the two deferred #122 items, chosen over #137 because the completion tier needs io_uring hardware that neither hosted CI nor this environment can exercise, while the seam is fully verifiable on epoll.

## The seam (core + backend_epoll)

- **`core.ConnHandler`** — a protocol-neutral contract for driving a taken-over connection: fed every readable burst, consumes complete frames from a view of the read buffer, appends into the same batch-flushed write buffer, returns `(consumed, Step)`. Partial frames = consume less; the engine compacts and re-calls.
- **The hand-off is a per-thread slot** (`enable_takeover` / `queue_takeover` / `take_queued_takeover`), mirroring the existing sendfile/queued-buf slot idiom exactly. An upgrade handler appends its `101`, queues, returns `.done`; the worker flips `ConnState.takeover` and routes subsequent bursts to `serve_takeover_conn`. On backends that never enable the slot, `queue_takeover` reports **false** and the handler answers an explicit error — no dead 101s.
- **Everything downstream is reused unchanged**: read-buffer growth/compaction, batched flush, EPOLLOUT backpressure parking, `sm_max_pending_write`, the timeout sweep (which now skips the HTTP 408 bytes for taken-over connections — a partial frame still arms the read deadline, an idle connection between messages never does). The HTTP hot path pays one predictable nil-check in `handle_readable`.
- **The ordering rule that makes it a seam**: frames pipelined in the SAME segment as the upgrade request stop the HTTP drain at the takeover point and are consumed by the takeover drain after the 101 flushes — e2e-tested.
- **Slot hygiene**: the thread-local slot is drained after *every* handler/continuation step (done/suspend/close, single, pipelined, clientless, tombstoned, streamed-body), so a queued takeover can never leak into another request. That also gives **async upgrades** for free: a handler that parks (e.g. an upstream auth check) can queue the takeover from its resumed continuation's `.done`.
- v1 limits, as scoped in #136: epoll-first (the interim-100 precedent); `.suspend` from a `ConnHandler` degrades to `.close`.

## The protocol sibling (websocket/)

Pure RFC 6455 codec, **zero vanilla imports** — the dependency rule is untouched (the engine never imports a protocol for this; the app's ConnHandler composes the codec):

- `append_accept_key`/`accept_key` (§4.2.2, base64 written straight into the response buffer), `frame_head` (complete-frame framing with `incomplete`/`err_malformed` int sentinels, matching `http1_1.client`'s idiom), `unmask_in_place`, unmasked server-frame writers (`write_frame_header`, `write_close`, `write_pong`).
- The malformed matrix is enforced in the parser: RSV bits, reserved opcodes, fragmented/oversized control frames, non-minimal 16/64-bit length encodings, oversized frames.
- Unit tests pin the RFC §1.3 handshake vector and §5.7 framing examples.

## The consumer (examples/websocket_echo)

Both halves are pure functions: `handle` (routing, §4.2.1 validation, the 501 fallback — asserted in-process, where the test binary's lack of `enable_takeover` reproduces a non-capable backend exactly) and `ws_echo_conn` (echo, ping→pong, close handshake, §5.1 unmasked-frame failure, partial frames, fragmented-input rejection — unit-tested with raw frame bytes). The vtest e2e drives a real epoll worker through the full choreography on three concurrent connections: handshake→echo→ping/pong→close→EOF, the pipelined-behind-upgrade probe, and the §5.1 violation.

## CI + docs

- `examples/websocket_echo/src` joins the Linux **and** Windows matrices (on Windows the 501-fallback + codec tests run — the takeover seam degrades cleanly); `websocket` joins the Windows module-tests list.
- `docs/ARCHITECTURE.md`: the `server/` row documents the seam, `websocket/` is no longer "reserved"; README gains the example row.

Verified locally: websocket unit tests, echo unit + e2e (3× stable), server module tests, full `tests/` suite, behaviour suite under `-d vanilla_poll`, `-os windows/macos -check` on the example and consumers, `v fmt -verify`, dependency-direction check.

Refs #136 (implements v1); #137 stays open for the completion tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvjM79KsDdT2Q9Y6SPfGxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvjM79KsDdT2Q9Y6SPfGxm)_