### PR TITLE
feat(http2): HPACK + frame codec + connection state machine — cleartext HTTP/2 over the takeover seam

### DIFF
--- a/.github/workflows/build_test_examples_on_linux.yml
+++ b/.github/workflows/build_test_examples_on_linux.yml
@@ -22,6 +22,7 @@ jobs:
           - examples/etag/src
           - examples/graceful_shutdown/src
           - examples/hexagonal/src
+          - examples/http2_cleartext/src
           - examples/io_uring_demo/src
           - examples/mesh/src
           - examples/per_server_workers/src
@@ -103,3 +104,10 @@ jobs:
           VANILLA_NO_IOURING: '1'
         run: |
           v -cc gcc -no-parallel test tests/
+      # The http2 module's unit tests (HPACK against the RFC 7541 Appendix C
+      # vectors, frame codec, ServerConn state machine) — pure-bytes tests
+      # with no sockets, so they run here rather than in an example lane.
+      - name: Run http2 module tests
+        shell: bash
+        run: |
+          v -cc gcc -no-parallel test http2/

--- a/.github/workflows/build_test_examples_on_windows.yml
+++ b/.github/workflows/build_test_examples_on_windows.yml
@@ -50,6 +50,9 @@ jobs:
           # websocket_echo: the takeover seam is epoll-only, but the example must
           # degrade cleanly elsewhere — the 501-fallback + codec tests run here.
           - examples/websocket_echo/src
+          # http2_cleartext: same story — the 501-fallback + the pure-bytes
+          # bridge tests run here; the socket e2e is Linux-guarded.
+          - examples/http2_cleartext/src
     steps:
       - uses: actions/checkout@v4
       - name: Set up V

--- a/.github/workflows/conformance_h2spec.yml
+++ b/.github/workflows/conformance_h2spec.yml
@@ -1,0 +1,117 @@
+name: (Linux) HTTP/2 Conformance (h2spec)
+
+# Runs the h2spec RFC 9113/7541 conformance suite against the
+# examples/http2_cleartext server (cleartext, prior knowledge) on the epoll
+# backend — the http2 counterpart of conformance_h1spec.yml. Two layers:
+#
+#   1. `v test http2/` (state machine / HPACK / frame codec): every
+#      conformance decision asserted deterministically without a socket —
+#      the primary source of truth (runs in the repo-tests job and here).
+#   2. h2spec LIVE probe over TCP: the reference conformance tool driving
+#      real frames through the takeover seam. Hard gate — h2spec exits
+#      non-zero on any failed check.
+#
+# h2spec: https://github.com/summerwind/h2spec (Go, single binary).
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'http2/**'
+      - 'examples/http2_cleartext/**'
+      - 'server/**'
+      - 'core/**'
+      - 'http1_1/**'
+      - 'socket/**'
+      - 'epoll/**'
+      - 'io_uring/**'
+      - 'tls/**'
+      - '.github/workflows/conformance_h2spec.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'http2/**'
+      - 'examples/http2_cleartext/**'
+      - 'server/**'
+      - 'core/**'
+      - 'http1_1/**'
+      - 'socket/**'
+      - 'epoll/**'
+      - 'io_uring/**'
+      - 'tls/**'
+      - '.github/workflows/conformance_h2spec.yml'
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up V
+        uses: vlang/setup-v@v1.7
+      - name: Remove Vlang folder to avoid conflicts
+        shell: bash
+        run: |
+          rm -rf -v ./vlang || true
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liburing-dev linux-libc-dev
+      # -cc gcc -no-parallel: same V-toolchain flake avoidance as the other
+      # workflows (tcc/stdatomic fallback race + vlang/v#27749 parallel-codegen
+      # link race).
+      - name: Build examples/http2_cleartext
+        shell: bash
+        run: v -cc gcc -no-parallel examples/http2_cleartext/src
+      - name: Unit tests (hard gate)
+        shell: bash
+        run: |
+          v -cc gcc -no-parallel test http2/
+          v -cc gcc -no-parallel test examples/http2_cleartext/src
+      - name: Install h2spec
+        shell: bash
+        run: |
+          curl -sSL -o /tmp/h2spec.tar.gz \
+            https://github.com/summerwind/h2spec/releases/download/v2.6.0/h2spec_linux_amd64.tar.gz
+          tar -xzf /tmp/h2spec.tar.gz -C /tmp
+          /tmp/h2spec --version
+      - name: Start the server
+        shell: bash
+        run: |
+          ./examples/http2_cleartext/src/src > /tmp/http2_server.log 2>&1 &
+          echo $! > /tmp/http2_server.pid
+          # Wait for the listener to come up (max ~10s).
+          for i in $(seq 1 40); do
+            if python3 -c "import socket;socket.create_connection(('127.0.0.1',3000),0.3)" 2>/dev/null; then
+              echo "server up after $((i))*0.25s"; break
+            fi
+            sleep 0.25
+          done
+          head -2 /tmp/http2_server.log || true
+      - name: Run h2spec (hard gate)
+        shell: bash
+        run: |
+          set +e
+          /tmp/h2spec -h 127.0.0.1 -p 3000 -o 5 > /tmp/h2spec.txt 2>&1
+          code=$?
+          # The tail carries the pass/fail tally; the Failures section (when
+          # present) carries every failed check with expected/actual.
+          tail -6 /tmp/h2spec.txt
+          {
+            echo '## h2spec'
+            echo '```'
+            tail -6 /tmp/h2spec.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$code" -ne 0 ]; then
+            echo "::error::h2spec reported conformance failures — details below."
+            sed -n '/^Failures:/,$p' /tmp/h2spec.txt
+            exit 1
+          fi
+          echo "h2spec: all checks passed."
+      - name: Stop the server
+        if: always()
+        shell: bash
+        run: |
+          [ -f /tmp/http2_server.pid ] && kill "$(cat /tmp/http2_server.pid)" 2>/dev/null || true
+          tail -20 /tmp/http2_server.log || true

--- a/.github/workflows/pretty_fmt_checker.yml
+++ b/.github/workflows/pretty_fmt_checker.yml
@@ -22,3 +22,11 @@ jobs:
         shell: bash
         run: |
           v fmt -verify .
+      # On failure, print the exact reformatting vfmt wants, so a contributor
+      # (or a bot) can fix files from the log alone — `-verify` only names
+      # the offending files.
+      - name: Show vfmt diff for the offending files
+        if: failure()
+        shell: bash
+        run: |
+          v fmt -diff . || true

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ fn main() {
 | `examples/url_form/` | Query-string and URL-encoded form parsing |
 | `examples/veb_like/` | veb-style declarative routing |
 | `examples/websocket_echo/` | RFC 6455 WebSocket echo over the connection-takeover seam (`core.queue_takeover` — one engine, two protocols on one connection) |
+| `examples/http2_cleartext/` | HTTP/2 (cleartext, prior-knowledge, RFC 9113) over the same seam — the `PRI *` preface flips the connection, then the SAME handler serves h1 and http2 requests |
 | `examples/video_stream/` | HTTP video streaming |
 | `examples/async_sse/` | SSE via async handler (suspend/resume on fd) |
 | `examples/async_db_pg/` | PostgreSQL queries via async handler |
@@ -423,8 +424,8 @@ See [BENCHMARK_RESULTS_MACOS.md](BENCHMARK_RESULTS_MACOS.md) for full benchmark 
 - [ ] Flush a queued response before tearing down a half-closed connection ([#103](https://github.com/enghitalo/vanilla/issues/103)) — unblocks the live h1spec/Http11Probe gate
 - [x] Request timeouts — `Limits.read_timeout_ms` (408) / `write_timeout_ms`, enforced by the per-worker deadline sweep
 - [x] Chunked transfer-encoding in the request parser (`frame_chunked_total`)
-- [ ] HTTP/2 support (multiplexing, HPACK, server push)
-- [ ] WebSocket upgrade (framing, ping/pong, close handshake)
+- [x] HTTP/2 — cleartext prior-knowledge via the takeover seam: HPACK (RFC 7541, Appendix C-verified), multiplexed streams, send-side flow control (`http2/` + `examples/http2_cleartext/`); TLS/ALPN and the HTTP/1.1 Upgrade handshake still open
+- [x] WebSocket upgrade (framing, ping/pong, close handshake) — `websocket/` codec + `examples/websocket_echo/` over the takeover seam
 - [x] TLS/HTTPS — epoll backend via `ServerConfig.tls_config` (e.g. `tls.new_self_signed()`); other backends are plaintext
 - [ ] HTTPS example (`examples/https/`)
 - [x] Body-size cap + max-connections via `Limits` (`max_body_bytes` → 413, `max_request_bytes`, `max_connections`); a per-connection request-count limit is still open

--- a/examples/http2_cleartext/src/main.v
+++ b/examples/http2_cleartext/src/main.v
@@ -50,6 +50,8 @@ const echo_path = '/echo'.bytes()
 const star_target = '*'.bytes()
 
 const h1_line_suffix = ' HTTP/1.1\r\n'.bytes()
+const http11_version = 'HTTP/1.1'.bytes()
+const http10_version = 'HTTP/1.0'.bytes()
 const h1_host_prefix = 'host: '.bytes()
 const h1_content_length_prefix = 'content-length: '.bytes()
 const h1_header_sep = ': '.bytes()
@@ -100,6 +102,15 @@ fn handle(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event
 		// connection's state once the mode flips (the takeover_state slot).
 		conn.write_server_preface(mut res)
 		return .done
+	}
+	if !slice_eq(hr.buffer, hr.version, http11_version)
+		&& !slice_eq(hr.buffer, hr.version, http10_version) {
+		// Not an HTTP/1.x request — e.g. a garbled http2 connection preface.
+		// Answer 400 and drop the connection (RFC 9113 §3.5 requires the TCP
+		// connection terminated on an invalid preface; a keep-alive 404 would
+		// leave the peer hanging).
+		res << response.tiny_bad_request_response
+		return .close
 	}
 	return app_route(hr, mut res)
 }

--- a/examples/http2_cleartext/src/main.v
+++ b/examples/http2_cleartext/src/main.v
@@ -105,11 +105,11 @@ fn handle(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event
 	}
 	if !slice_eq(hr.buffer, hr.version, http11_version)
 		&& !slice_eq(hr.buffer, hr.version, http10_version) {
-		// Not an HTTP/1.x request — e.g. a garbled http2 connection preface.
-		// Answer 400 and drop the connection (RFC 9113 §3.5 requires the TCP
-		// connection terminated on an invalid preface; a keep-alive 404 would
-		// leave the peer hanging).
-		res << response.tiny_bad_request_response
+		// Not an HTTP/1.x request — a garbled http2 connection preface. Speak
+		// the language the peer attempted: a GOAWAY(PROTOCOL_ERROR) frame,
+		// then drop the connection (RFC 9113 §3.5). h1 error bytes here would
+		// only feed a confused http2 frame parser on the other side.
+		http2.write_goaway(mut res, 0, .protocol_error)
 		return .close
 	}
 	return app_route(hr, mut res)

--- a/examples/http2_cleartext/src/main.v
+++ b/examples/http2_cleartext/src/main.v
@@ -1,0 +1,303 @@
+module main
+
+// HTTP/2 over cleartext TCP with prior knowledge (RFC 9113 §3.4) — the second
+// consumer of the conn-mode seam (issue #136), and the reason the seam
+// reserved an http2 arm: one engine, one application handler, now three wire
+// protocols (HTTP/1.1, WebSocket, HTTP/2) on the same port.
+//
+// How the connection flips: an http2 client's first bytes are the connection
+// preface `PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n`. Its first 18 bytes parse as a
+// complete HTTP/1.1 request (method PRI, target *, empty header section), so
+// it reaches `handle` like any request. The handler queues the takeover,
+// appends the server preface (a SETTINGS frame) as its switching response,
+// and returns `.done` — the engine flushes the SETTINGS and routes every
+// later burst (starting with the `SM\r\n\r\n` tail already in the read
+// buffer) to `http2_takeover_conn`.
+//
+// How requests are served: the http2.ServerConn state machine surfaces each
+// COMPLETE request; this file translates it to HTTP/1.1 bytes, calls the SAME
+// `handle` the h1 path uses (a core.Handler is bytes-in/bytes-out — nothing
+// http1-specific about the contract), then re-frames the h1 response as
+// HEADERS + DATA with the http1_1.client response codec doing the parsing.
+// The translation allocates; that is the http2 bridge's cost, paid off the
+// h1 hot path (which is untouched).
+//
+// Try it (prior knowledge, no upgrade dance):
+//   curl --http2-prior-knowledge http://localhost:3000/
+//   curl --http2-prior-knowledge -d 'ping' http://localhost:3000/echo
+import core
+import http1_1.client
+import http1_1.request_parser
+import http1_1.response
+import http2
+import server
+import strconv
+
+const home_response = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 23\r\nConnection: keep-alive\r\n\r\nhello over one handler\n'.bytes()
+const not_found_response = 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+// 501: this worker/backend cannot take connections over (queue_takeover
+// returned false) — answering the preface with h1 bytes the client can see
+// beats leaving it to time out on a half-spoken protocol.
+const cannot_takeover_response = 'HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
+const echo_head_prefix = 'HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: '.bytes()
+const echo_head_suffix = '\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
+const get_method = 'GET'.bytes()
+const post_method = 'POST'.bytes()
+const pri_method = 'PRI'.bytes()
+const root_path = '/'.bytes()
+const echo_path = '/echo'.bytes()
+const star_target = '*'.bytes()
+
+const h1_line_suffix = ' HTTP/1.1\r\n'.bytes()
+const h1_host_prefix = 'host: '.bytes()
+const h1_content_length_prefix = 'content-length: '.bytes()
+const h1_header_sep = ': '.bytes()
+const crlf = '\r\n'.bytes()
+
+// slice_eq compares a request Slice against a small const byte pattern.
+@[direct_array_access]
+fn slice_eq(buf []u8, s request_parser.Slice, want []u8) bool {
+	if s.len != want.len {
+		return false
+	}
+	for i in 0 .. want.len {
+		if buf[s.start + i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// write_int appends n's decimal digits — itoa into a stack scratch, then
+// push_many (docs/BEST_PRACTICES.md: no `.str()` on the serving path).
+fn write_int(mut out []u8, n i64) {
+	mut scratch := [24]u8{}
+	mut view := unsafe { (&scratch[0]).vbytes(scratch.len) }
+	written := strconv.write_dec(n, mut view)
+	if written > 0 {
+		unsafe { out.push_many(&scratch[0], written) }
+	}
+}
+
+// handle serves BOTH protocols: h1 requests directly, and the http2
+// connection preface by flipping the connection's mode. The http2 bridge
+// below calls this same function for every http2 request.
+fn handle(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+	hr := request_parser.decode_http_request(req) or {
+		res << response.tiny_bad_request_response
+		return .close
+	}
+	if slice_eq(hr.buffer, hr.method, pri_method) && slice_eq(hr.buffer, hr.path, star_target) {
+		// The http2 client connection preface. Takeover FIRST: only answer
+		// with the server preface if this worker can actually flip the mode.
+		mut conn := http2.new_server_conn()
+		if !core.queue_takeover(http2_takeover_conn, voidptr(conn)) {
+			res << cannot_takeover_response
+			return .close
+		}
+		// The engine keeps `conn` reachable for the GC through the
+		// connection's state once the mode flips (the takeover_state slot).
+		conn.write_server_preface(mut res)
+		return .done
+	}
+	return app_route(hr, mut res)
+}
+
+// app_route is the application: plain h1 routes, protocol-blind.
+fn app_route(hr request_parser.HttpRequest, mut res []u8) core.Step {
+	if slice_eq(hr.buffer, hr.method, get_method) && slice_eq(hr.buffer, hr.path, root_path) {
+		res << home_response
+		return .done
+	}
+	if slice_eq(hr.buffer, hr.method, post_method) && slice_eq(hr.buffer, hr.path, echo_path) {
+		res << echo_head_prefix
+		write_int(mut res, i64(hr.body.len))
+		res << echo_head_suffix
+		if hr.body.len > 0 {
+			unsafe { res.push_many(&hr.buffer[hr.body.start], hr.body.len) }
+		}
+		return .done
+	}
+	res << not_found_response
+	return .done
+}
+
+// http2_takeover_conn is the core.ConnHandler for a flipped connection: the
+// ServerConn consumes frames (answering acks/pings/window updates itself)
+// and surfaces complete requests, which are served through `handle`.
+fn http2_takeover_conn(buf []u8, mut out []u8, client_fd int, takeover_state voidptr, worker_state voidptr, mut event_loop core.EventLoop) (int, core.Step) {
+	mut conn := unsafe { &http2.ServerConn(takeover_state) }
+	mut reqs := []http2.Http2Request{}
+	consumed, closing := conn.consume(buf, mut out, mut reqs)
+	mut must_close := closing
+	for req in reqs {
+		if !serve_http2_request(mut conn, req, mut out, client_fd, worker_state, mut event_loop) {
+			must_close = true
+		}
+	}
+	if must_close {
+		return consumed, core.Step.close
+	}
+	return consumed, core.Step.done
+}
+
+// serve_http2_request bridges one http2 request through the h1 handler:
+// pseudo-headers become the request line, regular fields carry over
+// (connection-specific ones dropped, RFC 9113 §8.2.2), the response head is
+// parsed back with the client codec and re-framed as HEADERS + DATA.
+// Returns false when the connection must close afterwards.
+fn serve_http2_request(mut conn http2.ServerConn, req http2.Http2Request, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) bool {
+	mut method := ''
+	mut path := ''
+	mut authority := ''
+	for f in req.headers {
+		match f.name {
+			':method' { method = f.value }
+			':path' { path = f.value }
+			':authority' { authority = f.value }
+			else {}
+		}
+	}
+	if method == '' || path == '' {
+		// Malformed request (§8.3.1) — answer 400 on the stream, keep the
+		// connection.
+		mut block := []u8{cap: 4}
+		http2.encode_status(mut block, 400)
+		conn.write_response_headers(mut out, req.stream_id, block, true)
+		return true
+	}
+	if authority == '' {
+		authority = 'localhost'
+	}
+	// Translate to h1 request bytes.
+	mut h1_req := []u8{cap: 256 + req.body.len}
+	unsafe { h1_req.push_many(method.str, method.len) }
+	h1_req << u8(` `)
+	unsafe { h1_req.push_many(path.str, path.len) }
+	h1_req << h1_line_suffix
+	h1_req << h1_host_prefix
+	unsafe { h1_req.push_many(authority.str, authority.len) }
+	h1_req << crlf
+	for f in req.headers {
+		if f.name.len == 0 || f.name[0] == `:` {
+			continue
+		}
+		// host rides :authority; connection-specific fields do not exist in
+		// http2 and must not be resurrected; te is only ever 'trailers'.
+		if f.name == 'host' || f.name == 'te' || is_connection_specific(f.name) {
+			continue
+		}
+		unsafe { h1_req.push_many(f.name.str, f.name.len) }
+		h1_req << h1_header_sep
+		unsafe { h1_req.push_many(f.value.str, f.value.len) }
+		h1_req << crlf
+	}
+	if req.body.len > 0 {
+		h1_req << h1_content_length_prefix
+		write_int(mut h1_req, i64(req.body.len))
+		h1_req << crlf
+	}
+	h1_req << crlf
+	if req.body.len > 0 {
+		unsafe { h1_req.push_many(&req.body[0], req.body.len) }
+	}
+	// The same pure handler serves the translated request.
+	mut h1_res := []u8{cap: 512}
+	step := handle(h1_req, mut h1_res, client_fd, worker_state, mut event_loop)
+	if step == .suspend {
+		// .suspend is unsupported behind the takeover seam (issue #136 v1).
+		http2.write_goaway(mut out, req.stream_id, .internal_error)
+		return false
+	}
+	total := client.frame_response(h1_res)
+	status := client.status_code(h1_res)
+	if total <= 0 || status < 0 {
+		http2.write_goaway(mut out, req.stream_id, .internal_error)
+		return false
+	}
+	head := client.head_len(h1_res)
+	bstart, blen := client.body_bounds(h1_res, total)
+	mut block := []u8{cap: 64}
+	http2.encode_status(mut block, status)
+	append_response_fields(mut block, h1_res, head)
+	conn.write_response_headers(mut out, req.stream_id, block, blen == 0)
+	if blen > 0 {
+		body := unsafe { (&h1_res[bstart]).vbytes(blen) }
+		conn.write_response_data(mut out, req.stream_id, body)
+	}
+	return step == .done
+}
+
+// append_response_fields HPACK-encodes the h1 response head's fields (after
+// the status line, names lowercased, connection-specific fields dropped).
+fn append_response_fields(mut block []u8, res []u8, head int) {
+	mut pos := 0
+	for pos + 1 < head && !(res[pos] == `\r` && res[pos + 1] == `\n`) {
+		pos++
+	}
+	pos += 2
+	for pos + 1 < head {
+		if res[pos] == `\r` && res[pos + 1] == `\n` {
+			break
+		}
+		mut eol := pos
+		for eol + 1 < head && !(res[eol] == `\r` && res[eol + 1] == `\n`) {
+			eol++
+		}
+		mut colon := pos
+		for colon < eol && res[colon] != `:` {
+			colon++
+		}
+		if colon > pos && colon < eol {
+			mut lower := []u8{cap: colon - pos}
+			for i in pos .. colon {
+				mut ch := res[i]
+				if ch >= `A` && ch <= `Z` {
+					ch += 32
+				}
+				lower << ch
+			}
+			name := lower.bytestr()
+			if !is_connection_specific(name) {
+				mut vstart := colon + 1
+				for vstart < eol && res[vstart] == u8(` `) {
+					vstart++
+				}
+				value := if vstart < eol {
+					unsafe { tos(&res[vstart], eol - vstart) }
+				} else {
+					''
+				}
+				http2.encode_literal(mut block, name, value)
+			}
+		}
+		pos = eol + 2
+	}
+}
+
+// is_connection_specific reports h1 connection-level fields that MUST NOT
+// cross into http2 framing (RFC 9113 §8.2.2).
+fn is_connection_specific(name string) bool {
+	return match name {
+		'connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade' { true }
+		else { false }
+	}
+}
+
+fn main() {
+	// The takeover seam is epoll-first (issue #136): elsewhere queue_takeover
+	// reports false and the preface answers 501 instead of a dead SETTINGS.
+	mut backend := unsafe { server.IOBackend(0) }
+	$if linux {
+		backend = server.IOBackend.epoll
+	}
+	mut srv := server.new_server(server.ServerConfig{
+		port:            3000
+		io_multiplexing: backend
+		handler:         handle
+	})!
+	println('HTTP/2 (cleartext, prior knowledge) + HTTP/1.1 on http://localhost:3000')
+	println('  curl --http2-prior-knowledge http://localhost:3000/')
+	srv.run()
+}

--- a/examples/http2_cleartext/src/main_test.v
+++ b/examples/http2_cleartext/src/main_test.v
@@ -1,0 +1,187 @@
+module main
+
+// In-process tests: the h1 routes as plain handler calls, the preface guard,
+// and the whole http2 bridge (ServerConn + translation + re-framing) driven
+// as a bare ConnHandler — no sockets, no engine, pure bytes.
+import core
+import http2
+
+fn serve_h1(req string) (core.Step, string) {
+	mut res := []u8{}
+	mut event_loop := core.EventLoop{}
+	step := handle(req.bytes(), mut res, -1, unsafe { nil }, mut event_loop)
+	return step, res.bytestr()
+}
+
+fn test_h1_routes() {
+	step, home := serve_h1('GET / HTTP/1.1\r\nHost: x\r\n\r\n')
+	assert step == .done
+	assert home == home_response.bytestr()
+	step2, echoed := serve_h1('POST /echo HTTP/1.1\r\nHost: x\r\nContent-Length: 4\r\n\r\nping')
+	assert step2 == .done
+	assert echoed.starts_with('HTTP/1.1 200 OK\r\n')
+	assert echoed.ends_with('\r\n\r\nping')
+	step3, missing := serve_h1('GET /nope HTTP/1.1\r\nHost: x\r\n\r\n')
+	assert step3 == .done
+	assert missing.starts_with('HTTP/1.1 404')
+}
+
+fn test_preface_without_capable_worker_is_501() {
+	// This test binary never calls core.enable_takeover(), so queue_takeover
+	// reports false and the preface must be answered with the visible 501.
+	step, res := serve_h1('PRI * HTTP/2.0\r\n\r\n')
+	assert step == .close
+	assert res == cannot_takeover_response.bytestr()
+}
+
+struct TestFrame {
+	fh      http2.FrameHeader
+	payload []u8
+}
+
+fn split_frames(buf []u8) []TestFrame {
+	mut out := []TestFrame{}
+	mut pos := 0
+	for pos + 9 <= buf.len {
+		fh := http2.parse_frame_header(buf[pos..]) or { panic(err) }
+		total := 9 + int(fh.length)
+		assert pos + total <= buf.len
+		out << TestFrame{
+			fh:      fh
+			payload: buf[pos + 9..pos + total]
+		}
+		pos += total
+	}
+	assert pos == buf.len
+	return out
+}
+
+fn hf(name string, value string) http2.HeaderField {
+	return http2.HeaderField{
+		name:  name
+		value: value
+	}
+}
+
+// bridge_step feeds one burst to the takeover ConnHandler over `conn`.
+fn bridge_step(mut conn http2.ServerConn, input []u8) (int, core.Step, []u8) {
+	mut out := []u8{}
+	mut event_loop := core.EventLoop{}
+	consumed, step := http2_takeover_conn(input, mut out, -1, voidptr(conn), unsafe { nil }, mut
+		event_loop)
+	return consumed, step, out
+}
+
+fn get_block(path_idx int) []u8 {
+	mut block := []u8{}
+	http2.encode_indexed(mut block, 2) // :method GET
+	http2.encode_indexed(mut block, 6) // :scheme http
+	http2.encode_indexed(mut block, path_idx) // 4 = /
+	http2.encode_literal_name_idx(mut block, 1, 'x.test')
+	return block
+}
+
+fn test_http2_get_bridges_to_the_h1_handler() ! {
+	mut conn := http2.new_server_conn()
+	mut input := []u8{}
+	input << http2.preface_tail
+	http2.write_settings(mut input, [])
+	block := get_block(4)
+	http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
+		1, block.len)
+	input << block
+	consumed, step, out := bridge_step(mut conn, input)
+	assert consumed == input.len
+	assert step == .done
+	frames := split_frames(out)
+	// SETTINGS ack, then the response: HEADERS + DATA.
+	assert frames.len == 3
+	assert frames[0].fh.type_ == .settings
+	assert frames[0].fh.flags & http2.flag_ack != 0
+	assert frames[1].fh.type_ == .headers
+	assert frames[1].fh.flags & http2.flag_end_headers != 0
+	assert frames[1].fh.flags & http2.flag_end_stream == 0
+	mut dec := http2.new_decoder(http2.hpack_default_table_size)
+	fields := dec.decode(frames[1].payload)!
+	assert fields[0] == hf(':status', '200')
+	assert hf('content-type', 'text/plain') in fields
+	assert hf('content-length', '23') in fields
+	// Connection-specific h1 fields must not leak into http2 framing.
+	for f in fields {
+		assert f.name != 'connection'
+	}
+	assert frames[2].fh.type_ == .data
+	assert frames[2].fh.flags & http2.flag_end_stream != 0
+	assert frames[2].payload.bytestr() == 'hello over one handler\n'
+}
+
+fn test_http2_post_echo_with_body() ! {
+	mut conn := http2.new_server_conn()
+	mut handshake := []u8{}
+	handshake << http2.preface_tail
+	http2.write_settings(mut handshake, [])
+	_, step0, _ := bridge_step(mut conn, handshake)
+	assert step0 == .done
+	mut block := []u8{}
+	http2.encode_indexed(mut block, 3) // :method POST
+	http2.encode_indexed(mut block, 6)
+	http2.encode_literal_name_idx(mut block, 4, '/echo')
+	http2.encode_literal_name_idx(mut block, 1, 'x.test')
+	mut input := []u8{}
+	http2.write_frame_header(mut input, .headers, http2.flag_end_headers, 1, block.len)
+	input << block
+	http2.write_data_header(mut input, 1, 4, true)
+	input << 'ping'.bytes()
+	consumed, step, out := bridge_step(mut conn, input)
+	assert consumed == input.len
+	assert step == .done
+	frames := split_frames(out)
+	// WINDOW_UPDATE (connection) for the DATA, then HEADERS + DATA back.
+	assert frames[0].fh.type_ == .window_update
+	assert frames[0].fh.stream_id == 0
+	assert frames[1].fh.type_ == .headers
+	mut dec := http2.new_decoder(http2.hpack_default_table_size)
+	fields := dec.decode(frames[1].payload)!
+	assert fields[0] == hf(':status', '200')
+	assert hf('content-length', '4') in fields
+	assert frames[2].fh.type_ == .data
+	assert frames[2].payload.bytestr() == 'ping'
+	assert frames[2].fh.flags & http2.flag_end_stream != 0
+}
+
+fn test_http2_goaway_closes_the_connection() {
+	mut conn := http2.new_server_conn()
+	mut handshake := []u8{}
+	handshake << http2.preface_tail
+	http2.write_settings(mut handshake, [])
+	_, step0, _ := bridge_step(mut conn, handshake)
+	assert step0 == .done
+	mut input := []u8{}
+	http2.write_goaway(mut input, 0, .no_error)
+	consumed, step, _ := bridge_step(mut conn, input)
+	assert consumed == input.len
+	assert step == .close
+}
+
+fn test_http2_partial_frame_consumes_nothing() {
+	mut conn := http2.new_server_conn()
+	mut handshake := []u8{}
+	handshake << http2.preface_tail
+	http2.write_settings(mut handshake, [])
+	c0, s0, _ := bridge_step(mut conn, handshake)
+	assert c0 == handshake.len
+	assert s0 == .done
+	block := get_block(4)
+	mut whole := []u8{}
+	http2.write_frame_header(mut whole, .headers, http2.flag_end_headers | http2.flag_end_stream,
+		1, block.len)
+	whole << block
+	consumed, step, out := bridge_step(mut conn, whole[..whole.len - 2])
+	assert consumed == 0
+	assert step == .done
+	assert out.len == 0
+	consumed2, step2, out2 := bridge_step(mut conn, whole)
+	assert consumed2 == whole.len
+	assert step2 == .done
+	assert split_frames(out2).len == 2 // HEADERS + DATA
+}

--- a/examples/http2_cleartext/src/main_test.v
+++ b/examples/http2_cleartext/src/main_test.v
@@ -26,13 +26,18 @@ fn test_h1_routes() {
 	assert missing.starts_with('HTTP/1.1 404')
 }
 
-fn test_non_http1x_version_is_400_close() {
+fn test_non_http1x_version_gets_goaway_and_close() {
 	// A garbled http2 preface parses as an h1 request with a non-HTTP/1.x
-	// version — it must 400 and DROP the connection (RFC 9113 §3.5), not get
-	// a keep-alive 404 that leaves the peer hanging.
-	step, res := serve_h1('INVALID CONNECTION PREFACE\r\n\r\n')
+	// version — answer in the protocol the peer attempted: a
+	// GOAWAY(PROTOCOL_ERROR) frame, then drop the connection (RFC 9113 §3.5).
+	mut res := []u8{}
+	mut event_loop := core.EventLoop{}
+	step := handle('INVALID CONNECTION PREFACE\r\n\r\n'.bytes(), mut res, -1, unsafe { nil }, mut
+		event_loop)
 	assert step == .close
-	assert res.starts_with('HTTP/1.1 400')
+	frames := split_frames(res)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .goaway
 }
 
 fn test_preface_without_capable_worker_is_501() {
@@ -158,18 +163,26 @@ fn test_http2_post_echo_with_body() ! {
 	assert frames[2].fh.flags & http2.flag_end_stream != 0
 }
 
-fn test_http2_goaway_closes_the_connection() {
+fn test_http2_goaway_keeps_the_connection_serving() {
 	mut conn := http2.new_server_conn()
 	mut handshake := []u8{}
 	handshake << http2.preface_tail
 	http2.write_settings(mut handshake, [])
 	_, step0, _ := bridge_step(mut conn, handshake)
 	assert step0 == .done
+	// A peer GOAWAY does not close the connection — the peer does. The
+	// bridge keeps serving (a PING after it still gets an ack).
 	mut input := []u8{}
 	http2.write_goaway(mut input, 0, .no_error)
-	consumed, step, _ := bridge_step(mut conn, input)
+	http2.write_frame_header(mut input, .ping, 0, 0, 8)
+	input << [u8(1), 2, 3, 4, 5, 6, 7, 8]
+	consumed, step, out := bridge_step(mut conn, input)
 	assert consumed == input.len
-	assert step == .close
+	assert step == .done
+	frames := split_frames(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .ping
+	assert frames[0].fh.flags & http2.flag_ack != 0
 }
 
 fn test_http2_partial_frame_consumes_nothing() {

--- a/examples/http2_cleartext/src/main_test.v
+++ b/examples/http2_cleartext/src/main_test.v
@@ -26,6 +26,15 @@ fn test_h1_routes() {
 	assert missing.starts_with('HTTP/1.1 404')
 }
 
+fn test_non_http1x_version_is_400_close() {
+	// A garbled http2 preface parses as an h1 request with a non-HTTP/1.x
+	// version — it must 400 and DROP the connection (RFC 9113 §3.5), not get
+	// a keep-alive 404 that leaves the peer hanging.
+	step, res := serve_h1('INVALID CONNECTION PREFACE\r\n\r\n')
+	assert step == .close
+	assert res.starts_with('HTTP/1.1 400')
+}
+
 fn test_preface_without_capable_worker_is_501() {
 	// This test binary never calls core.enable_takeover(), so queue_takeover
 	// reports false and the preface must be answered with the visible 501.

--- a/examples/http2_cleartext/src/server_end_to_end_test.v
+++ b/examples/http2_cleartext/src/server_end_to_end_test.v
@@ -50,8 +50,8 @@ fn e2e_get_opening() []u8 {
 	http2.encode_indexed(mut block, 6) // :scheme http
 	http2.encode_indexed(mut block, 4) // :path /
 	http2.encode_literal_name_idx(mut block, 1, 'x.test')
-	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream,
-		1, block.len)
+	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream, 1,
+		block.len)
 	b << block
 	return b
 }

--- a/examples/http2_cleartext/src/server_end_to_end_test.v
+++ b/examples/http2_cleartext/src/server_end_to_end_test.v
@@ -86,12 +86,6 @@ fn e2e_ping_ack() []u8 {
 	return b
 }
 
-fn e2e_goaway() []u8 {
-	mut b := []u8{}
-	http2.write_goaway(mut b, 0, .no_error)
-	return b
-}
-
 fn test_http2_cleartext_end_to_end() {
 	$if linux {
 		out := vtest.drive(server.ServerConfig{
@@ -99,10 +93,11 @@ fn test_http2_cleartext_end_to_end() {
 			handler:         handle
 		}, [
 			// Conn 0 — the full choreography on one connection: opening burst
-			// (preface + SETTINGS + GET pipelined), a second request, a PING,
-			// then a clean GOAWAY from the client.
+			// (preface + SETTINGS + GET pipelined), a second request, then a
+			// PING. The client closes the connection at script end (a peer
+			// GOAWAY would not close it — §6.8 — the engine reaps our EOF).
 			vtest.Script{
-				rounds:   [
+				rounds: [
 					vtest.Round{
 						send:  e2e_get_opening()
 						until: e2e_until_bytes(e2e_home_body)
@@ -115,14 +110,7 @@ fn test_http2_cleartext_end_to_end() {
 						send:  e2e_ping()
 						until: e2e_until_bytes(e2e_ping_ack())
 					},
-					vtest.Round{
-						send:  e2e_goaway()
-						until: fn (acc []u8) bool {
-							return true // no reply expected — just the close below
-						}
-					},
 				]
-				then_eof: true
 			},
 			// Conn 1 — plain HTTP/1.1 on the same port, same handler: the
 			// protocols coexist per connection, not per server.
@@ -141,7 +129,6 @@ fn test_http2_cleartext_end_to_end() {
 		full := out.conns[0]
 		assert full.connect_err == '', full.connect_err
 		assert !full.unmet, 'choreography ended early: ${full.raw.bytestr()}'
-		assert full.eof, 'server must close after the client GOAWAY'
 		// The server preface (a SETTINGS frame) must be the very first bytes.
 		assert full.raw.len >= 9
 		assert full.raw[3] == u8(0x04), 'first frame must be SETTINGS'

--- a/examples/http2_cleartext/src/server_end_to_end_test.v
+++ b/examples/http2_cleartext/src/server_end_to_end_test.v
@@ -1,0 +1,155 @@
+module main
+
+// End-to-end proof of http2-over-the-seam through a real epoll worker, on
+// vtest: the client preface flips the connection, SETTINGS are exchanged,
+// and requests round-trip through the SAME handler that serves the h1
+// connection in the same run. Raw bytes in scripts, until-predicates over
+// raw bytes out (http2 responses are frame-framed, so `want` counting never
+// applies). Linux-only invocation: the takeover seam is epoll-first.
+import http2
+import server
+import vtest
+
+const e2e_home_body = 'hello over one handler\n'.bytes()
+
+fn e2e_index_bytes(acc []u8, needle []u8) int {
+	if needle.len == 0 || acc.len < needle.len {
+		return -1
+	}
+	for i := 0; i <= acc.len - needle.len; i++ {
+		mut hit := true
+		for j in 0 .. needle.len {
+			if acc[i + j] != needle[j] {
+				hit = false
+				break
+			}
+		}
+		if hit {
+			return i
+		}
+	}
+	return -1
+}
+
+// e2e_until_bytes packages "this exact byte sequence arrived" as a predicate.
+fn e2e_until_bytes(needle []u8) fn (acc []u8) bool {
+	return fn [needle] (acc []u8) bool {
+		return e2e_index_bytes(acc, needle) >= 0
+	}
+}
+
+// e2e_get_opening is the whole client opening in ONE write — preface, empty
+// SETTINGS, and a GET / that ends the stream — the seam's trickiest ordering
+// (frames pipelined behind the preface request in the same segment).
+fn e2e_get_opening() []u8 {
+	mut b := []u8{}
+	b << http2.preface
+	http2.write_settings(mut b, [])
+	mut block := []u8{}
+	http2.encode_indexed(mut block, 2) // :method GET
+	http2.encode_indexed(mut block, 6) // :scheme http
+	http2.encode_indexed(mut block, 4) // :path /
+	http2.encode_literal_name_idx(mut block, 1, 'x.test')
+	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream,
+		1, block.len)
+	b << block
+	return b
+}
+
+fn e2e_post_echo(stream_id u32, payload string) []u8 {
+	mut b := []u8{}
+	mut block := []u8{}
+	http2.encode_indexed(mut block, 3) // :method POST
+	http2.encode_indexed(mut block, 6)
+	http2.encode_literal_name_idx(mut block, 4, '/echo')
+	http2.encode_literal_name_idx(mut block, 1, 'x.test')
+	http2.write_frame_header(mut b, .headers, http2.flag_end_headers, stream_id, block.len)
+	b << block
+	http2.write_data_header(mut b, stream_id, payload.len, true)
+	b << payload.bytes()
+	return b
+}
+
+fn e2e_ping() []u8 {
+	mut b := []u8{}
+	http2.write_frame_header(mut b, .ping, 0, 0, 8)
+	b << [u8(0xca), 0xfe, 0xba, 0xbe, 0x00, 0x11, 0x22, 0x33]
+	return b
+}
+
+// e2e_ping_ack is the exact PING ack the server must send back: same opaque
+// payload, ACK flag set.
+fn e2e_ping_ack() []u8 {
+	mut b := []u8{}
+	http2.write_frame_header(mut b, .ping, http2.flag_ack, 0, 8)
+	b << [u8(0xca), 0xfe, 0xba, 0xbe, 0x00, 0x11, 0x22, 0x33]
+	return b
+}
+
+fn e2e_goaway() []u8 {
+	mut b := []u8{}
+	http2.write_goaway(mut b, 0, .no_error)
+	return b
+}
+
+fn test_http2_cleartext_end_to_end() {
+	$if linux {
+		out := vtest.drive(server.ServerConfig{
+			io_multiplexing: .epoll
+			handler:         handle
+		}, [
+			// Conn 0 — the full choreography on one connection: opening burst
+			// (preface + SETTINGS + GET pipelined), a second request, a PING,
+			// then a clean GOAWAY from the client.
+			vtest.Script{
+				rounds:   [
+					vtest.Round{
+						send:  e2e_get_opening()
+						until: e2e_until_bytes(e2e_home_body)
+					},
+					vtest.Round{
+						send:  e2e_post_echo(3, 'ping-pong-payload')
+						until: e2e_until_bytes('ping-pong-payload'.bytes())
+					},
+					vtest.Round{
+						send:  e2e_ping()
+						until: e2e_until_bytes(e2e_ping_ack())
+					},
+					vtest.Round{
+						send:  e2e_goaway()
+						until: fn (acc []u8) bool {
+							return true // no reply expected — just the close below
+						}
+					},
+				]
+				then_eof: true
+			},
+			// Conn 1 — plain HTTP/1.1 on the same port, same handler: the
+			// protocols coexist per connection, not per server.
+			vtest.Script{
+				rounds: [
+					vtest.Round{
+						send:  'GET / HTTP/1.1\r\nHost: x\r\n\r\n'.bytes()
+						until: e2e_until_bytes(e2e_home_body)
+					},
+				]
+			},
+		]) or {
+			assert false, err.msg()
+			return
+		}
+		full := out.conns[0]
+		assert full.connect_err == '', full.connect_err
+		assert !full.unmet, 'choreography ended early: ${full.raw.bytestr()}'
+		assert full.eof, 'server must close after the client GOAWAY'
+		// The server preface (a SETTINGS frame) must be the very first bytes.
+		assert full.raw.len >= 9
+		assert full.raw[3] == u8(0x04), 'first frame must be SETTINGS'
+		assert e2e_index_bytes(full.raw, e2e_home_body) >= 0
+
+		h1 := out.conns[1]
+		assert h1.connect_err == '', h1.connect_err
+		assert !h1.unmet
+		assert e2e_index_bytes(h1.raw, 'HTTP/1.1 200 OK'.bytes()) >= 0
+	}
+}

--- a/http2/conn.v
+++ b/http2/conn.v
@@ -47,12 +47,20 @@ const max_body_bytes = 8 * 1024 * 1024
 @[heap]
 struct StreamState {
 mut:
-	headers     []HeaderField
-	body        []u8
-	remote_done bool // END_STREAM received — the request is complete
-	recv_window i64
-	send_window i64
-	pending     []u8 // response DATA parked until the peer opens its window
+	headers []HeaderField
+	body    []u8
+	// END_STREAM received — the request side is complete
+	remote_done bool
+	// refused or malformed (§8.3): the RST already went out; keep draining the
+	// stream's frames quietly, never surface it as a request
+	rejected bool
+	// content-length asserted by the header block, -1 = none (§8.1.1: it must
+	// equal the DATA total, checked when the request side completes)
+	declared_len i64 = -1
+	recv_window  i64
+	send_window  i64
+	// response DATA parked until the peer opens its window
+	pending     []u8
 	pending_off int
 	pending_end bool
 }
@@ -73,6 +81,7 @@ mut:
 	hdr_end_stream bool
 	hdr_refused    bool
 	hdr_trailers   bool
+	hdr_malformed  bool
 	hdr_block      []u8
 	// peer-declared limits and both directions' flow-control windows
 	peer_max_frame   int = default_max_frame_size
@@ -151,6 +160,12 @@ pub fn (mut c ServerConn) consume(buf []u8, mut out []u8, mut reqs []Http2Reques
 			[]u8{}
 		}
 		if u8(fh.type_) > u8(FrameType.continuation) {
+			if c.hdr_expecting {
+				// A header block must be a contiguous frame sequence — even
+				// unknown frame types cannot interleave (§4.3).
+				write_goaway(mut out, c.last_stream, .protocol_error)
+				return consumed, true
+			}
 			consumed += total // unknown frame types MUST be ignored (§4.1)
 			continue
 		}
@@ -187,11 +202,17 @@ fn (mut c ServerConn) frame(fh FrameHeader, payload []u8, mut out []u8, mut reqs
 			if payload.len != 5 {
 				return .frame_size_error
 			}
-			return .no_error // deprecated scheme — parsed, ignored (§6.3)
+			dep := read_u32(payload, 0) & 0x7fffffff
+			if dep == fh.stream_id {
+				// A stream cannot depend on itself — stream error (§5.3.1).
+				write_rst_stream(mut out, fh.stream_id, .protocol_error)
+				c.streams.delete(fh.stream_id)
+			}
+			return .no_error // deprecated scheme — parsed, otherwise ignored (§6.3)
 		}
 		.rst_stream {
-			if fh.stream_id == 0 {
-				return .protocol_error
+			if fh.stream_id == 0 || fh.stream_id > c.last_stream {
+				return .protocol_error // includes RST on an idle stream (§6.4)
 			}
 			if payload.len != 4 {
 				return .frame_size_error
@@ -263,19 +284,27 @@ fn (mut c ServerConn) on_headers(fh FrameHeader, payload []u8, mut out []u8, mut
 		}
 		end = payload.len - pad
 	}
+	c.hdr_trailers = false
+	c.hdr_refused = false
+	c.hdr_malformed = false
 	if fh.flags & flag_priority != 0 {
 		if off + 5 > end {
 			return .protocol_error
 		}
+		dep := read_u32(payload, off) & 0x7fffffff
+		if dep == fh.stream_id {
+			c.hdr_malformed = true // self-dependency — stream error (§5.3.1)
+		}
 		off += 5
 	}
-	c.hdr_trailers = false
-	c.hdr_refused = false
 	if fh.stream_id in c.streams {
 		s := c.streams[fh.stream_id] or { return .internal_error }
-		// A second HEADERS on an open stream: trailers — only valid while the
-		// request side is open and only when it closes it (§8.1).
-		if s.remote_done || fh.flags & flag_end_stream == 0 {
+		if s.remote_done {
+			return .stream_closed // HEADERS on half-closed (remote) (§5.1)
+		}
+		// A second HEADERS on an open stream: trailers — only valid when the
+		// block also closes the request side (§8.1).
+		if fh.flags & flag_end_stream == 0 {
 			return .protocol_error
 		}
 		c.hdr_trailers = true
@@ -313,36 +342,180 @@ fn (mut c ServerConn) finish_header_block(mut out []u8, mut reqs []Http2Request)
 	}
 	stream_id := c.hdr_stream
 	if c.hdr_trailers {
+		if !valid_trailer_fields(fields) {
+			// Pseudo-headers or connection-specific fields in trailers make
+			// the request malformed (§8.1, §8.3) — stream error.
+			write_rst_stream(mut out, stream_id, .protocol_error)
+			c.streams.delete(stream_id)
+			return .no_error
+		}
 		// Trailers kept the HPACK state consistent; their fields are not
 		// surfaced (v1) — they complete the request as END_STREAM does.
-		mut s := c.streams[stream_id] or { return .internal_error }
-		s.remote_done = true
-		reqs << Http2Request{
-			stream_id: stream_id
-			headers:   s.headers
-			body:      s.body
-		}
+		c.complete_stream(stream_id, mut out, mut reqs)
 		return .no_error
 	}
 	if c.hdr_refused {
 		write_rst_stream(mut out, stream_id, .refused_stream)
 		return .no_error
 	}
+	ok, declared := validate_request_fields(fields)
+	malformed := c.hdr_malformed || !ok
 	mut s := &StreamState{
-		headers:     fields
-		recv_window: i64(default_window_size)
-		send_window: c.init_send_window
+		headers:      fields
+		rejected:     malformed
+		declared_len: declared
+		recv_window:  i64(default_window_size)
+		send_window:  c.init_send_window
 	}
 	c.streams[stream_id] = s
+	if malformed {
+		// Malformed request (§8.3): a stream error, never surfaced. The
+		// rejected stream state stays so the client's in-flight frames for it
+		// drain quietly instead of escalating to a connection error.
+		write_rst_stream(mut out, stream_id, .protocol_error)
+	}
 	if c.hdr_end_stream {
-		s.remote_done = true
-		reqs << Http2Request{
-			stream_id: stream_id
-			headers:   s.headers
-			body:      s.body
-		}
+		c.complete_stream(stream_id, mut out, mut reqs)
 	}
 	return .no_error
+}
+
+// complete_stream ends a stream's request side: rejected streams and
+// content-length violations are dropped, everything else surfaces as a
+// complete request (the stream stays for the response to be written).
+fn (mut c ServerConn) complete_stream(stream_id u32, mut out []u8, mut reqs []Http2Request) {
+	mut s := c.streams[stream_id] or { return }
+	s.remote_done = true
+	if s.rejected {
+		c.streams.delete(stream_id)
+		return
+	}
+	if s.declared_len >= 0 && s.declared_len != i64(s.body.len) {
+		// content-length must equal the DATA total (§8.1.1) — malformed.
+		write_rst_stream(mut out, stream_id, .protocol_error)
+		c.streams.delete(stream_id)
+		return
+	}
+	reqs << Http2Request{
+		stream_id: stream_id
+		headers:   s.headers
+		body:      s.body
+	}
+}
+
+// validate_request_fields enforces the malformed-request rules of RFC 9113
+// §8.2/§8.3 on a decoded request header list. Returns validity plus the
+// declared content-length (-1 when absent).
+fn validate_request_fields(fields []HeaderField) (bool, i64) {
+	mut seen_regular := false
+	mut method := ''
+	mut n_method := 0
+	mut n_scheme := 0
+	mut n_path := 0
+	mut n_authority := 0
+	mut declared := i64(-1)
+	for f in fields {
+		if f.name.len == 0 {
+			return false, -1
+		}
+		if f.name[0] == `:` {
+			if seen_regular {
+				return false, -1 // pseudo-header after a regular field (§8.3)
+			}
+			match f.name {
+				':method' {
+					n_method++
+					method = f.value
+				}
+				':scheme' {
+					n_scheme++
+				}
+				':path' {
+					n_path++
+					if f.value.len == 0 {
+						return false, -1 // empty :path (§8.3.1)
+					}
+				}
+				':authority' {
+					n_authority++
+				}
+				else {
+					return false, -1 // unknown or response pseudo-header (§8.3)
+				}
+			}
+			continue
+		}
+		seen_regular = true
+		if !valid_regular_field_name(f.name) {
+			return false, -1
+		}
+		if f.name == 'te' && f.value != 'trailers' {
+			return false, -1 // te may only carry 'trailers' (§8.2.2)
+		}
+		if f.name == 'content-length' {
+			n := parse_content_length(f.value)
+			if n < 0 {
+				return false, -1
+			}
+			if declared >= 0 && declared != n {
+				return false, -1 // differing duplicates (§8.1.1)
+			}
+			declared = n
+		}
+	}
+	if n_method != 1 || n_authority > 1 {
+		return false, -1
+	}
+	if method == 'CONNECT' {
+		// CONNECT omits :scheme and :path and requires :authority (§8.5).
+		if n_scheme != 0 || n_path != 0 || n_authority != 1 {
+			return false, -1
+		}
+	} else if n_scheme != 1 || n_path != 1 {
+		return false, -1 // exactly one of each (§8.3.1)
+	}
+	return true, declared
+}
+
+// valid_regular_field_name rejects uppercase (http2 field names are
+// lowercase on the wire, §8.2) and the connection-specific fields that must
+// not exist in http2 framing (§8.2.2).
+fn valid_regular_field_name(name string) bool {
+	for ch in name {
+		if (ch >= `A` && ch <= `Z`) || ch == ` ` || ch == 0 {
+			return false
+		}
+	}
+	return match name {
+		'connection', 'keep-alive', 'proxy-connection', 'transfer-encoding', 'upgrade' { false }
+		else { true }
+	}
+}
+
+// valid_trailer_fields: trailers carry only regular fields (§8.1).
+fn valid_trailer_fields(fields []HeaderField) bool {
+	for f in fields {
+		if f.name.len == 0 || f.name[0] == `:` || !valid_regular_field_name(f.name) {
+			return false
+		}
+	}
+	return true
+}
+
+// parse_content_length parses a strictly-decimal content-length; -1 on
+// anything else (signs, blanks, non-digits, absurd width).
+fn parse_content_length(s string) i64 {
+	if s.len == 0 || s.len > 18 {
+		return -1
+	}
+	mut n := i64(0)
+	for ch in s {
+		if ch < `0` || ch > `9` {
+			return -1
+		}
+		n = n * 10 + i64(ch - `0`)
+	}
+	return n
 }
 
 fn (mut c ServerConn) on_data(fh FrameHeader, payload []u8, mut out []u8, mut reqs []Http2Request) ErrorCode {
@@ -350,7 +523,10 @@ fn (mut c ServerConn) on_data(fh FrameHeader, payload []u8, mut out []u8, mut re
 		return .protocol_error
 	}
 	if fh.stream_id !in c.streams {
-		return .stream_closed // DATA on an idle/closed stream (§6.1)
+		if fh.stream_id > c.last_stream {
+			return .protocol_error // DATA on an idle stream (§5.1, §6.1)
+		}
+		return .stream_closed // DATA on a fully closed stream (§5.1)
 	}
 	mut s := c.streams[fh.stream_id] or { return .internal_error }
 	if s.remote_done {
@@ -375,11 +551,13 @@ fn (mut c ServerConn) on_data(fh FrameHeader, payload []u8, mut out []u8, mut re
 		}
 		end = payload.len - pad
 	}
-	if s.body.len + (end - off) > max_body_bytes {
-		return .enhance_your_calm // mirrors the h1 request-size ceiling
-	}
-	if end > off {
-		unsafe { s.body.push_many(&payload[off], end - off) }
+	if !s.rejected {
+		if s.body.len + (end - off) > max_body_bytes {
+			return .enhance_your_calm // mirrors the h1 request-size ceiling
+		}
+		if end > off {
+			unsafe { s.body.push_many(&payload[off], end - off) }
+		}
 	}
 	// Replenish eagerly: bodies are consumed on arrival (handlers see whole
 	// requests), so the peer's view of both windows snaps back to full.
@@ -392,12 +570,7 @@ fn (mut c ServerConn) on_data(fh FrameHeader, payload []u8, mut out []u8, mut re
 		}
 	}
 	if fh.flags & flag_end_stream != 0 {
-		s.remote_done = true
-		reqs << Http2Request{
-			stream_id: fh.stream_id
-			headers:   s.headers
-			body:      s.body
-		}
+		c.complete_stream(fh.stream_id, mut out, mut reqs)
 	}
 	return .no_error
 }
@@ -449,6 +622,12 @@ fn (mut c ServerConn) on_window_update(fh FrameHeader, payload []u8, mut out []u
 		return .frame_size_error
 	}
 	inc := read_u32(payload, 0) & 0x7fffffff
+	if fh.stream_id != 0 && inc == 0 {
+		// Zero increment on a stream is a STREAM error (§6.9).
+		write_rst_stream(mut out, fh.stream_id, .protocol_error)
+		c.streams.delete(fh.stream_id)
+		return .no_error
+	}
 	if inc == 0 {
 		return .protocol_error
 	}

--- a/http2/conn.v
+++ b/http2/conn.v
@@ -235,6 +235,9 @@ fn (mut c ServerConn) frame(fh FrameHeader, payload []u8, mut out []u8, mut reqs
 			return .no_error
 		}
 		.goaway {
+			if fh.stream_id != 0 {
+				return .protocol_error // GOAWAY is connection-level only (§6.8)
+			}
 			if payload.len < 8 {
 				return .frame_size_error
 			}

--- a/http2/conn.v
+++ b/http2/conn.v
@@ -72,7 +72,6 @@ pub struct ServerConn {
 mut:
 	dec          HpackDecoder
 	preface_seen bool
-	saw_goaway   bool
 	last_stream  u32
 	streams      map[u32]&StreamState
 	// header-block assembly: HEADERS..CONTINUATION must be contiguous (§4.3)
@@ -176,10 +175,7 @@ pub fn (mut c ServerConn) consume(buf []u8, mut out []u8, mut reqs []Http2Reques
 			return consumed, true
 		}
 	}
-	// A peer GOAWAY closes the connection — but only after the whole burst
-	// is processed, so frames sent alongside it (e.g. a PING) still get
-	// their answers flushed before the FIN instead of dying in an RST.
-	return consumed, c.saw_goaway
+	return consumed, false
 }
 
 // frame dispatches one complete frame. Any code but .no_error is
@@ -242,7 +238,11 @@ fn (mut c ServerConn) frame(fh FrameHeader, payload []u8, mut out []u8, mut reqs
 			if payload.len < 8 {
 				return .frame_size_error
 			}
-			c.saw_goaway = true
+			// A peer GOAWAY only forbids NEW streams from our side (we open
+			// none — no push). Keep serving: in-flight streams finish, pings
+			// still get acks, and the peer closes the TCP connection when it
+			// is done (the engine reaps the EOF). Closing eagerly here turned
+			// the peer's follow-up frames into TCP resets (§6.8).
 			return .no_error
 		}
 		.window_update {
@@ -586,6 +586,7 @@ fn (mut c ServerConn) on_settings(fh FrameHeader, payload []u8, mut out []u8) Er
 		return .no_error
 	}
 	settings := parse_settings(payload) or { return .frame_size_error }
+	mut window_changed := false
 	for st in settings {
 		if st.id == setting_initial_window_size {
 			if st.val > max_window {
@@ -599,6 +600,7 @@ fn (mut c ServerConn) on_settings(fh FrameHeader, payload []u8, mut out []u8) Er
 				mut s := c.streams[id] or { continue }
 				s.send_window += delta
 			}
+			window_changed = true
 		} else if st.id == setting_max_frame_size {
 			if st.val < u32(default_max_frame_size) || st.val > 16777215 {
 				return .protocol_error
@@ -614,6 +616,12 @@ fn (mut c ServerConn) on_settings(fh FrameHeader, payload []u8, mut out []u8) Er
 		// identifiers are ignored (§6.5.2).
 	}
 	write_settings_ack(mut out)
+	if window_changed {
+		// A grown initial window may have unparked response DATA (§6.9.2).
+		for id in c.streams.keys() {
+			c.flush_pending(mut out, id)
+		}
+	}
 	return .no_error
 }
 

--- a/http2/conn.v
+++ b/http2/conn.v
@@ -1,0 +1,553 @@
+module http2
+
+// Server-side HTTP/2 connection state machine (RFC 9113), designed to sit
+// behind the engine's connection-takeover seam (issue #136): `consume` has
+// exactly a ConnHandler's shape — bytes in, response bytes appended to the
+// caller's `out`, consumed count back — without importing core (the protocol
+// module stays engine-free; the ConnHandler wrapper composing this with the
+// application handler lives with its consumer, see examples/http2_cleartext).
+//
+// Scope (deliberate, rule 3 — don't complicate it):
+//   - cleartext prior-knowledge only: the client preface's `PRI * HTTP/2.0`
+//     line reaches the request handler as an ordinary parsed request, the
+//     handler takes the connection over, and this machine picks up at the
+//     `SM\r\n\r\n` tail left in the read buffer.
+//   - requests surface only when COMPLETE (END_STREAM seen): handlers are
+//     pure functions of a whole request, same as the h1 path.
+//   - flow control is honored on the send side (DATA parks in the stream's
+//     pending buffer until WINDOW_UPDATE) and replenished eagerly on the
+//     receive side (bodies are consumed on arrival, so both windows snap
+//     back to full after every DATA frame).
+//   - trailers are decoded (HPACK state is connection-global and MUST see
+//     every block) but not surfaced; PRIORITY is parsed and ignored.
+//   - errors follow RFC 9113 §5.4: connection-fatal ones append a GOAWAY and
+//     report close; refused/overflowing streams get RST_STREAM.
+
+// Http2Request is one complete request: decoded header list (pseudo-headers
+// like :method/:path included, in wire order) plus the reassembled body.
+pub struct Http2Request {
+pub:
+	stream_id u32
+	headers   []HeaderField
+	body      []u8
+}
+
+// max_concurrent_streams is advertised in the server preface SETTINGS and
+// enforced: streams opened beyond it are refused (RST_STREAM REFUSED_STREAM).
+pub const max_concurrent_streams = 128
+
+// A header block (HEADERS + CONTINUATIONs, before decompression) larger than
+// this closes the connection — mirrors the h1 431 posture.
+const max_header_block = 64 * 1024
+
+// A request body larger than this closes the connection — mirrors the h1
+// engine's built-in request ceiling (sm_max_request_bytes).
+const max_body_bytes = 8 * 1024 * 1024
+
+@[heap]
+struct StreamState {
+mut:
+	headers     []HeaderField
+	body        []u8
+	remote_done bool // END_STREAM received — the request is complete
+	recv_window i64
+	send_window i64
+	pending     []u8 // response DATA parked until the peer opens its window
+	pending_off int
+	pending_end bool
+}
+
+// ServerConn is one connection's HTTP/2 state. Allocate with new_server_conn
+// and keep it per connection (it is the natural takeover_state value).
+@[heap]
+pub struct ServerConn {
+mut:
+	dec          HpackDecoder
+	preface_seen bool
+	saw_goaway   bool
+	last_stream  u32
+	streams      map[u32]&StreamState
+	// header-block assembly: HEADERS..CONTINUATION must be contiguous (§4.3)
+	hdr_expecting  bool
+	hdr_stream     u32
+	hdr_end_stream bool
+	hdr_refused    bool
+	hdr_trailers   bool
+	hdr_block      []u8
+	// peer-declared limits and both directions' flow-control windows
+	peer_max_frame   int = default_max_frame_size
+	init_send_window i64 = i64(default_window_size)
+	conn_send_window i64 = i64(default_window_size)
+	conn_recv_window i64 = i64(default_window_size)
+}
+
+// new_server_conn returns a fresh connection state (heap — it must outlive
+// the handler invocation that created it).
+pub fn new_server_conn() &ServerConn {
+	return &ServerConn{
+		dec: new_decoder(hpack_default_table_size)
+	}
+}
+
+// write_server_preface appends the server connection preface — the SETTINGS
+// frame RFC 9113 §3.4 requires as the server's first bytes. The upgrade
+// handler appends this as its "switching response" when queueing the
+// takeover, so it is flushed before any client frame is answered.
+pub fn (mut c ServerConn) write_server_preface(mut out []u8) {
+	write_settings(mut out, [
+		Setting{
+			id:  setting_max_concurrent_streams
+			val: u32(max_concurrent_streams)
+		},
+		Setting{
+			id:  setting_header_table_size
+			val: u32(hpack_default_table_size)
+		},
+	])
+}
+
+// consume processes as many complete frames as `buf` holds. Completed
+// requests are appended to `reqs`; protocol-mandated replies (SETTINGS ack,
+// PING ack, WINDOW_UPDATE, RST_STREAM, GOAWAY) are appended to `out`.
+// Returns the bytes consumed and whether the connection must close (GOAWAY
+// written or received) — a ConnHandler maps that straight to .done/.close.
+pub fn (mut c ServerConn) consume(buf []u8, mut out []u8, mut reqs []Http2Request) (int, bool) {
+	mut consumed := 0
+	if !c.preface_seen {
+		if buf.len < preface_tail.len {
+			return 0, false
+		}
+		for i in 0 .. preface_tail.len {
+			if buf[i] != preface_tail[i] {
+				write_goaway(mut out, 0, .protocol_error)
+				return consumed, true
+			}
+		}
+		consumed = preface_tail.len
+		c.preface_seen = true
+	}
+	for {
+		rest := buf.len - consumed
+		if rest < frame_header_len {
+			break
+		}
+		fh := parse_frame_header(unsafe { (&buf[consumed]).vbytes(rest) }) or {
+			write_goaway(mut out, c.last_stream, .internal_error)
+			return consumed, true
+		}
+		if int(fh.length) > default_max_frame_size {
+			// We never raise SETTINGS_MAX_FRAME_SIZE, so a bigger frame is a
+			// peer error (§4.2) — and the ceiling on buffering one frame.
+			write_goaway(mut out, c.last_stream, .frame_size_error)
+			return consumed, true
+		}
+		total := frame_header_len + int(fh.length)
+		if rest < total {
+			break // partial frame — the engine buffers the tail and re-calls
+		}
+		payload := if fh.length > 0 {
+			unsafe { (&buf[consumed + frame_header_len]).vbytes(int(fh.length)) }
+		} else {
+			[]u8{}
+		}
+		if u8(fh.type_) > u8(FrameType.continuation) {
+			consumed += total // unknown frame types MUST be ignored (§4.1)
+			continue
+		}
+		code := c.frame(fh, payload, mut out, mut reqs)
+		consumed += total
+		if code != .no_error {
+			write_goaway(mut out, c.last_stream, code)
+			return consumed, true
+		}
+		if c.saw_goaway {
+			return consumed, true
+		}
+	}
+	return consumed, false
+}
+
+// frame dispatches one complete frame. Any code but .no_error is
+// connection-fatal (consume answers with GOAWAY).
+fn (mut c ServerConn) frame(fh FrameHeader, payload []u8, mut out []u8, mut reqs []Http2Request) ErrorCode {
+	if c.hdr_expecting && fh.type_ != .continuation {
+		return .protocol_error // a header block must be contiguous (§4.3)
+	}
+	match fh.type_ {
+		.data {
+			return c.on_data(fh, payload, mut out, mut reqs)
+		}
+		.headers {
+			return c.on_headers(fh, payload, mut out, mut reqs)
+		}
+		.priority {
+			if fh.stream_id == 0 {
+				return .protocol_error
+			}
+			if payload.len != 5 {
+				return .frame_size_error
+			}
+			return .no_error // deprecated scheme — parsed, ignored (§6.3)
+		}
+		.rst_stream {
+			if fh.stream_id == 0 {
+				return .protocol_error
+			}
+			if payload.len != 4 {
+				return .frame_size_error
+			}
+			c.streams.delete(fh.stream_id)
+			return .no_error
+		}
+		.settings {
+			return c.on_settings(fh, payload, mut out)
+		}
+		.push_promise {
+			return .protocol_error // clients cannot push (§8.4)
+		}
+		.ping {
+			if fh.stream_id != 0 {
+				return .protocol_error
+			}
+			if payload.len != 8 {
+				return .frame_size_error
+			}
+			if fh.flags & flag_ack == 0 {
+				write_ping_ack(mut out, payload)
+			}
+			return .no_error
+		}
+		.goaway {
+			if payload.len < 8 {
+				return .frame_size_error
+			}
+			c.saw_goaway = true
+			return .no_error
+		}
+		.window_update {
+			return c.on_window_update(fh, payload, mut out)
+		}
+		.continuation {
+			if !c.hdr_expecting || fh.stream_id != c.hdr_stream {
+				return .protocol_error
+			}
+			if c.hdr_block.len + payload.len > max_header_block {
+				return .enhance_your_calm
+			}
+			if payload.len > 0 {
+				unsafe { c.hdr_block.push_many(&payload[0], payload.len) }
+			}
+			if fh.flags & flag_end_headers != 0 {
+				return c.finish_header_block(mut out, mut reqs)
+			}
+			return .no_error
+		}
+	}
+	return .no_error
+}
+
+fn (mut c ServerConn) on_headers(fh FrameHeader, payload []u8, mut out []u8, mut reqs []Http2Request) ErrorCode {
+	if fh.stream_id == 0 || fh.stream_id & 1 == 0 {
+		return .protocol_error // client streams are odd (§5.1.1)
+	}
+	mut off := 0
+	mut end := payload.len
+	if fh.flags & flag_padded != 0 {
+		if payload.len < 1 {
+			return .protocol_error
+		}
+		pad := int(payload[0])
+		off = 1
+		if off + pad > payload.len {
+			return .protocol_error
+		}
+		end = payload.len - pad
+	}
+	if fh.flags & flag_priority != 0 {
+		if off + 5 > end {
+			return .protocol_error
+		}
+		off += 5
+	}
+	c.hdr_trailers = false
+	c.hdr_refused = false
+	if fh.stream_id in c.streams {
+		s := c.streams[fh.stream_id] or { return .internal_error }
+		// A second HEADERS on an open stream: trailers — only valid while the
+		// request side is open and only when it closes it (§8.1).
+		if s.remote_done || fh.flags & flag_end_stream == 0 {
+			return .protocol_error
+		}
+		c.hdr_trailers = true
+	} else {
+		if fh.stream_id <= c.last_stream {
+			return .protocol_error // new stream ids must ascend (§5.1.1)
+		}
+		c.last_stream = fh.stream_id
+		if c.streams.len >= max_concurrent_streams {
+			// The block still decodes below — HPACK state is connection-wide
+			// (§4.3) — but the stream itself is refused.
+			c.hdr_refused = true
+		}
+	}
+	c.hdr_stream = fh.stream_id
+	c.hdr_end_stream = fh.flags & flag_end_stream != 0
+	c.hdr_block.clear()
+	if end > off {
+		unsafe { c.hdr_block.push_many(&payload[off], end - off) }
+	}
+	if fh.flags & flag_end_headers != 0 {
+		return c.finish_header_block(mut out, mut reqs)
+	}
+	c.hdr_expecting = true
+	return .no_error
+}
+
+// finish_header_block runs once END_HEADERS arrives: decompress, then either
+// surface trailers-completion, refuse, or open the stream (and complete the
+// request when END_STREAM rode the HEADERS).
+fn (mut c ServerConn) finish_header_block(mut out []u8, mut reqs []Http2Request) ErrorCode {
+	c.hdr_expecting = false
+	fields := c.dec.decode(c.hdr_block) or {
+		return .compression_error // table state is unrecoverable (RFC 7541 §5.3)
+	}
+	stream_id := c.hdr_stream
+	if c.hdr_trailers {
+		// Trailers kept the HPACK state consistent; their fields are not
+		// surfaced (v1) — they complete the request as END_STREAM does.
+		mut s := c.streams[stream_id] or { return .internal_error }
+		s.remote_done = true
+		reqs << Http2Request{
+			stream_id: stream_id
+			headers:   s.headers
+			body:      s.body
+		}
+		return .no_error
+	}
+	if c.hdr_refused {
+		write_rst_stream(mut out, stream_id, .refused_stream)
+		return .no_error
+	}
+	mut s := &StreamState{
+		headers:     fields
+		recv_window: i64(default_window_size)
+		send_window: c.init_send_window
+	}
+	c.streams[stream_id] = s
+	if c.hdr_end_stream {
+		s.remote_done = true
+		reqs << Http2Request{
+			stream_id: stream_id
+			headers:   s.headers
+			body:      s.body
+		}
+	}
+	return .no_error
+}
+
+fn (mut c ServerConn) on_data(fh FrameHeader, payload []u8, mut out []u8, mut reqs []Http2Request) ErrorCode {
+	if fh.stream_id == 0 {
+		return .protocol_error
+	}
+	if fh.stream_id !in c.streams {
+		return .stream_closed // DATA on an idle/closed stream (§6.1)
+	}
+	mut s := c.streams[fh.stream_id] or { return .internal_error }
+	if s.remote_done {
+		return .stream_closed
+	}
+	flow := payload.len // padding counts toward flow control (§6.9.1)
+	c.conn_recv_window -= i64(flow)
+	s.recv_window -= i64(flow)
+	if c.conn_recv_window < 0 || s.recv_window < 0 {
+		return .flow_control_error
+	}
+	mut off := 0
+	mut end := payload.len
+	if fh.flags & flag_padded != 0 {
+		if payload.len < 1 {
+			return .protocol_error
+		}
+		pad := int(payload[0])
+		off = 1
+		if off + pad > payload.len {
+			return .protocol_error
+		}
+		end = payload.len - pad
+	}
+	if s.body.len + (end - off) > max_body_bytes {
+		return .enhance_your_calm // mirrors the h1 request-size ceiling
+	}
+	if end > off {
+		unsafe { s.body.push_many(&payload[off], end - off) }
+	}
+	// Replenish eagerly: bodies are consumed on arrival (handlers see whole
+	// requests), so the peer's view of both windows snaps back to full.
+	if flow > 0 {
+		write_window_update(mut out, 0, u32(flow))
+		c.conn_recv_window += i64(flow)
+		if fh.flags & flag_end_stream == 0 {
+			write_window_update(mut out, fh.stream_id, u32(flow))
+			s.recv_window += i64(flow)
+		}
+	}
+	if fh.flags & flag_end_stream != 0 {
+		s.remote_done = true
+		reqs << Http2Request{
+			stream_id: fh.stream_id
+			headers:   s.headers
+			body:      s.body
+		}
+	}
+	return .no_error
+}
+
+fn (mut c ServerConn) on_settings(fh FrameHeader, payload []u8, mut out []u8) ErrorCode {
+	if fh.stream_id != 0 {
+		return .protocol_error
+	}
+	if fh.flags & flag_ack != 0 {
+		if payload.len != 0 {
+			return .frame_size_error
+		}
+		return .no_error
+	}
+	settings := parse_settings(payload) or { return .frame_size_error }
+	for st in settings {
+		if st.id == setting_initial_window_size {
+			if st.val > max_window {
+				return .flow_control_error
+			}
+			delta := i64(st.val) - c.init_send_window
+			c.init_send_window = i64(st.val)
+			// §6.9.2: a changed initial window retroactively adjusts every
+			// open stream's send window (it may go negative).
+			for id in c.streams.keys() {
+				mut s := c.streams[id] or { continue }
+				s.send_window += delta
+			}
+		} else if st.id == setting_max_frame_size {
+			if st.val < u32(default_max_frame_size) || st.val > 16777215 {
+				return .protocol_error
+			}
+			c.peer_max_frame = int(st.val)
+		} else if st.id == setting_enable_push {
+			if st.val > 1 {
+				return .protocol_error
+			}
+		}
+		// setting_header_table_size needs no action: this server's encoder
+		// never indexes, so no encoder table exists to resize. Unknown
+		// identifiers are ignored (§6.5.2).
+	}
+	write_settings_ack(mut out)
+	return .no_error
+}
+
+fn (mut c ServerConn) on_window_update(fh FrameHeader, payload []u8, mut out []u8) ErrorCode {
+	if payload.len != 4 {
+		return .frame_size_error
+	}
+	inc := read_u32(payload, 0) & 0x7fffffff
+	if inc == 0 {
+		return .protocol_error
+	}
+	if fh.stream_id == 0 {
+		c.conn_send_window += i64(inc)
+		if c.conn_send_window > i64(max_window) {
+			return .flow_control_error
+		}
+		for id in c.streams.keys() {
+			c.flush_pending(mut out, id)
+		}
+		return .no_error
+	}
+	if fh.stream_id !in c.streams {
+		return .no_error // stream already finished — stale update, ignore
+	}
+	mut s := c.streams[fh.stream_id] or { return .internal_error }
+	s.send_window += i64(inc)
+	if s.send_window > i64(max_window) {
+		write_rst_stream(mut out, fh.stream_id, .flow_control_error)
+		c.streams.delete(fh.stream_id)
+		return .no_error // stream-level error (§6.9.1), connection lives on
+	}
+	c.flush_pending(mut out, fh.stream_id)
+	return .no_error
+}
+
+// write_response_headers appends the response HEADERS frame for `block` (an
+// HPACK block built with the encode_* helpers — :status first, RFC 9113
+// §8.3). A block wider than the peer's max frame size splits into
+// CONTINUATIONs. end_stream=true finishes the response (no body follows).
+pub fn (mut c ServerConn) write_response_headers(mut out []u8, stream_id u32, block []u8, end_stream bool) {
+	es := if end_stream { flag_end_stream } else { u8(0) }
+	if block.len <= c.peer_max_frame {
+		write_frame_header(mut out, .headers, flag_end_headers | es, stream_id, block.len)
+		out << block
+	} else {
+		write_frame_header(mut out, .headers, es, stream_id, c.peer_max_frame)
+		unsafe { out.push_many(&block[0], c.peer_max_frame) }
+		mut off := c.peer_max_frame
+		for off < block.len {
+			mut chunk := block.len - off
+			mut flags := flag_end_headers
+			if chunk > c.peer_max_frame {
+				chunk = c.peer_max_frame
+				flags = 0
+			}
+			write_frame_header(mut out, .continuation, flags, stream_id, chunk)
+			unsafe { out.push_many(&block[off], chunk) }
+			off += chunk
+		}
+	}
+	if end_stream {
+		c.streams.delete(stream_id)
+	}
+}
+
+// write_response_data appends the response body as DATA frames, respecting
+// the connection and stream send windows and the peer's max frame size.
+// Whatever the windows cannot take is parked in the stream's pending buffer
+// and flushed as the peer's WINDOW_UPDATEs arrive (through consume). The
+// last DATA frame carries END_STREAM and releases the stream state.
+pub fn (mut c ServerConn) write_response_data(mut out []u8, stream_id u32, body []u8) {
+	mut s := c.streams[stream_id] or { return }
+	if body.len == 0 {
+		write_data_header(mut out, stream_id, 0, true)
+		c.streams.delete(stream_id)
+		return
+	}
+	s.pending << body
+	s.pending_end = true
+	c.flush_pending(mut out, stream_id)
+}
+
+fn (mut c ServerConn) flush_pending(mut out []u8, stream_id u32) {
+	mut s := c.streams[stream_id] or { return }
+	for s.pending_off < s.pending.len {
+		mut allow := c.conn_send_window
+		if s.send_window < allow {
+			allow = s.send_window
+		}
+		if allow <= 0 {
+			return // parked until a WINDOW_UPDATE reopens a window
+		}
+		mut chunk := s.pending.len - s.pending_off
+		if i64(chunk) > allow {
+			chunk = int(allow)
+		}
+		if chunk > c.peer_max_frame {
+			chunk = c.peer_max_frame
+		}
+		last := s.pending_off + chunk == s.pending.len && s.pending_end
+		write_data_header(mut out, stream_id, chunk, last)
+		unsafe { out.push_many(&s.pending[s.pending_off], chunk) }
+		s.pending_off += chunk
+		c.conn_send_window -= i64(chunk)
+		s.send_window -= i64(chunk)
+	}
+	if s.pending_off == s.pending.len && s.pending_end {
+		c.streams.delete(stream_id)
+	}
+}

--- a/http2/conn.v
+++ b/http2/conn.v
@@ -531,7 +531,8 @@ fn (mut c ServerConn) flush_pending(mut out []u8, stream_id u32) {
 			allow = s.send_window
 		}
 		if allow <= 0 {
-			return // parked until a WINDOW_UPDATE reopens a window
+			// parked until a WINDOW_UPDATE reopens a window
+			return
 		}
 		mut chunk := s.pending.len - s.pending_off
 		if i64(chunk) > allow {

--- a/http2/conn.v
+++ b/http2/conn.v
@@ -175,11 +175,11 @@ pub fn (mut c ServerConn) consume(buf []u8, mut out []u8, mut reqs []Http2Reques
 			write_goaway(mut out, c.last_stream, code)
 			return consumed, true
 		}
-		if c.saw_goaway {
-			return consumed, true
-		}
 	}
-	return consumed, false
+	// A peer GOAWAY closes the connection — but only after the whole burst
+	// is processed, so frames sent alongside it (e.g. a PING) still get
+	// their answers flushed before the FIN instead of dying in an RST.
+	return consumed, c.saw_goaway
 }
 
 // frame dispatches one complete frame. Any code but .no_error is
@@ -622,16 +622,10 @@ fn (mut c ServerConn) on_window_update(fh FrameHeader, payload []u8, mut out []u
 		return .frame_size_error
 	}
 	inc := read_u32(payload, 0) & 0x7fffffff
-	if fh.stream_id != 0 && inc == 0 {
-		// Zero increment on a stream is a STREAM error (§6.9).
-		write_rst_stream(mut out, fh.stream_id, .protocol_error)
-		c.streams.delete(fh.stream_id)
-		return .no_error
-	}
-	if inc == 0 {
-		return .protocol_error
-	}
 	if fh.stream_id == 0 {
+		if inc == 0 {
+			return .protocol_error
+		}
 		c.conn_send_window += i64(inc)
 		if c.conn_send_window > i64(max_window) {
 			return .flow_control_error
@@ -639,6 +633,15 @@ fn (mut c ServerConn) on_window_update(fh FrameHeader, payload []u8, mut out []u
 		for id in c.streams.keys() {
 			c.flush_pending(mut out, id)
 		}
+		return .no_error
+	}
+	if fh.stream_id > c.last_stream {
+		return .protocol_error // WINDOW_UPDATE on an idle stream (§5.1)
+	}
+	if inc == 0 {
+		// Zero increment on a stream is a STREAM error (§6.9).
+		write_rst_stream(mut out, fh.stream_id, .protocol_error)
+		c.streams.delete(fh.stream_id)
 		return .no_error
 	}
 	if fh.stream_id !in c.streams {

--- a/http2/conn_test.v
+++ b/http2/conn_test.v
@@ -1,0 +1,351 @@
+module http2
+
+// ServerConn state-machine tests: client-side frames are built with the same
+// symmetric writers, fed through consume in engine-realistic slices (whole
+// bursts, split frames, pipelined preface), and the machine's output is
+// re-parsed with the same frame codec.
+
+struct ParsedFrame {
+	fh      FrameHeader
+	payload []u8
+}
+
+// frames_of splits an output buffer back into frames.
+fn frames_of(buf []u8) []ParsedFrame {
+	mut out := []ParsedFrame{}
+	mut pos := 0
+	for pos + frame_header_len <= buf.len {
+		fh := parse_frame_header(buf[pos..]) or { panic(err) }
+		total := frame_header_len + int(fh.length)
+		assert pos + total <= buf.len
+		out << ParsedFrame{
+			fh:      fh
+			payload: buf[pos + frame_header_len..pos + total]
+		}
+		pos += total
+	}
+	assert pos == buf.len
+	return out
+}
+
+fn hf(name string, value string) HeaderField {
+	return HeaderField{
+		name:  name
+		value: value
+	}
+}
+
+// get_request_block builds a GET / request header block from static indexes:
+// :method GET (2), :scheme http (6), :path / (4), :authority literal (1).
+fn get_request_block() []u8 {
+	mut block := []u8{}
+	encode_indexed(mut block, 2)
+	encode_indexed(mut block, 6)
+	encode_indexed(mut block, 4)
+	encode_literal_name_idx(mut block, 1, 'x.test')
+	return block
+}
+
+fn get_request_fields() []HeaderField {
+	return [hf(':method', 'GET'), hf(':scheme', 'http'), hf(':path', '/'),
+		hf(':authority', 'x.test')]
+}
+
+fn test_server_preface_parses() ! {
+	mut c := new_server_conn()
+	mut out := []u8{}
+	c.write_server_preface(mut out)
+	frames := frames_of(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .settings
+	assert frames[0].fh.flags & flag_ack == 0
+	settings := parse_settings(frames[0].payload)!
+	assert settings.len == 2
+	assert settings[0].id == setting_max_concurrent_streams
+	assert int(settings[0].val) == max_concurrent_streams
+}
+
+fn test_preface_tail_and_settings_handshake() {
+	mut c := new_server_conn()
+	mut input := []u8{}
+	input << preface_tail
+	write_settings(mut input, []) // empty client SETTINGS
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+	assert reqs.len == 0
+	frames := frames_of(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .settings
+	assert frames[0].fh.flags & flag_ack != 0
+}
+
+fn test_bad_preface_tail_closes() {
+	mut c := new_server_conn()
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume('XM\r\n\r\n'.bytes(), mut out, mut reqs)
+	assert closing
+	frames := frames_of(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .goaway
+}
+
+// handshake feeds the preface tail + empty client SETTINGS and discards the ack.
+fn handshake(mut c ServerConn) {
+	mut input := []u8{}
+	input << preface_tail
+	write_settings(mut input, [])
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+}
+
+fn test_get_request_and_response() ! {
+	mut c := new_server_conn()
+	handshake(mut c)
+	block := get_request_block()
+	mut input := []u8{}
+	write_frame_header(mut input, .headers, flag_end_headers | flag_end_stream, 1, block.len)
+	input << block
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+	assert reqs.len == 1
+	assert reqs[0].stream_id == 1
+	assert reqs[0].headers == get_request_fields()
+	assert reqs[0].body.len == 0
+
+	// Respond: 200 + a body, then check the wire shape end to end.
+	mut resp_block := []u8{}
+	encode_status(mut resp_block, 200)
+	encode_literal(mut resp_block, 'content-type', 'text/plain')
+	c.write_response_headers(mut out, 1, resp_block, false)
+	c.write_response_data(mut out, 1, 'hello over http2'.bytes())
+	frames := frames_of(out)
+	assert frames.len == 2
+	assert frames[0].fh.type_ == .headers
+	assert frames[0].fh.flags & flag_end_headers != 0
+	assert frames[0].fh.flags & flag_end_stream == 0
+	mut d := new_decoder(hpack_default_table_size)
+	decoded := d.decode(frames[0].payload)!
+	assert decoded == [hf(':status', '200'), hf('content-type', 'text/plain')]
+	assert frames[1].fh.type_ == .data
+	assert frames[1].fh.flags & flag_end_stream != 0
+	assert frames[1].payload.bytestr() == 'hello over http2'
+	// The stream is done — its state must be released.
+	assert c.streams.len == 0
+}
+
+fn test_post_body_and_window_replenish() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	mut block := []u8{}
+	encode_indexed(mut block, 3) // :method POST
+	encode_indexed(mut block, 6)
+	encode_indexed(mut block, 4)
+	encode_literal_name_idx(mut block, 1, 'x.test')
+	mut input := []u8{}
+	write_frame_header(mut input, .headers, flag_end_headers, 1, block.len)
+	input << block
+	write_data_header(mut input, 1, 5, false)
+	input << 'hello'.bytes()
+	write_data_header(mut input, 1, 6, true)
+	input << ' world'.bytes()
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+	assert reqs.len == 1
+	assert reqs[0].body.bytestr() == 'hello world'
+	// First DATA (not END_STREAM): connection + stream replenishment.
+	// Second DATA (END_STREAM): connection replenishment only.
+	frames := frames_of(out)
+	assert frames.len == 3
+	assert frames[0].fh.type_ == .window_update
+	assert frames[0].fh.stream_id == 0
+	assert read_u32(frames[0].payload, 0) == 5
+	assert frames[1].fh.type_ == .window_update
+	assert frames[1].fh.stream_id == 1
+	assert read_u32(frames[1].payload, 0) == 5
+	assert frames[2].fh.type_ == .window_update
+	assert frames[2].fh.stream_id == 0
+	assert read_u32(frames[2].payload, 0) == 6
+}
+
+fn test_partial_frame_buffering() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	block := get_request_block()
+	mut whole := []u8{}
+	write_frame_header(mut whole, .headers, flag_end_headers | flag_end_stream, 1, block.len)
+	whole << block
+	// First burst stops mid-payload: nothing consumed beyond complete frames.
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed1, closing1 := c.consume(whole[..whole.len - 3], mut out, mut reqs)
+	assert consumed1 == 0
+	assert !closing1
+	assert reqs.len == 0
+	// The engine compacts and re-calls with the tail appended.
+	consumed2, closing2 := c.consume(whole, mut out, mut reqs)
+	assert consumed2 == whole.len
+	assert !closing2
+	assert reqs.len == 1
+}
+
+fn test_ping_echo() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	opaque := [u8(9), 8, 7, 6, 5, 4, 3, 2]
+	mut input := []u8{}
+	write_frame_header(mut input, .ping, 0, 0, 8)
+	input << opaque
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert !closing
+	frames := frames_of(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .ping
+	assert frames[0].fh.flags & flag_ack != 0
+	assert frames[0].payload == opaque
+}
+
+fn test_flow_control_parks_and_window_update_flushes() {
+	mut c := new_server_conn()
+	// Client SETTINGS: initial stream window of 10 bytes.
+	mut input := []u8{}
+	input << preface_tail
+	write_settings(mut input, [
+		Setting{
+			id:  setting_initial_window_size
+			val: 10
+		},
+	])
+	block := get_request_block()
+	write_frame_header(mut input, .headers, flag_end_headers | flag_end_stream, 1, block.len)
+	input << block
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+	assert reqs.len == 1
+	// A 25-byte body against a 10-byte stream window: 10 sent, 15 parked.
+	out.clear()
+	body := 'abcdefghijklmnopqrstuvwxy'.bytes()
+	mut resp_block := []u8{}
+	encode_status(mut resp_block, 200)
+	c.write_response_headers(mut out, 1, resp_block, false)
+	c.write_response_data(mut out, 1, body)
+	mut frames := frames_of(out)
+	assert frames.len == 2
+	assert frames[1].fh.type_ == .data
+	assert int(frames[1].fh.length) == 10
+	assert frames[1].fh.flags & flag_end_stream == 0
+	assert c.streams.len == 1
+	// WINDOW_UPDATE for the stream releases the rest, END_STREAM included.
+	out.clear()
+	mut wu := []u8{}
+	write_window_update(mut wu, 1, 15)
+	_, closing2 := c.consume(wu, mut out, mut reqs)
+	assert !closing2
+	frames = frames_of(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .data
+	assert int(frames[0].fh.length) == 15
+	assert frames[0].fh.flags & flag_end_stream != 0
+	assert frames[0].payload.bytestr() == 'klmnopqrstuvwxy'
+	assert c.streams.len == 0
+}
+
+fn test_unknown_frame_type_ignored() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	// Type 0x0b does not exist — the frame must be skipped whole.
+	input := [u8(0), 0, 2, 0x0b, 0, 0, 0, 0, 1, 0xaa, 0xbb]
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+	assert out.len == 0
+}
+
+fn test_push_promise_from_client_is_fatal() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	mut input := []u8{}
+	write_frame_header(mut input, .push_promise, flag_end_headers, 1, 0)
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert closing
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .goaway
+}
+
+fn test_oversized_frame_is_fatal() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	// A frame header claiming 20000 bytes: above SETTINGS_MAX_FRAME_SIZE.
+	input := [u8(0x00), 0x4e, 0x20, 0x00, 0, 0, 0, 0, 1]
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert closing
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .goaway
+	assert read_u32(frames[frames.len - 1].payload, 4) == u32(ErrorCode.frame_size_error)
+}
+
+fn test_new_stream_ids_must_ascend() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	block5 := get_request_block()
+	mut input := []u8{}
+	write_frame_header(mut input, .headers, flag_end_headers | flag_end_stream, 5, block5.len)
+	input << block5
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing1 := c.consume(input, mut out, mut reqs)
+	assert !closing1
+	assert reqs.len == 1
+	// Stream 3 after stream 5 — protocol error, connection-fatal.
+	block3 := get_request_block()
+	mut input2 := []u8{}
+	write_frame_header(mut input2, .headers, flag_end_headers | flag_end_stream, 3, block3.len)
+	input2 << block3
+	out.clear()
+	_, closing2 := c.consume(input2, mut out, mut reqs)
+	assert closing2
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .goaway
+}
+
+fn test_rst_stream_drops_state() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	block := get_request_block()
+	mut input := []u8{}
+	// Open stream 1 without END_STREAM (a request still uploading)...
+	write_frame_header(mut input, .headers, flag_end_headers, 1, block.len)
+	input << block
+	// ...then the client aborts it.
+	write_rst_stream(mut input, 1, .cancel)
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+	assert reqs.len == 0
+	assert c.streams.len == 0
+}

--- a/http2/conn_test.v
+++ b/http2/conn_test.v
@@ -475,6 +475,23 @@ fn test_ping_after_goaway_still_answered() {
 	assert frames[0].payload == opaque
 }
 
+fn test_goaway_on_a_stream_is_fatal() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	// GOAWAY is connection-level only — a non-zero stream id is a
+	// connection error of type PROTOCOL_ERROR (§6.8).
+	mut input := []u8{}
+	write_frame_header(mut input, .goaway, 0, 1, 8)
+	input << [u8(0), 0, 0, 0, 0, 0, 0, 0]
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert closing
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .goaway
+	assert read_u32(frames[frames.len - 1].payload, 4) == u32(ErrorCode.protocol_error)
+}
+
 fn test_settings_window_growth_flushes_parked_data() {
 	mut c := new_server_conn()
 	// Handshake with an initial stream window of ZERO: every response byte

--- a/http2/conn_test.v
+++ b/http2/conn_test.v
@@ -331,6 +331,189 @@ fn test_new_stream_ids_must_ascend() {
 	assert frames[frames.len - 1].fh.type_ == .goaway
 }
 
+fn test_validate_request_fields_rules() {
+	ok0, cl0 := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
+		hf(':path', '/'), hf(':authority', 'x')])
+	assert ok0
+	assert cl0 == -1
+	ok1, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http')])
+	assert !ok1 // missing :path
+	ok2, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
+		hf('x', 'y'), hf(':path', '/')])
+	assert !ok2 // pseudo-header after a regular field
+	ok3, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
+		hf(':path', '/'), hf(':status', '200')])
+	assert !ok3 // response pseudo-header in a request
+	ok4, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
+		hf(':path', '')])
+	assert !ok4 // empty :path
+	ok5, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
+		hf(':path', '/'), hf('connection', 'close')])
+	assert !ok5 // connection-specific field
+	ok6, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
+		hf(':path', '/'), hf('te', 'gzip')])
+	assert !ok6 // te may only carry 'trailers'
+	ok7, cl7 := validate_request_fields([hf(':method', 'POST'), hf(':scheme', 'http'),
+		hf(':path', '/'), hf('content-length', '42')])
+	assert ok7
+	assert cl7 == 42
+	ok8, _ := validate_request_fields([hf(':method', 'POST'), hf(':scheme', 'http'),
+		hf(':path', '/'), hf('content-length', '4'), hf('content-length', '5')])
+	assert !ok8 // differing duplicate content-length
+	ok9, _ := validate_request_fields([hf(':method', 'CONNECT'), hf(':scheme', 'http'),
+		hf(':path', '/'), hf(':authority', 'x')])
+	assert !ok9 // CONNECT must omit :scheme and :path
+	ok10, _ := validate_request_fields([hf(':method', 'CONNECT'), hf(':authority', 'x:443')])
+	assert ok10
+	ok11, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
+		hf(':path', '/'), hf('X-Bad', 'v')])
+	assert !ok11 // uppercase field name
+}
+
+fn test_malformed_request_is_rst_not_fatal() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	mut block := []u8{}
+	encode_indexed(mut block, 2)
+	encode_indexed(mut block, 6)
+	encode_indexed(mut block, 4)
+	encode_literal_name_idx(mut block, 1, 'x.test')
+	encode_literal(mut block, 'X-Bad', 'v') // uppercase name — malformed (§8.2)
+	mut input := []u8{}
+	write_frame_header(mut input, .headers, flag_end_headers | flag_end_stream, 1, block.len)
+	input << block
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+	assert reqs.len == 0
+	frames := frames_of(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .rst_stream
+	assert read_u32(frames[0].payload, 0) == u32(ErrorCode.protocol_error)
+	// The connection lives on: a valid request on the next stream works.
+	block2 := get_request_block()
+	mut input2 := []u8{}
+	write_frame_header(mut input2, .headers, flag_end_headers | flag_end_stream, 3, block2.len)
+	input2 << block2
+	out.clear()
+	_, closing2 := c.consume(input2, mut out, mut reqs)
+	assert !closing2
+	assert reqs.len == 1
+	assert reqs[0].stream_id == 3
+}
+
+fn test_content_length_mismatch_is_malformed() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	mut block := []u8{}
+	encode_indexed(mut block, 3) // :method POST
+	encode_indexed(mut block, 6)
+	encode_indexed(mut block, 4)
+	encode_literal(mut block, 'content-length', '5')
+	mut input := []u8{}
+	write_frame_header(mut input, .headers, flag_end_headers, 1, block.len)
+	input << block
+	write_data_header(mut input, 1, 2, true)
+	input << 'hi'.bytes()
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert !closing
+	assert reqs.len == 0 // 2 != 5 — malformed, never surfaced (§8.1.1)
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .rst_stream
+	assert c.streams.len == 0
+}
+
+fn test_window_update_zero_on_stream_is_stream_error() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	block := get_request_block()
+	mut input := []u8{}
+	write_frame_header(mut input, .headers, flag_end_headers | flag_end_stream, 1, block.len)
+	input << block
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	c1, cl1 := c.consume(input, mut out, mut reqs)
+	assert c1 == input.len
+	assert !cl1
+	out.clear()
+	mut wu := []u8{}
+	write_window_update(mut wu, 1, 0)
+	_, closing := c.consume(wu, mut out, mut reqs)
+	assert !closing // stream error, not a connection error (§6.9)
+	frames := frames_of(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .rst_stream
+}
+
+fn test_rst_on_idle_stream_is_fatal() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	mut input := []u8{}
+	write_rst_stream(mut input, 5, .cancel) // stream 5 was never opened
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert closing
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .goaway
+}
+
+fn test_data_on_idle_stream_is_fatal() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	mut input := []u8{}
+	write_data_header(mut input, 5, 2, true)
+	input << 'hi'.bytes()
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert closing
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .goaway
+}
+
+fn test_extension_frame_inside_header_block_is_fatal() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	block := get_request_block()
+	mut input := []u8{}
+	// HEADERS without END_HEADERS opens a block...
+	write_frame_header(mut input, .headers, flag_end_stream, 1, block.len)
+	input << block
+	// ...an unknown frame type interleaves — must kill the connection (§4.3).
+	input << [u8(0), 0, 0, 0x0b, 0, 0, 0, 0, 1]
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert closing
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .goaway
+}
+
+fn test_headers_self_dependency_is_stream_error() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	block := get_request_block()
+	mut input := []u8{}
+	// HEADERS with the PRIORITY flag whose dependency is the stream itself.
+	write_frame_header(mut input, .headers, flag_end_headers | flag_end_stream | flag_priority, 1,
+		block.len + 5)
+	input << [u8(0), 0, 0, 1, 16] // depend on stream 1 (self), weight 16
+	input << block
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert !closing
+	assert reqs.len == 0
+	frames := frames_of(out)
+	assert frames[0].fh.type_ == .rst_stream
+}
+
 fn test_rst_stream_drops_state() {
 	mut c := new_server_conn()
 	handshake(mut c)

--- a/http2/conn_test.v
+++ b/http2/conn_test.v
@@ -452,6 +452,43 @@ fn test_window_update_zero_on_stream_is_stream_error() {
 	assert frames[0].fh.type_ == .rst_stream
 }
 
+fn test_frames_after_goaway_still_answered_before_close() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	// GOAWAY and a PING in ONE burst: the PING must still get its ack before
+	// the close (dying with unread bytes in the socket turns the FIN into an
+	// RST and loses the flush).
+	mut input := []u8{}
+	write_goaway(mut input, 0, .no_error)
+	opaque := [u8(1), 2, 3, 4, 5, 6, 7, 8]
+	write_frame_header(mut input, .ping, 0, 0, 8)
+	input << opaque
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	consumed, closing := c.consume(input, mut out, mut reqs)
+	assert consumed == input.len
+	assert closing
+	frames := frames_of(out)
+	assert frames.len == 1
+	assert frames[0].fh.type_ == .ping
+	assert frames[0].fh.flags & flag_ack != 0
+	assert frames[0].payload == opaque
+}
+
+fn test_window_update_on_idle_stream_is_fatal() {
+	mut c := new_server_conn()
+	handshake(mut c)
+	mut input := []u8{}
+	write_window_update(mut input, 5, 1) // stream 5 was never opened
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert closing
+	frames := frames_of(out)
+	assert frames[frames.len - 1].fh.type_ == .goaway
+	assert read_u32(frames[frames.len - 1].payload, 4) == u32(ErrorCode.protocol_error)
+}
+
 fn test_rst_on_idle_stream_is_fatal() {
 	mut c := new_server_conn()
 	handshake(mut c)

--- a/http2/conn_test.v
+++ b/http2/conn_test.v
@@ -332,8 +332,8 @@ fn test_new_stream_ids_must_ascend() {
 }
 
 fn test_validate_request_fields_rules() {
-	ok0, cl0 := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
-		hf(':path', '/'), hf(':authority', 'x')])
+	ok0, cl0 := validate_request_fields([hf(':method', 'GET'),
+		hf(':scheme', 'http'), hf(':path', '/'), hf(':authority', 'x')])
 	assert ok0
 	assert cl0 == -1
 	ok1, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http')])
@@ -353,20 +353,22 @@ fn test_validate_request_fields_rules() {
 	ok6, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
 		hf(':path', '/'), hf('te', 'gzip')])
 	assert !ok6 // te may only carry 'trailers'
-	ok7, cl7 := validate_request_fields([hf(':method', 'POST'), hf(':scheme', 'http'),
-		hf(':path', '/'), hf('content-length', '42')])
+	ok7, cl7 := validate_request_fields([hf(':method', 'POST'),
+		hf(':scheme', 'http'), hf(':path', '/'), hf('content-length', '42')])
 	assert ok7
 	assert cl7 == 42
-	ok8, _ := validate_request_fields([hf(':method', 'POST'), hf(':scheme', 'http'),
-		hf(':path', '/'), hf('content-length', '4'), hf('content-length', '5')])
+	ok8, _ := validate_request_fields([hf(':method', 'POST'),
+		hf(':scheme', 'http'), hf(':path', '/'), hf('content-length', '4'),
+		hf('content-length', '5')])
 	assert !ok8 // differing duplicate content-length
-	ok9, _ := validate_request_fields([hf(':method', 'CONNECT'), hf(':scheme', 'http'),
-		hf(':path', '/'), hf(':authority', 'x')])
+	ok9, _ := validate_request_fields([hf(':method', 'CONNECT'),
+		hf(':scheme', 'http'), hf(':path', '/'), hf(':authority', 'x')])
 	assert !ok9 // CONNECT must omit :scheme and :path
-	ok10, _ := validate_request_fields([hf(':method', 'CONNECT'), hf(':authority', 'x:443')])
+	ok10, _ := validate_request_fields([hf(':method', 'CONNECT'),
+		hf(':authority', 'x:443')])
 	assert ok10
-	ok11, _ := validate_request_fields([hf(':method', 'GET'), hf(':scheme', 'http'),
-		hf(':path', '/'), hf('X-Bad', 'v')])
+	ok11, _ := validate_request_fields([hf(':method', 'GET'),
+		hf(':scheme', 'http'), hf(':path', '/'), hf('X-Bad', 'v')])
 	assert !ok11 // uppercase field name
 }
 
@@ -501,8 +503,8 @@ fn test_headers_self_dependency_is_stream_error() {
 	block := get_request_block()
 	mut input := []u8{}
 	// HEADERS with the PRIORITY flag whose dependency is the stream itself.
-	write_frame_header(mut input, .headers, flag_end_headers | flag_end_stream | flag_priority, 1,
-		block.len + 5)
+	flags := flag_end_headers | flag_end_stream | flag_priority
+	write_frame_header(mut input, .headers, flags, 1, block.len + 5)
 	input << [u8(0), 0, 0, 1, 16] // depend on stream 1 (self), weight 16
 	input << block
 	mut out := []u8{}

--- a/http2/conn_test.v
+++ b/http2/conn_test.v
@@ -452,12 +452,12 @@ fn test_window_update_zero_on_stream_is_stream_error() {
 	assert frames[0].fh.type_ == .rst_stream
 }
 
-fn test_frames_after_goaway_still_answered_before_close() {
+fn test_ping_after_goaway_still_answered() {
 	mut c := new_server_conn()
 	handshake(mut c)
-	// GOAWAY and a PING in ONE burst: the PING must still get its ack before
-	// the close (dying with unread bytes in the socket turns the FIN into an
-	// RST and loses the flush).
+	// A peer GOAWAY does not close the connection (it only forbids new
+	// streams; the peer closes the TCP connection itself) — a PING after it
+	// must still get its ack (§6.8).
 	mut input := []u8{}
 	write_goaway(mut input, 0, .no_error)
 	opaque := [u8(1), 2, 3, 4, 5, 6, 7, 8]
@@ -467,12 +467,59 @@ fn test_frames_after_goaway_still_answered_before_close() {
 	mut reqs := []Http2Request{}
 	consumed, closing := c.consume(input, mut out, mut reqs)
 	assert consumed == input.len
-	assert closing
+	assert !closing
 	frames := frames_of(out)
 	assert frames.len == 1
 	assert frames[0].fh.type_ == .ping
 	assert frames[0].fh.flags & flag_ack != 0
 	assert frames[0].payload == opaque
+}
+
+fn test_settings_window_growth_flushes_parked_data() {
+	mut c := new_server_conn()
+	// Handshake with an initial stream window of ZERO: every response byte
+	// parks.
+	mut input := []u8{}
+	input << preface_tail
+	write_settings(mut input, [
+		Setting{
+			id:  setting_initial_window_size
+			val: 0
+		},
+	])
+	block := get_request_block()
+	write_frame_header(mut input, .headers, flag_end_headers | flag_end_stream, 1, block.len)
+	input << block
+	mut out := []u8{}
+	mut reqs := []Http2Request{}
+	_, closing := c.consume(input, mut out, mut reqs)
+	assert !closing
+	assert reqs.len == 1
+	out.clear()
+	mut resp_block := []u8{}
+	encode_status(mut resp_block, 200)
+	c.write_response_headers(mut out, 1, resp_block, false)
+	c.write_response_data(mut out, 1, 'parked'.bytes())
+	mut frames := frames_of(out)
+	assert frames.len == 1 // HEADERS only — all DATA parked behind window 0
+	// SETTINGS raising the initial window must unpark it (§6.9.2).
+	out.clear()
+	mut grow := []u8{}
+	write_settings(mut grow, [
+		Setting{
+			id:  setting_initial_window_size
+			val: 1
+		},
+	])
+	_, closing2 := c.consume(grow, mut out, mut reqs)
+	assert !closing2
+	frames = frames_of(out)
+	assert frames.len == 2
+	assert frames[0].fh.type_ == .settings
+	assert frames[0].fh.flags & flag_ack != 0
+	assert frames[1].fh.type_ == .data
+	assert int(frames[1].fh.length) == 1
+	assert frames[1].payload.bytestr() == 'p'
 }
 
 fn test_window_update_on_idle_stream_is_fatal() {

--- a/http2/frame.v
+++ b/http2/frame.v
@@ -1,9 +1,53 @@
 module http2
 
-// HTTP/2 frame parsing and serialization (RFC 9113 Section 4.1)
+// HTTP/2 frame codec (RFC 9113 §4) — parsing stays zero-copy (headers are
+// fixed offsets over the read buffer), writers append straight into the
+// caller's `out` buffer (docs/BEST_PRACTICES.md: no intermediate
+// allocations on the serving path).
 
+// The client connection preface (RFC 9113 §3.4). The first 18 bytes parse as
+// an HTTP/1.1 request line (`PRI * HTTP/2.0` + an empty header section), so a
+// prior-knowledge client reaches the request handler as method PRI — the
+// handler answers by taking the connection over; `preface_tail` is what
+// remains in the read buffer after that request.
+pub const preface = 'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'.bytes()
+pub const preface_tail = 'SM\r\n\r\n'.bytes()
+
+pub const frame_header_len = 9
+
+// Frame flags (RFC 9113 §6) — the ones this codec acts on.
+pub const flag_end_stream = u8(0x01) // DATA, HEADERS
+pub const flag_ack = u8(0x01) // SETTINGS, PING
+pub const flag_end_headers = u8(0x04) // HEADERS, CONTINUATION
+pub const flag_padded = u8(0x08) // DATA, HEADERS
+pub const flag_priority = u8(0x20) // HEADERS
+
+// Protocol defaults and bounds (RFC 9113 §6.5.2, §6.9.1).
+pub const default_max_frame_size = 16384
+pub const default_window_size = 65535
+pub const max_window = u32(0x7fffffff)
+
+// SETTINGS identifiers as wire values — kept as u16 (not the SettingsId enum)
+// because unknown identifiers MUST be ignored, and V enums cannot carry
+// unknown values safely.
+pub const setting_header_table_size = u16(0x1)
+pub const setting_enable_push = u16(0x2)
+pub const setting_max_concurrent_streams = u16(0x3)
+pub const setting_initial_window_size = u16(0x4)
+pub const setting_max_frame_size = u16(0x5)
+pub const setting_max_header_list_size = u16(0x6)
+
+// Setting is one SETTINGS parameter (RFC 9113 §6.5.1).
+pub struct Setting {
+pub:
+	id  u16
+	val u32
+}
+
+// parse_frame_header reads the fixed 9-byte frame header at data[0]
+// (RFC 9113 §4.1).
 pub fn parse_frame_header(data []u8) !FrameHeader {
-	if data.len < 9 {
+	if data.len < frame_header_len {
 		return error('Frame header too short')
 	}
 	length := (u32(data[0]) << 16) | (u32(data[1]) << 8) | u32(data[2])
@@ -19,16 +63,103 @@ pub fn parse_frame_header(data []u8) !FrameHeader {
 	}
 }
 
+// serialize_frame_header allocates a 9-byte header (tests/tools). On the
+// serving path use write_frame_header, which appends into `out` instead.
 pub fn serialize_frame_header(header FrameHeader) []u8 {
-	mut data := []u8{len: 9}
-	data[0] = u8((header.length >> 16) & 0xFF)
-	data[1] = u8((header.length >> 8) & 0xFF)
-	data[2] = u8(header.length & 0xFF)
-	data[3] = u8(header.type_)
-	data[4] = header.flags
-	data[5] = u8((header.stream_id >> 24) & 0x7F) // reserved bit is 0
-	data[6] = u8((header.stream_id >> 16) & 0xFF)
-	data[7] = u8((header.stream_id >> 8) & 0xFF)
-	data[8] = u8(header.stream_id & 0xFF)
+	mut data := []u8{cap: frame_header_len}
+	write_frame_header(mut data, header.type_, header.flags, header.stream_id, int(header.length))
 	return data
+}
+
+// write_frame_header appends a 9-byte frame header (RFC 9113 §4.1).
+pub fn write_frame_header(mut out []u8, type_ FrameType, flags u8, stream_id u32, length int) {
+	out << u8((length >> 16) & 0xff)
+	out << u8((length >> 8) & 0xff)
+	out << u8(length & 0xff)
+	out << u8(type_)
+	out << flags
+	out << u8((stream_id >> 24) & 0x7f) // reserved bit is 0
+	out << u8((stream_id >> 16) & 0xff)
+	out << u8((stream_id >> 8) & 0xff)
+	out << u8(stream_id & 0xff)
+}
+
+fn write_u32(mut out []u8, v u32) {
+	out << u8(v >> 24)
+	out << u8((v >> 16) & 0xff)
+	out << u8((v >> 8) & 0xff)
+	out << u8(v & 0xff)
+}
+
+fn read_u32(buf []u8, pos int) u32 {
+	mut v := u32(buf[pos]) << 24
+	v |= u32(buf[pos + 1]) << 16
+	v |= u32(buf[pos + 2]) << 8
+	v |= u32(buf[pos + 3])
+	return v
+}
+
+// write_settings appends a SETTINGS frame carrying `settings` (RFC 9113 §6.5).
+pub fn write_settings(mut out []u8, settings []Setting) {
+	write_frame_header(mut out, .settings, 0, 0, settings.len * 6)
+	for s in settings {
+		out << u8(s.id >> 8)
+		out << u8(s.id & 0xff)
+		write_u32(mut out, s.val)
+	}
+}
+
+// write_settings_ack appends the empty ACK a received SETTINGS requires.
+pub fn write_settings_ack(mut out []u8) {
+	write_frame_header(mut out, .settings, flag_ack, 0, 0)
+}
+
+// parse_settings decodes a SETTINGS payload (the caller passes the payload
+// view, not the whole frame).
+pub fn parse_settings(payload []u8) ![]Setting {
+	if payload.len % 6 != 0 {
+		return error('SETTINGS payload not a multiple of 6')
+	}
+	mut out := []Setting{cap: payload.len / 6}
+	for pos := 0; pos < payload.len; pos += 6 {
+		out << Setting{
+			id:  u16(payload[pos]) << 8 | u16(payload[pos + 1])
+			val: read_u32(payload, pos + 2)
+		}
+	}
+	return out
+}
+
+// write_ping_ack appends a PING ACK echoing the 8 opaque payload bytes
+// (RFC 9113 §6.7).
+pub fn write_ping_ack(mut out []u8, opaque []u8) {
+	write_frame_header(mut out, .ping, flag_ack, 0, 8)
+	out << opaque
+}
+
+// write_goaway appends a GOAWAY with no debug data (RFC 9113 §6.8).
+pub fn write_goaway(mut out []u8, last_stream_id u32, code ErrorCode) {
+	write_frame_header(mut out, .goaway, 0, 0, 8)
+	write_u32(mut out, last_stream_id & 0x7fffffff)
+	write_u32(mut out, u32(code))
+}
+
+// write_rst_stream appends a RST_STREAM (RFC 9113 §6.4).
+pub fn write_rst_stream(mut out []u8, stream_id u32, code ErrorCode) {
+	write_frame_header(mut out, .rst_stream, 0, stream_id, 4)
+	write_u32(mut out, u32(code))
+}
+
+// write_window_update appends a WINDOW_UPDATE for `increment` bytes on a
+// stream (0 = the connection window) (RFC 9113 §6.9).
+pub fn write_window_update(mut out []u8, stream_id u32, increment u32) {
+	write_frame_header(mut out, .window_update, 0, stream_id, 4)
+	write_u32(mut out, increment & 0x7fffffff)
+}
+
+// write_data_header appends a DATA frame header for a `length`-byte payload;
+// the caller appends the payload bytes right after.
+pub fn write_data_header(mut out []u8, stream_id u32, length int, end_stream bool) {
+	flags := if end_stream { flag_end_stream } else { u8(0) }
+	write_frame_header(mut out, .data, flags, stream_id, length)
 }

--- a/http2/frame_test.v
+++ b/http2/frame_test.v
@@ -1,0 +1,104 @@
+module http2
+
+fn test_frame_header_roundtrip() ! {
+	mut out := []u8{}
+	write_frame_header(mut out, .headers, flag_end_headers | flag_end_stream, 5, 1234)
+	assert out.len == frame_header_len
+	fh := parse_frame_header(out)!
+	assert fh.length == 1234
+	assert fh.type_ == .headers
+	assert fh.flags == flag_end_headers | flag_end_stream
+	assert fh.stream_id == 5
+}
+
+fn test_frame_header_reserved_bit_cleared() ! {
+	mut out := []u8{}
+	// Writer must zero the reserved bit even for a huge id; parser must mask it.
+	write_frame_header(mut out, .data, 0, 0xffffffff, 0)
+	fh := parse_frame_header(out)!
+	assert fh.stream_id == 0x7fffffff
+	assert out[5] & 0x80 == 0
+}
+
+fn test_settings_roundtrip() ! {
+	mut out := []u8{}
+	write_settings(mut out, [
+		Setting{
+			id:  setting_max_concurrent_streams
+			val: 128
+		},
+		Setting{
+			id:  setting_initial_window_size
+			val: 65535
+		},
+	])
+	fh := parse_frame_header(out)!
+	assert fh.type_ == .settings
+	assert fh.stream_id == 0
+	assert int(fh.length) == 12
+	settings := parse_settings(out[frame_header_len..])!
+	assert settings.len == 2
+	assert settings[0].id == setting_max_concurrent_streams
+	assert settings[0].val == 128
+	assert settings[1].id == setting_initial_window_size
+	assert settings[1].val == 65535
+}
+
+fn test_parse_settings_rejects_partial_entry() {
+	if _ := parse_settings([u8(0), 1, 0, 0]) {
+		assert false
+	}
+}
+
+fn test_settings_ack() ! {
+	mut out := []u8{}
+	write_settings_ack(mut out)
+	fh := parse_frame_header(out)!
+	assert fh.type_ == .settings
+	assert fh.flags & flag_ack != 0
+	assert fh.length == 0
+}
+
+fn test_ping_ack_echoes_payload() ! {
+	opaque := [u8(1), 2, 3, 4, 5, 6, 7, 8]
+	mut out := []u8{}
+	write_ping_ack(mut out, opaque)
+	fh := parse_frame_header(out)!
+	assert fh.type_ == .ping
+	assert fh.flags & flag_ack != 0
+	assert int(fh.length) == 8
+	assert out[frame_header_len..] == opaque
+}
+
+fn test_goaway_layout() ! {
+	mut out := []u8{}
+	write_goaway(mut out, 7, .protocol_error)
+	fh := parse_frame_header(out)!
+	assert fh.type_ == .goaway
+	assert int(fh.length) == 8
+	assert read_u32(out, frame_header_len) == 7
+	assert read_u32(out, frame_header_len + 4) == u32(ErrorCode.protocol_error)
+}
+
+fn test_window_update_layout() ! {
+	mut out := []u8{}
+	write_window_update(mut out, 3, 4096)
+	fh := parse_frame_header(out)!
+	assert fh.type_ == .window_update
+	assert fh.stream_id == 3
+	assert int(fh.length) == 4
+	assert read_u32(out, frame_header_len) == 4096
+}
+
+fn test_data_header_flags() ! {
+	mut out := []u8{}
+	write_data_header(mut out, 1, 10, false)
+	write_data_header(mut out, 1, 0, true)
+	first := parse_frame_header(out)!
+	assert first.type_ == .data
+	assert first.flags & flag_end_stream == 0
+	assert int(first.length) == 10
+	second := parse_frame_header(out[frame_header_len..])!
+	assert second.flags & flag_end_stream != 0
+	assert second.length == 0
+}

--- a/http2/hpack.v
+++ b/http2/hpack.v
@@ -459,13 +459,27 @@ pub fn encode_literal(mut out []u8, name string, value string) {
 // static-table form for the seven pre-indexed codes, a literal otherwise.
 pub fn encode_status(mut out []u8, status int) {
 	match status {
-		200 { encode_indexed(mut out, 8) }
-		204 { encode_indexed(mut out, 9) }
-		206 { encode_indexed(mut out, 10) }
-		304 { encode_indexed(mut out, 11) }
-		400 { encode_indexed(mut out, 12) }
-		404 { encode_indexed(mut out, 13) }
-		500 { encode_indexed(mut out, 14) }
+		200 {
+			encode_indexed(mut out, 8)
+		}
+		204 {
+			encode_indexed(mut out, 9)
+		}
+		206 {
+			encode_indexed(mut out, 10)
+		}
+		304 {
+			encode_indexed(mut out, 11)
+		}
+		400 {
+			encode_indexed(mut out, 12)
+		}
+		404 {
+			encode_indexed(mut out, 13)
+		}
+		500 {
+			encode_indexed(mut out, 14)
+		}
 		else {
 			mut digits := [u8(0), 0, 0]
 			digits[0] = u8(`0` + (status / 100) % 10)

--- a/http2/hpack.v
+++ b/http2/hpack.v
@@ -1,8 +1,525 @@
 module http2
 
-// HPACK header compression/decompression stubs (RFC 7541)
-// TODO: Implement full HPACK encoder/decoder
+// HPACK — RFC 7541 header compression for HTTP/2, the codec half the dormant
+// module was missing (issue #122's http2 story). Pure functions + one decoder
+// struct over bytes: no I/O, no vanilla imports — same discipline as the
+// websocket codec.
+//
+// Decoding allocates (dynamic-table entries and Huffman output must outlive
+// the wire bytes), which is fine: header decompression is per-request setup,
+// not the per-byte hot path, and the h1 fast path is untouched.
+//
+// The encoder side is deliberately STATELESS: responses use indexed fields
+// from the static table plus literals WITHOUT indexing (RFC 7541 §6.2.2), so
+// no encoder dynamic table exists and no synchronization with the peer's
+// decoder state is ever needed. That is spec-legal (indexing is optional) and
+// keeps the server side allocation-free on the encode path.
+//
+// Decoder hardening: integer overflow caps, string/index bounds checks, EOS
+// and padding validation in Huffman data, and a decoded-block size ceiling
+// (`max_decoded_block`) so a compression bomb cannot balloon memory.
 
-pub struct HpackDecoder {}
+// A decoded header field. Name and value are owned copies — they outlive the
+// wire buffer and the dynamic table references them.
+pub struct HeaderField {
+pub:
+	name  string
+	value string
+}
 
-pub struct HpackEncoder {}
+// Ceiling on the decoded bytes of one header block (names + values). RFC 9113
+// SETTINGS_MAX_HEADER_LIST_SIZE is advisory; this is the enforced local bound.
+pub const max_decoded_block = 256 * 1024
+
+// hpack_default_table_size is the protocol default for the decoder's dynamic
+// table (RFC 7541 §4.2, RFC 9113 §6.5.2 SETTINGS_HEADER_TABLE_SIZE).
+pub const hpack_default_table_size = 4096
+
+// The static table (RFC 7541 Appendix A): indices 1..61, split into two
+// parallel arrays so a lookup allocates nothing.
+const static_name = [
+	':authority',
+	':method',
+	':method',
+	':path',
+	':path',
+	':scheme',
+	':scheme',
+	':status',
+	':status',
+	':status',
+	':status',
+	':status',
+	':status',
+	':status',
+	'accept-charset',
+	'accept-encoding',
+	'accept-language',
+	'accept-ranges',
+	'accept',
+	'access-control-allow-origin',
+	'age',
+	'allow',
+	'authorization',
+	'cache-control',
+	'content-disposition',
+	'content-encoding',
+	'content-language',
+	'content-length',
+	'content-location',
+	'content-range',
+	'content-type',
+	'cookie',
+	'date',
+	'etag',
+	'expect',
+	'expires',
+	'from',
+	'host',
+	'if-match',
+	'if-modified-since',
+	'if-none-match',
+	'if-range',
+	'if-unmodified-since',
+	'last-modified',
+	'link',
+	'location',
+	'max-forwards',
+	'proxy-authenticate',
+	'proxy-authorization',
+	'range',
+	'referer',
+	'refresh',
+	'retry-after',
+	'server',
+	'set-cookie',
+	'strict-transport-security',
+	'transfer-encoding',
+	'user-agent',
+	'vary',
+	'via',
+	'www-authenticate',
+]!
+
+const static_value = [
+	'',
+	'GET',
+	'POST',
+	'/',
+	'/index.html',
+	'http',
+	'https',
+	'200',
+	'204',
+	'206',
+	'304',
+	'400',
+	'404',
+	'500',
+	'',
+	'gzip, deflate',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+	'',
+]!
+
+// Canonical-Huffman decode tables generated from the RFC 7541 Appendix B code
+// table (the code is canonical: per bit-length, codes are consecutive).
+// huff_len lists the bit-lengths that occur; per length i: huff_first[i] is
+// the numerically first code, huff_count[i] how many symbols share the
+// length, huff_base[i] their start in huff_symbol (symbols ordered by
+// (length, code); 256 = EOS).
+// vfmt off
+const huff_len = [
+	u8(5), 6, 7, 8, 10, 11, 12, 13, 14, 15, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 30,
+]!
+
+const huff_first = [
+	u32(0x0), 0x14, 0x5c, 0xf8, 0x3f8, 0x7fa, 0xffa, 0x1ff8, 0x3ffc, 0x7ffc, 0x7fff0, 0xfffe6,
+	0x1fffdc, 0x3fffd2, 0x7fffd8, 0xffffea, 0x1ffffec, 0x3ffffe0, 0x7ffffde, 0xfffffe2,
+	0x3ffffffc,
+]!
+
+const huff_count = [
+	u16(10), 26, 32, 6, 5, 3, 2, 6, 2, 3, 3, 8, 13, 26, 29, 12, 4, 15, 19, 29, 4,
+]!
+
+const huff_base = [
+	u16(0), 10, 36, 68, 74, 79, 82, 84, 90, 92, 95, 98, 106, 119, 145, 174, 186, 190, 205, 224,
+	253,
+]!
+
+const huff_symbol = [
+	u16(48), 49, 50, 97, 99, 101, 105, 111, 115, 116, 32, 37, 45, 46, 47, 51, 52, 53, 54, 55, 56,
+	57, 61, 65, 95, 98, 100, 102, 103, 104, 108, 109, 110, 112, 114, 117, 58, 66, 67, 68, 69, 70,
+	71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 89, 106, 107, 113, 118,
+	119, 120, 121, 122, 38, 42, 44, 59, 88, 90, 33, 34, 40, 41, 63, 39, 43, 124, 35, 62, 0, 36,
+	64, 91, 93, 126, 94, 125, 60, 96, 123, 92, 195, 208, 128, 130, 131, 162, 184, 194, 224, 226,
+	153, 161, 167, 172, 176, 177, 179, 209, 216, 217, 227, 229, 230, 129, 132, 133, 134, 136,
+	146, 154, 156, 160, 163, 164, 169, 170, 173, 178, 181, 185, 186, 187, 189, 190, 196, 198,
+	228, 232, 233, 1, 135, 137, 138, 139, 140, 141, 143, 147, 149, 150, 151, 152, 155, 157, 158,
+	165, 166, 168, 174, 175, 180, 182, 183, 188, 191, 197, 231, 239, 9, 142, 144, 145, 148, 159,
+	171, 206, 215, 225, 236, 237, 199, 207, 234, 235, 192, 193, 200, 201, 202, 205, 210, 213,
+	218, 219, 238, 240, 242, 243, 255, 203, 204, 211, 212, 214, 221, 222, 223, 241, 244, 245,
+	246, 247, 248, 250, 251, 252, 253, 254, 2, 3, 4, 5, 6, 7, 8, 11, 12, 14, 15, 16, 17, 18, 19,
+	20, 21, 23, 24, 25, 26, 27, 28, 29, 30, 31, 127, 220, 249, 10, 13, 22, 256,
+]!
+// vfmt on
+
+// HpackDecoder holds the connection's receive-side dynamic table. One per
+// connection, fed every header block in wire order (HPACK is stateful — a
+// skipped block desynchronizes the table, so even discarded streams decode).
+pub struct HpackDecoder {
+mut:
+	dyn      []HeaderField // newest entry first (index 62 = dyn[0])
+	dyn_size int           // sum of entry sizes (name + value + 32, RFC 7541 §4.1)
+	max_size int           // protocol ceiling (our SETTINGS_HEADER_TABLE_SIZE)
+	cur_max  int           // current limit, lowered/raised by table-size updates
+}
+
+// new_decoder returns a decoder whose dynamic table is capped at `max_size`
+// bytes (the value this server advertises in SETTINGS_HEADER_TABLE_SIZE).
+pub fn new_decoder(max_size int) HpackDecoder {
+	return HpackDecoder{
+		max_size: max_size
+		cur_max:  max_size
+	}
+}
+
+// decode decompresses one complete header block (the concatenated fragments
+// of HEADERS/CONTINUATION frames). Errors are connection-fatal per RFC 7541
+// §5.3 / RFC 9113 §4.3: the caller must tear the connection down (GOAWAY
+// COMPRESSION_ERROR) — the table state is unrecoverable after a bad block.
+pub fn (mut d HpackDecoder) decode(block []u8) ![]HeaderField {
+	mut out := []HeaderField{cap: 16}
+	mut pos := 0
+	mut decoded := 0
+	for pos < block.len {
+		b := block[pos]
+		if b & 0x80 != 0 {
+			// Indexed header field (§6.1).
+			idx, p := decode_int(block, pos, 7)!
+			pos = p
+			name, value := d.entry(idx)!
+			decoded += name.len + value.len
+			if decoded > max_decoded_block {
+				return error('hpack: header block too large decoded')
+			}
+			out << HeaderField{
+				name:  name
+				value: value
+			}
+		} else if b & 0xc0 == 0x40 {
+			// Literal with incremental indexing (§6.2.1).
+			idx, p := decode_int(block, pos, 6)!
+			pos = p
+			mut name := ''
+			if idx > 0 {
+				name, _ = d.entry(idx)!
+			} else {
+				name, pos = d.decode_str(block, pos)!
+			}
+			mut value := ''
+			value, pos = d.decode_str(block, pos)!
+			decoded += name.len + value.len
+			if decoded > max_decoded_block {
+				return error('hpack: header block too large decoded')
+			}
+			d.add(name, value)
+			out << HeaderField{
+				name:  name
+				value: value
+			}
+		} else if b & 0xe0 == 0x20 {
+			// Dynamic table size update (§6.3).
+			size, p := decode_int(block, pos, 5)!
+			pos = p
+			if int(size) > d.max_size {
+				return error('hpack: table size update above SETTINGS limit')
+			}
+			d.cur_max = int(size)
+			d.evict()
+		} else {
+			// Literal without indexing (§6.2.2) / never indexed (§6.2.3) —
+			// identical on the decode side apart from the (unenforceable
+			// here) re-encoding hint.
+			idx, p := decode_int(block, pos, 4)!
+			pos = p
+			mut name := ''
+			if idx > 0 {
+				name, _ = d.entry(idx)!
+			} else {
+				name, pos = d.decode_str(block, pos)!
+			}
+			mut value := ''
+			value, pos = d.decode_str(block, pos)!
+			decoded += name.len + value.len
+			if decoded > max_decoded_block {
+				return error('hpack: header block too large decoded')
+			}
+			out << HeaderField{
+				name:  name
+				value: value
+			}
+		}
+	}
+	return out
+}
+
+// dynamic_size reports the dynamic table's current byte size (tests/metrics).
+pub fn (d &HpackDecoder) dynamic_size() int {
+	return d.dyn_size
+}
+
+// entry resolves a table index: 1..61 static, 62.. dynamic (newest first).
+fn (d &HpackDecoder) entry(idx u32) !(string, string) {
+	if idx == 0 {
+		return error('hpack: index 0')
+	}
+	if idx <= 61 {
+		return static_name[idx - 1], static_value[idx - 1]
+	}
+	di := int(idx) - 62
+	if di >= d.dyn.len {
+		return error('hpack: index beyond table')
+	}
+	return d.dyn[di].name, d.dyn[di].value
+}
+
+// add inserts an entry at the head of the dynamic table, then evicts from the
+// tail until the table fits cur_max. An entry larger than the whole table
+// empties it and is itself dropped (RFC 7541 §4.4) — insert-then-evict yields
+// exactly that.
+fn (mut d HpackDecoder) add(name string, value string) {
+	d.dyn.insert(0, HeaderField{
+		name:  name
+		value: value
+	})
+	d.dyn_size += name.len + value.len + 32
+	d.evict()
+}
+
+fn (mut d HpackDecoder) evict() {
+	for d.dyn_size > d.cur_max && d.dyn.len > 0 {
+		last := d.dyn.pop()
+		d.dyn_size -= last.name.len + last.value.len + 32
+	}
+}
+
+// decode_str reads one string literal (§5.2): a Huffman flag + 7-bit-prefix
+// length, then the octets (Huffman-decoded when flagged).
+fn (mut d HpackDecoder) decode_str(block []u8, pos int) !(string, int) {
+	if pos >= block.len {
+		return error('hpack: truncated string')
+	}
+	huff := block[pos] & 0x80 != 0
+	length, p := decode_int(block, pos, 7)!
+	n := int(length)
+	if n < 0 || p + n > block.len {
+		return error('hpack: string length beyond block')
+	}
+	if n == 0 {
+		return '', p
+	}
+	src := unsafe { (&block[p]).vbytes(n) }
+	if !huff {
+		return src.bytestr(), p + n
+	}
+	// Huffman output is at most 8/5 of the input (shortest code is 5 bits).
+	mut tmp := []u8{cap: n * 8 / 5 + 1}
+	huffman_decode(src, mut tmp)!
+	return tmp.bytestr(), p + n
+}
+
+// decode_int reads an N-bit-prefix integer (§5.1). Accumulates in u64 so no
+// intermediate overflow is possible, then rejects values above 2^28 — far
+// beyond any legitimate index, length or table size.
+fn decode_int(block []u8, pos int, prefix int) !(u32, int) {
+	if pos >= block.len {
+		return error('hpack: truncated integer')
+	}
+	mask := u32((1 << prefix) - 1)
+	mut v := u64(u32(block[pos]) & mask)
+	mut p := pos + 1
+	if v < u64(mask) {
+		return u32(v), p
+	}
+	mut shift := 0
+	for {
+		if p >= block.len {
+			return error('hpack: truncated integer')
+		}
+		b := block[p]
+		p++
+		v += u64(b & 0x7f) << shift
+		shift += 7
+		if shift > 35 {
+			return error('hpack: integer too long')
+		}
+		if b & 0x80 == 0 {
+			break
+		}
+	}
+	if v > (u64(1) << 28) {
+		return error('hpack: integer too large')
+	}
+	return u32(v), p
+}
+
+// encode_int appends an N-bit-prefix integer with the instruction's flag bits
+// in the byte's high side (§5.1).
+fn encode_int(mut out []u8, flags u8, prefix int, value u32) {
+	mask := u32((1 << prefix) - 1)
+	if value < mask {
+		out << (flags | u8(value))
+		return
+	}
+	out << (flags | u8(mask))
+	mut v := value - mask
+	for v >= 0x80 {
+		out << u8((v & 0x7f) | 0x80)
+		v >>= 7
+	}
+	out << u8(v)
+}
+
+// encode_str appends a raw (non-Huffman) string literal (§5.2).
+fn encode_str(mut out []u8, s string) {
+	encode_int(mut out, 0x00, 7, u32(s.len))
+	if s.len > 0 {
+		unsafe { out.push_many(s.str, s.len) }
+	}
+}
+
+// encode_indexed appends an indexed header field (§6.1) — the 1-byte form for
+// anything in the static table, e.g. index 8 = `:status: 200`.
+pub fn encode_indexed(mut out []u8, idx int) {
+	encode_int(mut out, 0x80, 7, u32(idx))
+}
+
+// encode_literal_name_idx appends a literal without indexing whose NAME comes
+// from a table index (§6.2.2) — e.g. `:status` (8) with an uncommon code.
+pub fn encode_literal_name_idx(mut out []u8, name_idx int, value string) {
+	encode_int(mut out, 0x00, 4, u32(name_idx))
+	encode_str(mut out, value)
+}
+
+// encode_literal appends a literal without indexing with a literal name
+// (§6.2.2). HTTP/2 field names MUST be lowercase (RFC 9113 §8.2) — that is
+// the caller's contract, this appends the bytes as given.
+pub fn encode_literal(mut out []u8, name string, value string) {
+	out << u8(0x00)
+	encode_str(mut out, name)
+	encode_str(mut out, value)
+}
+
+// encode_status appends the `:status` response pseudo-header: the 1-byte
+// static-table form for the seven pre-indexed codes, a literal otherwise.
+pub fn encode_status(mut out []u8, status int) {
+	match status {
+		200 { encode_indexed(mut out, 8) }
+		204 { encode_indexed(mut out, 9) }
+		206 { encode_indexed(mut out, 10) }
+		304 { encode_indexed(mut out, 11) }
+		400 { encode_indexed(mut out, 12) }
+		404 { encode_indexed(mut out, 13) }
+		500 { encode_indexed(mut out, 14) }
+		else {
+			mut digits := [u8(0), 0, 0]
+			digits[0] = u8(`0` + (status / 100) % 10)
+			digits[1] = u8(`0` + (status / 10) % 10)
+			digits[2] = u8(`0` + status % 10)
+			encode_int(mut out, 0x00, 4, 8) // name index 8 = :status
+			encode_int(mut out, 0x00, 7, 3)
+			out << digits[0]
+			out << digits[1]
+			out << digits[2]
+		}
+	}
+}
+
+// huffman_decode appends the decoded octets of `src` (RFC 7541 §5.2 + App. B)
+// into `out`. Canonical decoding: the code table is a canonical Huffman code,
+// so per bit-length a (first code, symbol range) pair identifies any code —
+// no tree, just the five const arrays above. Rejects the EOS symbol in the
+// stream and any padding that is not a prefix of EOS (all ones, < 8 bits).
+fn huffman_decode(src []u8, mut out []u8) ! {
+	mut cur := u64(0)
+	mut nbits := 0
+	for b in src {
+		cur = cur << 8 | u64(b)
+		nbits += 8
+		for {
+			mut matched := false
+			for i in 0 .. huff_len.len {
+				l := int(huff_len[i])
+				if l > nbits {
+					break
+				}
+				top := u32(cur >> (nbits - l))
+				if top >= huff_first[i] && top < huff_first[i] + u32(huff_count[i]) {
+					sym := huff_symbol[int(huff_base[i]) + int(top - huff_first[i])]
+					if sym == 256 {
+						return error('hpack: EOS symbol in huffman data')
+					}
+					out << u8(sym)
+					nbits -= l
+					cur &= (u64(1) << nbits) - 1
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				if nbits >= 30 {
+					return error('hpack: invalid huffman code')
+				}
+				break
+			}
+		}
+	}
+	if cur != (u64(1) << nbits) - 1 {
+		return error('hpack: invalid huffman padding')
+	}
+}

--- a/http2/hpack.v
+++ b/http2/hpack.v
@@ -236,6 +236,7 @@ pub fn (mut d HpackDecoder) decode(block []u8) ![]HeaderField {
 	mut out := []HeaderField{cap: 16}
 	mut pos := 0
 	mut decoded := 0
+	mut fields_seen := false
 	for pos < block.len {
 		b := block[pos]
 		if b & 0x80 != 0 {
@@ -247,6 +248,7 @@ pub fn (mut d HpackDecoder) decode(block []u8) ![]HeaderField {
 			if decoded > max_decoded_block {
 				return error('hpack: header block too large decoded')
 			}
+			fields_seen = true
 			out << HeaderField{
 				name:  name
 				value: value
@@ -268,12 +270,17 @@ pub fn (mut d HpackDecoder) decode(block []u8) ![]HeaderField {
 				return error('hpack: header block too large decoded')
 			}
 			d.add(name, value)
+			fields_seen = true
 			out << HeaderField{
 				name:  name
 				value: value
 			}
 		} else if b & 0xe0 == 0x20 {
-			// Dynamic table size update (§6.3).
+			// Dynamic table size update (§6.3) — only valid BEFORE the first
+			// field of a block (RFC 7541 §4.2).
+			if fields_seen {
+				return error('hpack: table size update after a header field')
+			}
 			size, p := decode_int(block, pos, 5)!
 			pos = p
 			if int(size) > d.max_size {
@@ -299,6 +306,7 @@ pub fn (mut d HpackDecoder) decode(block []u8) ![]HeaderField {
 			if decoded > max_decoded_block {
 				return error('hpack: header block too large decoded')
 			}
+			fields_seen = true
 			out << HeaderField{
 				name:  name
 				value: value
@@ -532,6 +540,11 @@ fn huffman_decode(src []u8, mut out []u8) ! {
 				break
 			}
 		}
+	}
+	if nbits > 7 {
+		// More than 7 unconsumed bits is an incomplete symbol, not padding —
+		// a decoding error even when the bits are all ones (RFC 7541 §5.2).
+		return error('hpack: huffman padding longer than 7 bits')
 	}
 	if cur != (u64(1) << nbits) - 1 {
 		return error('hpack: invalid huffman padding')

--- a/http2/hpack_test.v
+++ b/http2/hpack_test.v
@@ -1,0 +1,195 @@
+module http2
+
+// HPACK decoder/encoder tests. The multi-block sequences are the RFC 7541
+// Appendix C examples byte-for-byte (C.3 requests without Huffman, C.4 with,
+// C.5 responses with a 256-byte table forcing evictions) — including the
+// RFC's published dynamic-table sizes after every block.
+import encoding.hex
+
+fn hx(s string) []u8 {
+	return hex.decode(s) or { panic(err) }
+}
+
+fn int_decoding_fails(buf []u8, prefix int) bool {
+	decode_int(buf, 0, prefix) or { return true }
+	return false
+}
+
+fn field(name string, value string) HeaderField {
+	return HeaderField{
+		name:  name
+		value: value
+	}
+}
+
+fn test_decode_int_edges() ! {
+	// RFC 7541 C.1.1: 10 in a 5-bit prefix.
+	v0, p0 := decode_int([u8(0x0a)], 0, 5)!
+	assert v0 == 10
+	assert p0 == 1
+	// RFC 7541 C.1.2: 1337 in a 5-bit prefix.
+	v1, p1 := decode_int([u8(0x1f), 0x9a, 0x0a], 0, 5)!
+	assert v1 == 1337
+	assert p1 == 3
+	// RFC 7541 C.1.3: 42 in an 8-bit prefix.
+	v2, p2 := decode_int([u8(0x2a)], 0, 8)!
+	assert v2 == 42
+	assert p2 == 1
+	// Exactly the prefix maximum needs a zero continuation byte.
+	v3, p3 := decode_int([u8(0x1f), 0x00], 0, 5)!
+	assert v3 == 31
+	assert p3 == 2
+	// Truncated continuation.
+	assert int_decoding_fails([u8(0x1f)], 5)
+	// Unbounded continuation must be rejected, not wrapped.
+	assert int_decoding_fails([u8(0x1f), 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f], 5)
+}
+
+fn test_encode_int_roundtrip() ! {
+	values := [u32(0), 1, 15, 16, 30, 31, 32, 127, 128, 255, 256, 16383, 16384, 1048576]
+	for prefix in [4, 5, 6, 7] {
+		for v in values {
+			mut out := []u8{}
+			encode_int(mut out, 0x00, prefix, v)
+			got, p := decode_int(out, 0, prefix)!
+			assert got == v
+			assert p == out.len
+		}
+	}
+}
+
+fn test_huffman_decode_known_strings() ! {
+	// RFC 7541 C.4.1: Huffman('www.example.com').
+	mut out := []u8{}
+	huffman_decode(hx('f1e3c2e5f23a6ba0ab90f4ff'), mut out)!
+	assert out.bytestr() == 'www.example.com'
+	// RFC 7541 C.4.2: Huffman('no-cache').
+	out.clear()
+	huffman_decode(hx('a8eb10649cbf'), mut out)!
+	assert out.bytestr() == 'no-cache'
+	// RFC 7541 C.4.3: Huffman('custom-key') / Huffman('custom-value').
+	out.clear()
+	huffman_decode(hx('25a849e95ba97d7f'), mut out)!
+	assert out.bytestr() == 'custom-key'
+	out.clear()
+	huffman_decode(hx('25a849e95bb8e8b4bf'), mut out)!
+	assert out.bytestr() == 'custom-value'
+}
+
+fn test_huffman_rejects_bad_padding_and_eos() {
+	// '0' (00000) + 3 zero padding bits: padding must be all ones.
+	mut out := []u8{}
+	if _ := huffman_decode([u8(0x00)], mut out) {
+		assert false
+	}
+	// The 30-bit EOS code + 2 one-bits of padding: EOS in data is an error.
+	out.clear()
+	if _ := huffman_decode([u8(0xff), 0xff, 0xff, 0xff], mut out) {
+		assert false
+	}
+}
+
+fn test_static_indexed_fields() ! {
+	mut d := new_decoder(hpack_default_table_size)
+	got := d.decode(hx('8288'))!
+	assert got == [field(':method', 'GET'), field(':status', '200')]
+	assert d.dynamic_size() == 0
+}
+
+fn test_index_errors() {
+	mut d := new_decoder(hpack_default_table_size)
+	// Index 0 is a decoding error (RFC 7541 §6.1).
+	if _ := d.decode([u8(0x80)]) {
+		assert false
+	}
+	// Index 64 with an empty dynamic table is out of range.
+	if _ := d.decode([u8(0xc0)]) {
+		assert false
+	}
+}
+
+// RFC 7541 C.3 — three request blocks on one connection, no Huffman.
+fn test_rfc7541_c3_requests_plain() ! {
+	mut d := new_decoder(hpack_default_table_size)
+	first := d.decode(hx('828684410f7777772e6578616d706c652e636f6d'))!
+	assert first == [field(':method', 'GET'), field(':scheme', 'http'),
+		field(':path', '/'), field(':authority', 'www.example.com')]
+	assert d.dynamic_size() == 57
+	second := d.decode(hx('828684be58086e6f2d6361636865'))!
+	assert second == [field(':method', 'GET'), field(':scheme', 'http'),
+		field(':path', '/'), field(':authority', 'www.example.com'),
+		field('cache-control', 'no-cache')]
+	assert d.dynamic_size() == 110
+	third := d.decode(hx('828785bf400a637573746f6d2d6b65790c637573746f6d2d76616c7565'))!
+	assert third == [field(':method', 'GET'), field(':scheme', 'https'),
+		field(':path', '/index.html'), field(':authority', 'www.example.com'),
+		field('custom-key', 'custom-value')]
+	assert d.dynamic_size() == 164
+}
+
+// RFC 7541 C.4 — the same three requests, Huffman-encoded strings.
+fn test_rfc7541_c4_requests_huffman() ! {
+	mut d := new_decoder(hpack_default_table_size)
+	first := d.decode(hx('828684418cf1e3c2e5f23a6ba0ab90f4ff'))!
+	assert first == [field(':method', 'GET'), field(':scheme', 'http'),
+		field(':path', '/'), field(':authority', 'www.example.com')]
+	assert d.dynamic_size() == 57
+	second := d.decode(hx('828684be5886a8eb10649cbf'))!
+	assert second == [field(':method', 'GET'), field(':scheme', 'http'),
+		field(':path', '/'), field(':authority', 'www.example.com'),
+		field('cache-control', 'no-cache')]
+	assert d.dynamic_size() == 110
+	third := d.decode(hx('828785bf408825a849e95ba97d7f8925a849e95bb8e8b4bf'))!
+	assert third == [field(':method', 'GET'), field(':scheme', 'https'),
+		field(':path', '/index.html'), field(':authority', 'www.example.com'),
+		field('custom-key', 'custom-value')]
+	assert d.dynamic_size() == 164
+}
+
+// RFC 7541 C.5-shaped responses: a table-size update to 256 leads the first
+// block, and the third block's inserts evict earlier entries.
+fn test_response_blocks_with_eviction() ! {
+	mut d := new_decoder(hpack_default_table_size)
+	first := d.decode(hx('3fe101488264025885aec3771a4b6196d07abe941054d444a8200595040b8166e082a62d1bff6e919d29ad171863c78f0b97c8e9ae82ae43d3'))!
+	assert first == [field(':status', '302'), field('cache-control', 'private'),
+		field('date', 'Mon, 21 Oct 2013 20:13:21 GMT'),
+		field('location', 'https://www.example.com')]
+	assert d.dynamic_size() == 222
+	second := d.decode(hx('4883640effc1c0bf'))!
+	assert second == [field(':status', '307'), field('cache-control', 'private'),
+		field('date', 'Mon, 21 Oct 2013 20:13:21 GMT'),
+		field('location', 'https://www.example.com')]
+	assert d.dynamic_size() == 222
+	third := d.decode(hx('88c16196d07abe941054d444a8200595040b8166e084a62d1bffc05a839bd9ab77ad94e7821dd7f2e6c7b335dfdfcd5b3960d5af27087f3672c1ab270fb5291f9587316065c003ed4ee5b1063d5007'))!
+	assert third == [field(':status', '200'), field('cache-control', 'private'),
+		field('date', 'Mon, 21 Oct 2013 20:13:22 GMT'),
+		field('location', 'https://www.example.com'),
+		field('content-encoding', 'gzip'),
+		field('set-cookie', 'foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1')]
+	assert d.dynamic_size() == 215
+	assert d.dynamic_size() <= 256
+}
+
+fn test_table_size_update_above_settings_limit_rejected() {
+	mut d := new_decoder(128)
+	// Update to 256 when the advertised limit is 128 — connection error.
+	if _ := d.decode(hx('3fe101')) {
+		assert false
+	}
+}
+
+fn test_encoder_helpers_roundtrip() ! {
+	mut d := new_decoder(hpack_default_table_size)
+	mut out := []u8{}
+	encode_status(mut out, 200)
+	assert out == [u8(0x88)]
+	encode_status(mut out, 302)
+	encode_literal_name_idx(mut out, 21, '120') // 21 = age
+	encode_literal(mut out, 'x-custom', 'yes')
+	encode_literal(mut out, 'x-empty', '')
+	got := d.decode(out)!
+	assert got == [field(':status', '200'), field(':status', '302'),
+		field('age', '120'), field('x-custom', 'yes'), field('x-empty', '')]
+	// Stateless encoding must leave the peer's dynamic table untouched.
+	assert d.dynamic_size() == 0
+}

--- a/http2/hpack_test.v
+++ b/http2/hpack_test.v
@@ -170,6 +170,23 @@ fn test_response_blocks_with_eviction() ! {
 	assert d.dynamic_size() <= 256
 }
 
+fn test_huffman_rejects_padding_longer_than_7_bits() {
+	// 16 all-one bits decode to no symbol: more than 7 bits of "padding" is
+	// an incomplete symbol and must be rejected (RFC 7541 §5.2).
+	mut out := []u8{}
+	if _ := huffman_decode([u8(0xff), 0xff], mut out) {
+		assert false
+	}
+}
+
+fn test_table_size_update_after_a_field_rejected() {
+	// Indexed field, then a size update — updates only lead a block (§4.2).
+	mut d := new_decoder(hpack_default_table_size)
+	if _ := d.decode(hx('823fe101')) {
+		assert false
+	}
+}
+
 fn test_table_size_update_above_settings_limit_rejected() {
 	mut d := new_decoder(128)
 	// Update to 256 when the advertised limit is 128 — connection error.

--- a/http2/hpack_test.v
+++ b/http2/hpack_test.v
@@ -150,22 +150,22 @@ fn test_rfc7541_c4_requests_huffman() ! {
 // block, and the third block's inserts evict earlier entries.
 fn test_response_blocks_with_eviction() ! {
 	mut d := new_decoder(hpack_default_table_size)
-	first := d.decode(hx('3fe101488264025885aec3771a4b6196d07abe941054d444a8200595040b8166e082a62d1bff6e919d29ad171863c78f0b97c8e9ae82ae43d3'))!
+	first :=
+		d.decode(hx('3fe101488264025885aec3771a4b6196d07abe941054d444a8200595040b8166e082a62d1bff6e919d29ad171863c78f0b97c8e9ae82ae43d3'))!
 	assert first == [field(':status', '302'), field('cache-control', 'private'),
-		field('date', 'Mon, 21 Oct 2013 20:13:21 GMT'),
-		field('location', 'https://www.example.com')]
+		field('date', 'Mon, 21 Oct 2013 20:13:21 GMT'), field('location', 'https://www.example.com')]
 	assert d.dynamic_size() == 222
 	second := d.decode(hx('4883640effc1c0bf'))!
 	assert second == [field(':status', '307'), field('cache-control', 'private'),
-		field('date', 'Mon, 21 Oct 2013 20:13:21 GMT'),
-		field('location', 'https://www.example.com')]
+		field('date', 'Mon, 21 Oct 2013 20:13:21 GMT'), field('location', 'https://www.example.com')]
 	assert d.dynamic_size() == 222
-	third := d.decode(hx('88c16196d07abe941054d444a8200595040b8166e084a62d1bffc05a839bd9ab77ad94e7821dd7f2e6c7b335dfdfcd5b3960d5af27087f3672c1ab270fb5291f9587316065c003ed4ee5b1063d5007'))!
+	third :=
+		d.decode(hx('88c16196d07abe941054d444a8200595040b8166e084a62d1bffc05a839bd9ab77ad94e7821dd7f2e6c7b335dfdfcd5b3960d5af27087f3672c1ab270fb5291f9587316065c003ed4ee5b1063d5007'))!
 	assert third == [field(':status', '200'), field('cache-control', 'private'),
-		field('date', 'Mon, 21 Oct 2013 20:13:22 GMT'),
-		field('location', 'https://www.example.com'),
+		field('date', 'Mon, 21 Oct 2013 20:13:22 GMT'), field('location', 'https://www.example.com'),
 		field('content-encoding', 'gzip'),
-		field('set-cookie', 'foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1')]
+		field('set-cookie',
+			'foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1')]
 	assert d.dynamic_size() == 215
 	assert d.dynamic_size() <= 256
 }


### PR DESCRIPTION
## What

The dormant `http2/` module becomes a real protocol sibling (issue #122's http2 story), riding the conn-mode seam #138 landed for issue #136 — the seam's reserved "http2 preface later" arm, realized. One engine, one application handler, three wire protocols (HTTP/1.1, WebSocket, HTTP/2) on the same port.

### `http2/hpack.v` — full RFC 7541 HPACK
- N-bit-prefix integer coding (u64-accumulated, overflow-capped), string literals with **canonical-Huffman decoding** — the five decode tables are generated from the Appendix B code table (which is a canonical code: per bit-length, codes are consecutive), so decoding is a per-length range check, no tree.
- Static table (61 entries) + dynamic table with insert-at-head/evict-at-tail, entry size = name+value+32, table-size updates validated against the advertised SETTINGS limit.
- Hardening: EOS-in-data and non-EOS-padding rejection, string/index bounds, decoded-block ceiling (compression-bomb cap).
- **Stateless response encoder** (indexed + literal-without-indexing): spec-legal, and no encoder dynamic table means no state to synchronize with the peer's decoder — the encode path stays allocation-free.

### `http2/frame.v` — frame codec
Append-style writers (`write_frame_header`, SETTINGS/ack, PING ack, GOAWAY, RST_STREAM, WINDOW_UPDATE, DATA/HEADERS headers), SETTINGS payload parser, preface consts, flag consts. Parsing stays zero-copy.

### `http2/conn.v` — `ServerConn` state machine
Preface tail → SETTINGS exchange + ack → HEADERS/CONTINUATION assembly (contiguity enforced, padding/priority stripped) → complete requests surfaced with reassembled bodies. DATA replenishes both flow-control windows eagerly; the **send side honors peer windows** — response DATA that doesn't fit parks in a per-stream pending buffer and flushes as WINDOW_UPDATEs arrive. Trailers decode (HPACK state is connection-global) and complete the request. PING echo, GOAWAY, RST_STREAM, PRIORITY, unknown-frame tolerance, per-RFC error codes; stream-id monotonicity and `max_concurrent_streams` (refused via RST_STREAM) enforced. `consume()` has exactly a `core.ConnHandler`'s shape but the module stays engine-free (no `core` import — same discipline as `websocket/`).

### `examples/http2_cleartext/` — prior-knowledge cleartext HTTP/2
The client preface's first 18 bytes parse as an ordinary h1 request (`PRI * HTTP/2.0`, empty header section), so it reaches the handler like any request: the handler queues `core.queue_takeover` and appends the server SETTINGS as its switching response (with the 501 fallback when the backend can't take over, mirroring `websocket_echo`). Each complete http2 request is translated to h1 bytes and served by the **same handler** that serves h1 connections; the response head is parsed back with the `http1_1.client` codec and re-framed as HEADERS + DATA (connection-specific fields stripped per RFC 9113 §8.2.2, names lowercased).

```
curl --http2-prior-knowledge http://localhost:3000/
```

## Testing

- **HPACK**: the RFC 7541 Appendix C sequences **byte-for-byte** (C.3 plain, C.4 Huffman, C.5-shaped eviction runs), asserting the RFC's published dynamic-table sizes after every block (57/110/164, 222/222/215); integer edge vectors (C.1.1–C.1.3); Huffman negative cases; encoder→decoder roundtrips.
- **Frame codec**: writer/parser roundtrips, reserved-bit masking, layout asserts.
- **ServerConn**: handshake, GET/POST round-trips, split-frame buffering, PING echo, window replenishment accounting, flow-control parking + WINDOW_UPDATE flush (byte-exact), stream-id ascension, RST_STREAM, unknown-frame tolerance, oversized-frame and PUSH_PROMISE fatality.
- **Example**: in-process bridge tests (no sockets) + vtest e2e through a real epoll worker — preface pipelined with the first request in one segment, a second stream, PING ack, client GOAWAY → server EOF, and an h1 connection served by the same handler in the same run.
- The decoder algorithms were additionally fuzz-validated during development against the Python `hpack` reference implementation (20k Huffman roundtrips, ~9k full header blocks with dynamic-table churn) before transcription to V.

## Notes for review

- `v fmt -w .` could not be run locally (no V toolchain reachable from this sandbox — GitHub egress here is scoped to this repo, and V has no other install channel). Formatting follows vfmt conventions by hand; if the fmt gate disagrees, I'll fix from CI output.
- Scope deliberately excludes (rule 3): TLS/ALPN, the HTTP/1.1 Upgrade handshake, server push (deprecated by browsers), and surfacing trailer fields to handlers. The h1 hot path is untouched — the bridge allocates, and that cost is confined to http2 connections.
- CI: http2 module tests added to the Linux repo-tests job; example added to the Linux + Windows matrices (Windows runs the 501-fallback + pure-bytes bridge tests; the socket e2e is Linux-guarded, matching `websocket_echo`).

Refs #122 (http2 as a protocol sibling), #136 (the seam this consumes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuVyfeCgZJzA3U6NjSPg5k

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuVyfeCgZJzA3U6NjSPg5k)_