### PR TITLE
feat(seam): .suspend for takeover ConnHandlers — async handlers over http2 (issue #136 follow-up)

### DIFF
--- a/core/takeover_slot.c.v
+++ b/core/takeover_slot.c.v
@@ -25,16 +25,24 @@ fn C.vanilla_to_take(out_cont &voidptr, out_state &voidptr) bool
 // bytes to `out` (the same persistent, batch-flushed write buffer handlers
 // use). It returns how many bytes of `buf` it consumed plus the next Step:
 //
-//   .done  — keep the connection open and wait for more bytes
-//   .close — flush whatever is in `out`, then close the connection
+//   .done    — keep the connection open and wait for more bytes
+//   .suspend — park the connection on the fd just armed via
+//              event_loop.watch_fd(...): the registered continuation (a
+//              core.WakeFn, same contract as an h1 park) resumes it when the
+//              fd fires — appending protocol bytes to the SAME write buffer —
+//              and its .done hands the socket back to the takeover drain.
+//              While parked the engine reads nothing from the client (bytes
+//              wait in the socket, mirroring a parked h1 request) and at most
+//              ONE watch may be armed per connection (the close-path teardown
+//              tracks exactly one fd). Suspending WITHOUT arming a watch
+//              closes the connection — nothing would ever resume it.
+//   .close   — flush whatever is in `out`, then close the connection
 //
 // A partial frame is expressed by consuming fewer bytes than `buf.len` (or 0):
 // the engine keeps the tail buffered, compacts it to the front, and calls
 // again when more bytes arrive. Consuming nothing while returning .done on a
 // full buffer would spin the connection — the engine closes it if the buffer
-// can no longer grow. `.suspend` is not supported for takeover connections in
-// v1 (treated as .close); push/backpressure choreography composes with the
-// watch primitive as a follow-up (issue #136).
+// can no longer grow.
 //
 //   takeover_state — the value passed to queue_takeover (per-connection
 //                    protocol state, e.g. fragmentation reassembly); the

--- a/examples/http2_cleartext/src/main.v
+++ b/examples/http2_cleartext/src/main.v
@@ -22,9 +22,20 @@ module main
 // The translation allocates; that is the http2 bridge's cost, paid off the
 // h1 hot path (which is untouched).
 //
+// Async routes work over BOTH protocols (the issue #136 follow-up: .suspend
+// is legal for ConnHandlers): GET /slow parks on a timerfd. Served over h1
+// the ENGINE parks the request. Served over http2 the bridge hands the app a
+// CAPTURE event loop — the watch the app arms is recorded, re-armed on the
+// real loop with a bridge continuation, and the app's resumed h1 response is
+// re-framed for exactly the stream that parked. Other streams in the same
+// burst are served while the parked one waits (v1 limit: one parked stream
+// per connection — the engine's one-armed-watch contract; extra parkers are
+// refused with RST_STREAM so the client retries).
+//
 // Try it (prior knowledge, no upgrade dance):
 //   curl --http2-prior-knowledge http://localhost:3000/
 //   curl --http2-prior-knowledge -d 'ping' http://localhost:3000/echo
+//   curl --http2-prior-knowledge http://localhost:3000/slow
 import core
 import http1_1.client
 import http1_1.request_parser
@@ -42,11 +53,15 @@ const cannot_takeover_response = 'HTTP/1.1 501 Not Implemented\r\nContent-Length
 const echo_head_prefix = 'HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: '.bytes()
 const echo_head_suffix = '\r\nConnection: keep-alive\r\n\r\n'.bytes()
 
+const slow_response = 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 10\r\nConnection: keep-alive\r\n\r\nslow done\n'.bytes()
+const slow_unavailable_response = 'HTTP/1.1 501 Not Implemented\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+
 const get_method = 'GET'.bytes()
 const post_method = 'POST'.bytes()
 const pri_method = 'PRI'.bytes()
 const root_path = '/'.bytes()
 const echo_path = '/echo'.bytes()
+const slow_path = '/slow'.bytes()
 const star_target = '*'.bytes()
 
 const h1_line_suffix = ' HTTP/1.1\r\n'.bytes()
@@ -93,14 +108,16 @@ fn handle(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event
 	if slice_eq(hr.buffer, hr.method, pri_method) && slice_eq(hr.buffer, hr.path, star_target) {
 		// The http2 client connection preface. Takeover FIRST: only answer
 		// with the server preface if this worker can actually flip the mode.
-		mut conn := http2.new_server_conn()
-		if !core.queue_takeover(http2_takeover_conn, voidptr(conn)) {
+		mut bridge := &BridgeState{
+			conn: http2.new_server_conn()
+		}
+		if !core.queue_takeover(http2_takeover_conn, voidptr(bridge)) {
 			res << cannot_takeover_response
 			return .close
 		}
-		// The engine keeps `conn` reachable for the GC through the
+		// The engine keeps `bridge` reachable for the GC through the
 		// connection's state once the mode flips (the takeover_state slot).
-		conn.write_server_preface(mut res)
+		bridge.conn.write_server_preface(mut res)
 		return .done
 	}
 	if !slice_eq(hr.buffer, hr.version, http11_version)
@@ -112,14 +129,19 @@ fn handle(req []u8, mut res []u8, client_fd int, worker_state voidptr, mut event
 		http2.write_goaway(mut res, 0, .protocol_error)
 		return .close
 	}
-	return app_route(hr, mut res)
+	return app_route(hr, mut res, mut event_loop)
 }
 
-// app_route is the application: plain h1 routes, protocol-blind.
-fn app_route(hr request_parser.HttpRequest, mut res []u8) core.Step {
+// app_route is the application: plain h1 routes, protocol-blind. Async routes
+// park through event_loop — over h1 that is the engine's loop; over http2 it
+// is the bridge's capture loop (see serve_http2_request).
+fn app_route(hr request_parser.HttpRequest, mut res []u8, mut event_loop core.EventLoop) core.Step {
 	if slice_eq(hr.buffer, hr.method, get_method) && slice_eq(hr.buffer, hr.path, root_path) {
 		res << home_response
 		return .done
+	}
+	if slice_eq(hr.buffer, hr.method, get_method) && slice_eq(hr.buffer, hr.path, slow_path) {
+		return slow_route(mut res, mut event_loop)
 	}
 	if slice_eq(hr.buffer, hr.method, post_method) && slice_eq(hr.buffer, hr.path, echo_path) {
 		res << echo_head_prefix
@@ -134,21 +156,76 @@ fn app_route(hr request_parser.HttpRequest, mut res []u8) core.Step {
 	return .done
 }
 
+// BridgeState is the per-connection takeover_state: the http2 protocol state
+// plus the bridge's one-parked-stream bookkeeping (the engine's contract
+// allows one armed watch per parked connection).
+struct BridgeState {
+mut:
+	conn   &http2.ServerConn
+	parked bool
+}
+
+// WatchCapture records the ONE watch an app handler arms while served over
+// http2. The bridge hands the app a capture EventLoop whose register writes
+// here instead of arming anything — the real watch is armed by the bridge
+// with its own continuation, so the app's resumed output is re-framed for
+// the stream that parked instead of leaking raw h1 bytes onto the wire.
+struct WatchCapture {
+mut:
+	fd       int = -1
+	interest core.WatchInterest
+	cont     core.WakeFn = unsafe { nil }
+	udata    voidptr
+}
+
+// capture_register is the RegisterFn installed on the capture loop: it
+// records the app's watch instead of arming it (el.reactor smuggles the
+// WatchCapture — the capture loop never reaches a real reactor).
+fn capture_register(mut el core.EventLoop, ext_fd int, interest core.WatchInterest, cont core.WakeFn, udata voidptr) {
+	mut capture := unsafe { &WatchCapture(el.reactor) }
+	capture.fd = ext_fd
+	capture.interest = interest
+	capture.cont = cont
+	capture.udata = udata
+	el.last_watched = ext_fd
+}
+
+// StreamWait carries a parked stream across the engine's park/resume hop:
+// which stream to answer, the app's continuation, and the h1 response bytes
+// accumulated so far (streamed across multi-hop suspends).
+@[heap]
+struct StreamWait {
+mut:
+	bridge    &BridgeState
+	stream_id u32
+	app_cont  core.WakeFn = unsafe { nil }
+	app_udata voidptr
+	h1_res    []u8
+}
+
 // http2_takeover_conn is the core.ConnHandler for a flipped connection: the
 // ServerConn consumes frames (answering acks/pings/window updates itself)
-// and surfaces complete requests, which are served through `handle`.
+// and surfaces complete requests, which are served through `handle`. A
+// stream that parks (async route) suspends the connection; the bridge's
+// continuation resumes it when the watched fd fires.
 fn http2_takeover_conn(buf []u8, mut out []u8, client_fd int, takeover_state voidptr, worker_state voidptr, mut event_loop core.EventLoop) (int, core.Step) {
-	mut conn := unsafe { &http2.ServerConn(takeover_state) }
+	mut bridge := unsafe { &BridgeState(takeover_state) }
+	mut conn := bridge.conn
 	mut reqs := []http2.Http2Request{}
 	consumed, closing := conn.consume(buf, mut out, mut reqs)
 	mut must_close := closing
 	for req in reqs {
-		if !serve_http2_request(mut conn, req, mut out, client_fd, worker_state, mut event_loop) {
+		if !serve_http2_request(mut bridge, req, mut out, client_fd, worker_state, mut event_loop) {
 			must_close = true
 		}
 	}
 	if must_close {
+		// The engine tears down any watch armed by a parked stream in this
+		// same call (a .close with a live watch never leaks it).
 		return consumed, core.Step.close
+	}
+	if bridge.parked {
+		return consumed, core.Step.suspend
 	}
 	return consumed, core.Step.done
 }
@@ -156,9 +233,11 @@ fn http2_takeover_conn(buf []u8, mut out []u8, client_fd int, takeover_state voi
 // serve_http2_request bridges one http2 request through the h1 handler:
 // pseudo-headers become the request line, regular fields carry over
 // (connection-specific ones dropped, RFC 9113 §8.2.2), the response head is
-// parsed back with the client codec and re-framed as HEADERS + DATA.
+// parsed back with the client codec and re-framed as HEADERS + DATA. An app
+// handler that suspends parks the stream via bridge_park.
 // Returns false when the connection must close afterwards.
-fn serve_http2_request(mut conn http2.ServerConn, req http2.Http2Request, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) bool {
+fn serve_http2_request(mut bridge BridgeState, req http2.Http2Request, mut out []u8, client_fd int, worker_state voidptr, mut event_loop core.EventLoop) bool {
+	mut conn := bridge.conn
 	mut method := ''
 	mut path := ''
 	mut authority := ''
@@ -213,18 +292,110 @@ fn serve_http2_request(mut conn http2.ServerConn, req http2.Http2Request, mut ou
 	if req.body.len > 0 {
 		unsafe { h1_req.push_many(&req.body[0], req.body.len) }
 	}
-	// The same pure handler serves the translated request.
+	// The same pure handler serves the translated request — against a CAPTURE
+	// event loop, so an async route's watch is recorded (not armed) and the
+	// bridge can re-frame its resumed output for this stream.
 	mut h1_res := []u8{cap: 512}
-	step := handle(h1_req, mut h1_res, client_fd, worker_state, mut event_loop)
+	mut capture := WatchCapture{}
+	mut probe_loop := core.EventLoop{
+		client_fd: client_fd
+		reactor:   unsafe { voidptr(&capture) }
+		register:  capture_register
+	}
+	step := handle(h1_req, mut h1_res, client_fd, worker_state, mut probe_loop)
 	if step == .suspend {
-		// .suspend is unsupported behind the takeover seam (issue #136 v1).
-		http2.write_goaway(mut out, req.stream_id, .internal_error)
+		return bridge_park(mut bridge, req.stream_id, capture, h1_res, mut out, mut event_loop)
+	}
+	if !frame_h1_response(mut conn, req.stream_id, h1_res, mut out) {
 		return false
 	}
+	return step == .done
+}
+
+// bridge_park parks one stream: the app's captured watch is re-armed on the
+// REAL event loop with bridge_wake as its continuation, and the connection
+// suspends (http2_takeover_conn returns .suspend). One parked stream per
+// connection — the engine's close-path teardown tracks exactly one watch —
+// so a second parker is refused (RST_STREAM) and the client retries.
+// Returns false when the connection must close.
+fn bridge_park(mut bridge BridgeState, stream_id u32, capture WatchCapture, h1_partial []u8, mut out []u8, mut event_loop core.EventLoop) bool {
+	if capture.fd < 0 || capture.cont == unsafe { nil } {
+		// Suspended without arming a watch — nothing would resume the stream.
+		http2.write_goaway(mut out, stream_id, .internal_error)
+		return false
+	}
+	if bridge.parked {
+		// Release the app's request-owned fd (e.g. a timerfd). This branch is
+		// unreachable where async routes degrade to sync answers, but it must
+		// still compile everywhere.
+		$if !windows {
+			C.close(capture.fd)
+		}
+		mut conn := bridge.conn
+		conn.abort_stream(mut out, stream_id, .refused_stream)
+		return true
+	}
+	wait := &StreamWait{
+		bridge:    unsafe { &BridgeState(voidptr(&bridge)) }
+		stream_id: stream_id
+		app_cont:  capture.cont
+		app_udata: capture.udata
+		h1_res:    h1_partial
+	}
+	bridge.parked = true
+	event_loop.watch_fd(capture.fd, capture.interest, bridge_wake, voidptr(wait))
+	return true
+}
+
+// bridge_wake is the continuation the bridge arms for a parked stream: it
+// runs the app's continuation against the stream's PRIVATE h1 buffer (again
+// under a capture loop, so multi-hop suspends re-park cleanly), then
+// re-frames the finished h1 response for exactly that stream.
+fn bridge_wake(mut out []u8, ready_fd int, ready_fd_error bool, watch_payload voidptr, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+	mut wait := unsafe { &StreamWait(watch_payload) }
+	mut bridge := wait.bridge
+	mut capture := WatchCapture{}
+	mut probe_loop := core.EventLoop{
+		client_fd: event_loop.client_fd
+		reactor:   unsafe { voidptr(&capture) }
+		register:  capture_register
+	}
+	step := wait.app_cont(mut wait.h1_res, ready_fd, ready_fd_error, wait.app_udata, worker_state, mut
+		probe_loop)
+	if step == .suspend {
+		if capture.fd < 0 || capture.cont == unsafe { nil } {
+			bridge.parked = false
+			http2.write_goaway(mut out, wait.stream_id, .internal_error)
+			return .close
+		}
+		// Multi-hop park: re-arm with this same StreamWait, stay suspended.
+		wait.app_cont = capture.cont
+		wait.app_udata = capture.udata
+		event_loop.watch_fd(capture.fd, capture.interest, bridge_wake, voidptr(wait))
+		return .suspend
+	}
+	bridge.parked = false
+	mut conn := bridge.conn
+	if !frame_h1_response(mut conn, wait.stream_id, wait.h1_res, mut out) {
+		return .close
+	}
+	if step == .close {
+		// The app asked to drop the connection after its response — say so in
+		// the protocol the peer speaks.
+		http2.write_goaway(mut out, 0, .no_error)
+		return .close
+	}
+	return .done
+}
+
+// frame_h1_response re-frames a complete h1 response as HEADERS + DATA for
+// `stream_id`. Returns false (after a GOAWAY) when the response is unusable —
+// connection-fatal, since the stream would otherwise hang forever.
+fn frame_h1_response(mut conn http2.ServerConn, stream_id u32, h1_res []u8, mut out []u8) bool {
 	total := client.frame_response(h1_res)
 	status := client.status_code(h1_res)
 	if total <= 0 || status < 0 {
-		http2.write_goaway(mut out, req.stream_id, .internal_error)
+		http2.write_goaway(mut out, stream_id, .internal_error)
 		return false
 	}
 	head := client.head_len(h1_res)
@@ -232,12 +403,24 @@ fn serve_http2_request(mut conn http2.ServerConn, req http2.Http2Request, mut ou
 	mut block := []u8{cap: 64}
 	http2.encode_status(mut block, status)
 	append_response_fields(mut block, h1_res, head)
-	conn.write_response_headers(mut out, req.stream_id, block, blen == 0)
+	conn.write_response_headers(mut out, stream_id, block, blen == 0)
 	if blen > 0 {
 		body := unsafe { (&h1_res[bstart]).vbytes(blen) }
-		conn.write_response_data(mut out, req.stream_id, body)
+		conn.write_response_data(mut out, stream_id, body)
 	}
-	return step == .done
+	return true
+}
+
+// slow_route parks the request on a one-shot 30 ms timerfd — the async_timer
+// idiom. Served over h1 the ENGINE parks the request; served over http2 the
+// BRIDGE captures the watch and parks the stream. Same handler, both
+// protocols. On platforms without timerfd the route degrades to a sync 501.
+fn slow_route(mut res []u8, mut event_loop core.EventLoop) core.Step {
+	$if linux {
+		return slow_route_linux(mut res, mut event_loop)
+	}
+	res << slow_unavailable_response
+	return .done
 }
 
 // append_response_fields HPACK-encodes the h1 response head's fields (after

--- a/examples/http2_cleartext/src/main_test.v
+++ b/examples/http2_cleartext/src/main_test.v
@@ -214,11 +214,11 @@ fn test_bridge_parks_and_resumes_async_stream() ! {
 		slow_block := get_block_path('/slow')
 		home_block := get_block(4)
 		mut input := []u8{}
-		http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
-			1, slow_block.len)
+		http2.write_frame_header(mut input, .headers,
+			http2.flag_end_headers | http2.flag_end_stream, 1, slow_block.len)
 		input << slow_block
-		http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
-			3, home_block.len)
+		http2.write_frame_header(mut input, .headers,
+			http2.flag_end_headers | http2.flag_end_stream, 3, home_block.len)
 		input << home_block
 		// Engine-loop stand-in: capture what the bridge arms for the park.
 		mut engine_capture := WatchCapture{}
@@ -228,8 +228,8 @@ fn test_bridge_parks_and_resumes_async_stream() ! {
 			register:  capture_register
 		}
 		mut out := []u8{}
-		consumed, step := http2_takeover_conn(input, mut out, -1, voidptr(bridge), unsafe { nil }, mut
-			el)
+		consumed, step :=
+			http2_takeover_conn(input, mut out, -1, voidptr(bridge), unsafe { nil }, mut el)
 		assert consumed == input.len
 		assert step == .suspend
 		assert bridge.parked
@@ -287,11 +287,11 @@ fn test_second_parker_is_refused_with_rst() {
 		slow1 := get_block_path('/slow')
 		slow3 := get_block_path('/slow')
 		mut input := []u8{}
-		http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
-			1, slow1.len)
+		http2.write_frame_header(mut input, .headers,
+			http2.flag_end_headers | http2.flag_end_stream, 1, slow1.len)
 		input << slow1
-		http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
-			3, slow3.len)
+		http2.write_frame_header(mut input, .headers,
+			http2.flag_end_headers | http2.flag_end_stream, 3, slow3.len)
 		input << slow3
 		mut engine_capture := WatchCapture{}
 		mut el := core.EventLoop{
@@ -300,8 +300,8 @@ fn test_second_parker_is_refused_with_rst() {
 			register:  capture_register
 		}
 		mut out := []u8{}
-		consumed, step := http2_takeover_conn(input, mut out, -1, voidptr(bridge), unsafe { nil }, mut
-			el)
+		consumed, step :=
+			http2_takeover_conn(input, mut out, -1, voidptr(bridge), unsafe { nil }, mut el)
 		assert consumed == input.len
 		assert step == .suspend
 		frames := split_frames(out)

--- a/examples/http2_cleartext/src/main_test.v
+++ b/examples/http2_cleartext/src/main_test.v
@@ -77,11 +77,11 @@ fn hf(name string, value string) http2.HeaderField {
 	}
 }
 
-// bridge_step feeds one burst to the takeover ConnHandler over `conn`.
-fn bridge_step(mut conn http2.ServerConn, input []u8) (int, core.Step, []u8) {
+// bridge_step feeds one burst to the takeover ConnHandler over `bridge`.
+fn bridge_step(mut bridge BridgeState, input []u8) (int, core.Step, []u8) {
 	mut out := []u8{}
 	mut event_loop := core.EventLoop{}
-	consumed, step := http2_takeover_conn(input, mut out, -1, voidptr(conn), unsafe { nil }, mut
+	consumed, step := http2_takeover_conn(input, mut out, -1, voidptr(&bridge), unsafe { nil }, mut
 		event_loop)
 	return consumed, step, out
 }
@@ -96,7 +96,9 @@ fn get_block(path_idx int) []u8 {
 }
 
 fn test_http2_get_bridges_to_the_h1_handler() ! {
-	mut conn := http2.new_server_conn()
+	mut bridge := &BridgeState{
+		conn: http2.new_server_conn()
+	}
 	mut input := []u8{}
 	input << http2.preface_tail
 	http2.write_settings(mut input, [])
@@ -104,7 +106,7 @@ fn test_http2_get_bridges_to_the_h1_handler() ! {
 	http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
 		1, block.len)
 	input << block
-	consumed, step, out := bridge_step(mut conn, input)
+	consumed, step, out := bridge_step(mut bridge, input)
 	assert consumed == input.len
 	assert step == .done
 	frames := split_frames(out)
@@ -130,11 +132,13 @@ fn test_http2_get_bridges_to_the_h1_handler() ! {
 }
 
 fn test_http2_post_echo_with_body() ! {
-	mut conn := http2.new_server_conn()
+	mut bridge := &BridgeState{
+		conn: http2.new_server_conn()
+	}
 	mut handshake := []u8{}
 	handshake << http2.preface_tail
 	http2.write_settings(mut handshake, [])
-	_, step0, _ := bridge_step(mut conn, handshake)
+	_, step0, _ := bridge_step(mut bridge, handshake)
 	assert step0 == .done
 	mut block := []u8{}
 	http2.encode_indexed(mut block, 3) // :method POST
@@ -146,7 +150,7 @@ fn test_http2_post_echo_with_body() ! {
 	input << block
 	http2.write_data_header(mut input, 1, 4, true)
 	input << 'ping'.bytes()
-	consumed, step, out := bridge_step(mut conn, input)
+	consumed, step, out := bridge_step(mut bridge, input)
 	assert consumed == input.len
 	assert step == .done
 	frames := split_frames(out)
@@ -164,11 +168,13 @@ fn test_http2_post_echo_with_body() ! {
 }
 
 fn test_http2_goaway_keeps_the_connection_serving() {
-	mut conn := http2.new_server_conn()
+	mut bridge := &BridgeState{
+		conn: http2.new_server_conn()
+	}
 	mut handshake := []u8{}
 	handshake << http2.preface_tail
 	http2.write_settings(mut handshake, [])
-	_, step0, _ := bridge_step(mut conn, handshake)
+	_, step0, _ := bridge_step(mut bridge, handshake)
 	assert step0 == .done
 	// A peer GOAWAY does not close the connection — the peer does. The
 	// bridge keeps serving (a PING after it still gets an ack).
@@ -176,7 +182,7 @@ fn test_http2_goaway_keeps_the_connection_serving() {
 	http2.write_goaway(mut input, 0, .no_error)
 	http2.write_frame_header(mut input, .ping, 0, 0, 8)
 	input << [u8(1), 2, 3, 4, 5, 6, 7, 8]
-	consumed, step, out := bridge_step(mut conn, input)
+	consumed, step, out := bridge_step(mut bridge, input)
 	assert consumed == input.len
 	assert step == .done
 	frames := split_frames(out)
@@ -185,12 +191,153 @@ fn test_http2_goaway_keeps_the_connection_serving() {
 	assert frames[0].fh.flags & http2.flag_ack != 0
 }
 
+fn get_block_path(path string) []u8 {
+	mut block := []u8{}
+	http2.encode_indexed(mut block, 2) // :method GET
+	http2.encode_indexed(mut block, 6) // :scheme http
+	http2.encode_literal_name_idx(mut block, 4, path)
+	http2.encode_literal_name_idx(mut block, 1, 'x.test')
+	return block
+}
+
+fn test_bridge_parks_and_resumes_async_stream() ! {
+	$if linux {
+		mut bridge := &BridgeState{
+			conn: http2.new_server_conn()
+		}
+		mut handshake := []u8{}
+		handshake << http2.preface_tail
+		http2.write_settings(mut handshake, [])
+		_, s0, _ := bridge_step(mut bridge, handshake)
+		assert s0 == .done
+		// One burst, two streams: /slow parks on a timerfd, / answers now.
+		slow_block := get_block_path('/slow')
+		home_block := get_block(4)
+		mut input := []u8{}
+		http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
+			1, slow_block.len)
+		input << slow_block
+		http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
+			3, home_block.len)
+		input << home_block
+		// Engine-loop stand-in: capture what the bridge arms for the park.
+		mut engine_capture := WatchCapture{}
+		mut el := core.EventLoop{
+			client_fd: -1
+			reactor:   unsafe { voidptr(&engine_capture) }
+			register:  capture_register
+		}
+		mut out := []u8{}
+		consumed, step := http2_takeover_conn(input, mut out, -1, voidptr(bridge), unsafe { nil }, mut
+			el)
+		assert consumed == input.len
+		assert step == .suspend
+		assert bridge.parked
+		assert engine_capture.fd >= 0 // the app's real timerfd, re-armed by the bridge
+		assert el.last_watched == engine_capture.fd
+		// Stream 3 answered immediately; stream 1 has nothing yet.
+		frames := split_frames(out)
+		mut saw_home := false
+		for f in frames {
+			assert f.fh.stream_id != 1
+			if f.fh.type_ == .data && f.fh.stream_id == 3 {
+				assert f.payload.bytestr() == 'hello over one handler\n'
+				saw_home = true
+			}
+		}
+		assert saw_home
+		// The timer "fires": run the continuation the engine would run.
+		mut resume_capture := WatchCapture{}
+		mut el2 := core.EventLoop{
+			client_fd: -1
+			reactor:   unsafe { voidptr(&resume_capture) }
+			register:  capture_register
+		}
+		mut out2 := []u8{}
+		rstep := engine_capture.cont(mut out2, engine_capture.fd, false, engine_capture.udata,
+			unsafe { nil }, mut el2)
+		assert rstep == .done
+		assert !bridge.parked
+		frames2 := split_frames(out2)
+		assert frames2.len == 2
+		assert frames2[0].fh.type_ == .headers
+		assert frames2[0].fh.stream_id == 1
+		mut dec := http2.new_decoder(http2.hpack_default_table_size)
+		fields := dec.decode(frames2[0].payload)!
+		assert fields[0] == hf(':status', '200')
+		assert frames2[1].fh.type_ == .data
+		assert frames2[1].fh.stream_id == 1
+		assert frames2[1].fh.flags & http2.flag_end_stream != 0
+		assert frames2[1].payload.bytestr() == 'slow done\n'
+	}
+}
+
+fn test_second_parker_is_refused_with_rst() {
+	$if linux {
+		mut bridge := &BridgeState{
+			conn: http2.new_server_conn()
+		}
+		mut handshake := []u8{}
+		handshake << http2.preface_tail
+		http2.write_settings(mut handshake, [])
+		_, s0, _ := bridge_step(mut bridge, handshake)
+		assert s0 == .done
+		// TWO /slow streams in one burst: the first parks, the second is
+		// refused (one armed watch per parked connection — engine contract).
+		slow1 := get_block_path('/slow')
+		slow3 := get_block_path('/slow')
+		mut input := []u8{}
+		http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
+			1, slow1.len)
+		input << slow1
+		http2.write_frame_header(mut input, .headers, http2.flag_end_headers | http2.flag_end_stream,
+			3, slow3.len)
+		input << slow3
+		mut engine_capture := WatchCapture{}
+		mut el := core.EventLoop{
+			client_fd: -1
+			reactor:   unsafe { voidptr(&engine_capture) }
+			register:  capture_register
+		}
+		mut out := []u8{}
+		consumed, step := http2_takeover_conn(input, mut out, -1, voidptr(bridge), unsafe { nil }, mut
+			el)
+		assert consumed == input.len
+		assert step == .suspend
+		frames := split_frames(out)
+		mut saw_rst := false
+		for f in frames {
+			if f.fh.type_ == .rst_stream && f.fh.stream_id == 3 {
+				assert f.payload == [u8(0), 0, 0, 7] // REFUSED_STREAM
+				saw_rst = true
+			}
+		}
+		assert saw_rst
+		// The parked stream still completes.
+		mut resume_capture := WatchCapture{}
+		mut el2 := core.EventLoop{
+			client_fd: -1
+			reactor:   unsafe { voidptr(&resume_capture) }
+			register:  capture_register
+		}
+		mut out2 := []u8{}
+		rstep := engine_capture.cont(mut out2, engine_capture.fd, false, engine_capture.udata,
+			unsafe { nil }, mut el2)
+		assert rstep == .done
+		frames2 := split_frames(out2)
+		assert frames2.len == 2
+		assert frames2[1].payload.bytestr() == 'slow done\n'
+	}
+}
+
 fn test_http2_partial_frame_consumes_nothing() {
-	mut conn := http2.new_server_conn()
+	mut bridge := &BridgeState{
+		conn: http2.new_server_conn()
+	}
 	mut handshake := []u8{}
 	handshake << http2.preface_tail
 	http2.write_settings(mut handshake, [])
-	c0, s0, _ := bridge_step(mut conn, handshake)
+	c0, s0, _ := bridge_step(mut bridge, handshake)
 	assert c0 == handshake.len
 	assert s0 == .done
 	block := get_block(4)
@@ -198,11 +345,11 @@ fn test_http2_partial_frame_consumes_nothing() {
 	http2.write_frame_header(mut whole, .headers, http2.flag_end_headers | http2.flag_end_stream,
 		1, block.len)
 	whole << block
-	consumed, step, out := bridge_step(mut conn, whole[..whole.len - 2])
+	consumed, step, out := bridge_step(mut bridge, whole[..whole.len - 2])
 	assert consumed == 0
 	assert step == .done
 	assert out.len == 0
-	consumed2, step2, out2 := bridge_step(mut conn, whole)
+	consumed2, step2, out2 := bridge_step(mut bridge, whole)
 	assert consumed2 == whole.len
 	assert step2 == .done
 	assert split_frames(out2).len == 2 // HEADERS + DATA

--- a/examples/http2_cleartext/src/server_end_to_end_test.v
+++ b/examples/http2_cleartext/src/server_end_to_end_test.v
@@ -82,16 +82,16 @@ fn e2e_async_opening() []u8 {
 	http2.encode_indexed(mut slow_block, 6)
 	http2.encode_literal_name_idx(mut slow_block, 4, '/slow')
 	http2.encode_literal_name_idx(mut slow_block, 1, 'x.test')
-	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream,
-		1, slow_block.len)
+	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream, 1,
+		slow_block.len)
 	b << slow_block
 	mut home_block := []u8{}
 	http2.encode_indexed(mut home_block, 2)
 	http2.encode_indexed(mut home_block, 6)
 	http2.encode_indexed(mut home_block, 4)
 	http2.encode_literal_name_idx(mut home_block, 1, 'x.test')
-	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream,
-		3, home_block.len)
+	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream, 3,
+		home_block.len)
 	b << home_block
 	return b
 }

--- a/examples/http2_cleartext/src/server_end_to_end_test.v
+++ b/examples/http2_cleartext/src/server_end_to_end_test.v
@@ -11,6 +11,7 @@ import server
 import vtest
 
 const e2e_home_body = 'hello over one handler\n'.bytes()
+const e2e_slow_body = 'slow done\n'.bytes()
 
 fn e2e_index_bytes(acc []u8, needle []u8) int {
 	if needle.len == 0 || acc.len < needle.len {
@@ -70,6 +71,31 @@ fn e2e_post_echo(stream_id u32, payload string) []u8 {
 	return b
 }
 
+// e2e_async_opening: preface + SETTINGS + GET /slow (stream 1, parks on a
+// timerfd) + GET / (stream 3, answers immediately) — all in ONE write.
+fn e2e_async_opening() []u8 {
+	mut b := []u8{}
+	b << http2.preface
+	http2.write_settings(mut b, [])
+	mut slow_block := []u8{}
+	http2.encode_indexed(mut slow_block, 2)
+	http2.encode_indexed(mut slow_block, 6)
+	http2.encode_literal_name_idx(mut slow_block, 4, '/slow')
+	http2.encode_literal_name_idx(mut slow_block, 1, 'x.test')
+	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream,
+		1, slow_block.len)
+	b << slow_block
+	mut home_block := []u8{}
+	http2.encode_indexed(mut home_block, 2)
+	http2.encode_indexed(mut home_block, 6)
+	http2.encode_indexed(mut home_block, 4)
+	http2.encode_literal_name_idx(mut home_block, 1, 'x.test')
+	http2.write_frame_header(mut b, .headers, http2.flag_end_headers | http2.flag_end_stream,
+		3, home_block.len)
+	b << home_block
+	return b
+}
+
 fn e2e_ping() []u8 {
 	mut b := []u8{}
 	http2.write_frame_header(mut b, .ping, 0, 0, 8)
@@ -122,6 +148,28 @@ fn test_http2_cleartext_end_to_end() {
 					},
 				]
 			},
+			// Conn 2 — ASYNC over http2 (the .suspend-over-the-seam follow-up
+			// of issue #136): /slow parks stream 1 on a timerfd while / on
+			// stream 3 answers immediately; the parked stream completes when
+			// the timer fires and resumes the connection.
+			vtest.Script{
+				rounds: [
+					vtest.Round{
+						send:  e2e_async_opening()
+						until: e2e_until_bytes(e2e_slow_body)
+					},
+				]
+			},
+			// Conn 3 — the SAME async route over plain h1: the engine parks
+			// the request (pre-existing machinery, proven undisturbed).
+			vtest.Script{
+				rounds: [
+					vtest.Round{
+						send:  'GET /slow HTTP/1.1\r\nHost: x\r\n\r\n'.bytes()
+						until: e2e_until_bytes(e2e_slow_body)
+					},
+				]
+			},
 		]) or {
 			assert false, err.msg()
 			return
@@ -138,5 +186,19 @@ fn test_http2_cleartext_end_to_end() {
 		assert h1.connect_err == '', h1.connect_err
 		assert !h1.unmet
 		assert e2e_index_bytes(h1.raw, 'HTTP/1.1 200 OK'.bytes()) >= 0
+
+		async := out.conns[2]
+		assert async.connect_err == '', async.connect_err
+		assert !async.unmet, 'async choreography ended early: ${async.raw.bytestr()}'
+		home_at := e2e_index_bytes(async.raw, e2e_home_body)
+		slow_at := e2e_index_bytes(async.raw, e2e_slow_body)
+		assert home_at >= 0
+		// The ready stream must not wait behind the parked one: / answers in
+		// microseconds, the timer holds /slow for 30 ms.
+		assert slow_at > home_at, 'the parked stream blocked the ready one'
+
+		h1slow := out.conns[3]
+		assert h1slow.connect_err == '', h1slow.connect_err
+		assert !h1slow.unmet, 'h1 /slow never resumed: ${h1slow.raw.bytestr()}'
 	}
 }

--- a/examples/http2_cleartext/src/slow_linux.c.v
+++ b/examples/http2_cleartext/src/slow_linux.c.v
@@ -1,0 +1,39 @@
+module main
+
+// The Linux half of GET /slow: a one-shot 30 ms timerfd armed through
+// event_loop.watch_fd — the async_timer idiom. Lives in an OS-suffix file so
+// the example still builds where timerfd does not exist (slow_route's $else
+// answers 501 there).
+import core
+
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+fn C.timerfd_create(clockid int, flags int) int
+fn C.timerfd_settime(fd int, flags int, new_value voidptr, old_value voidptr) int
+fn C.read(fd int, buf voidptr, count usize) int
+
+fn slow_route_linux(mut res []u8, mut event_loop core.EventLoop) core.Step {
+	tfd := C.timerfd_create(C.CLOCK_MONOTONIC, 0)
+	if tfd < 0 {
+		res << slow_unavailable_response
+		return .done
+	}
+	// struct itimerspec = { it_interval{sec,nsec}, it_value{sec,nsec} } = 4×i64.
+	mut spec := [4]i64{}
+	spec[3] = 30 * 1_000_000 // one-shot, 30 ms
+	C.timerfd_settime(tfd, 0, voidptr(&spec[0]), unsafe { nil })
+	event_loop.watch_fd(tfd, .readable, slow_done, unsafe { nil })
+	return .suspend
+}
+
+// slow_done runs when the timerfd fires: drain it, close it (the request owns
+// it), append the response, and finish.
+fn slow_done(mut out []u8, ready_fd int, ready_fd_error bool, watch_payload voidptr, worker_state voidptr, mut event_loop core.EventLoop) core.Step {
+	mut tmp := [8]u8{}
+	C.read(ready_fd, &tmp[0], 8)
+	C.close(ready_fd)
+	out << slow_response
+	return .done
+}

--- a/http2/conn.v
+++ b/http2/conn.v
@@ -669,6 +669,15 @@ fn (mut c ServerConn) on_window_update(fh FrameHeader, payload []u8, mut out []u
 	return .no_error
 }
 
+// abort_stream refuses or aborts a stream the server cannot serve: RST_STREAM
+// with `code`, and the stream's state released. For composition layers that
+// must shed a stream (e.g. a bridge over a saturated resource) — protocol
+// violations are RSTed internally, this is the application-level escape.
+pub fn (mut c ServerConn) abort_stream(mut out []u8, stream_id u32, code ErrorCode) {
+	write_rst_stream(mut out, stream_id, code)
+	c.streams.delete(stream_id)
+}
+
 // write_response_headers appends the response HEADERS frame for `block` (an
 // HPACK block built with the encode_* helpers — :status first, RFC 9113
 // §8.3). A block wider than the peer's max frame size splits into

--- a/server/backend_epoll/async_linux.c.v
+++ b/server/backend_epoll/async_linux.c.v
@@ -627,10 +627,12 @@ fn serve_takeover_conn(mut reactor Reactor, epoll_fd int, fd int, limits core.Li
 }
 
 // drain_takeover feeds the buffered bytes to the connection's ConnHandler until
-// it stops consuming (partial frame) or the buffer empties. Mirrors
-// drain_requests' shape: consumed bytes are compacted away, responses batch in
-// write_buf, and the pending-write cap bounds a peer that floods frames without
-// reading. Returns false if the connection was closed.
+// it stops consuming (partial frame), parks on a watch (.suspend), or the
+// buffer empties. Mirrors drain_requests' shape: consumed bytes are compacted
+// away, responses batch in write_buf, and the pending-write cap bounds a peer
+// that floods frames without reading. Returns false when the caller must stop
+// touching the connection — closed, OR parked on a watch (resumed later by
+// on_watch_ready, exactly like a parked h1 request).
 @[direct_array_access; manualfree]
 fn drain_takeover(mut reactor Reactor, epoll_fd int, fd int, limits core.Limits, active_conns &core.Counter, mut st PlainState, mut cs ConnState, state voidptr) bool {
 	mut event_loop := core.EventLoop{
@@ -643,10 +645,10 @@ fn drain_takeover(mut reactor Reactor, epoll_fd int, fd int, limits core.Limits,
 		event_loop.last_watched = -1
 		mut consumed, step := cs.takeover(buf_view(cs.read_buf, 0, cs.read_buf.len), mut
 			cs.write_buf, fd, cs.takeover_state, state, mut event_loop)
-		if event_loop.last_watched >= 0 {
-			// v1: takeover connections cannot park (.suspend unsupported, issue
-			// #136) — any watch a ConnHandler armed is a contract violation; tear
-			// it down before it can fire against a reused client_fd.
+		if step != .suspend && event_loop.last_watched >= 0 {
+			// Watched but did not park (.done/.close after watch_fd — a contract
+			// violation): tear the stray watch down before it can fire against a
+			// reused client_fd.
 			detach_rejected_watch(mut reactor, epoll_fd, event_loop.last_watched, fd)
 		}
 		if consumed > cs.read_buf.len {
@@ -662,9 +664,31 @@ fn drain_takeover(mut reactor Reactor, epoll_fd int, fd int, limits core.Limits,
 				}
 				// consumed > 0: more complete frames may still be buffered — loop.
 			}
-			else {
-				// .close — and .suspend (unsupported in v1) degrades to it: flush
-				// what the handler appended (e.g. its close frame), then close.
+			.suspend {
+				// The ConnHandler parked on a watch (the issue #136 follow-up):
+				// the registered continuation resumes the connection when the fd
+				// fires — the same park/resume machinery h1 requests use. Until
+				// then the connection reads nothing (handle_readable's awaiting_fd
+				// gate); unprocessed bytes wait in read_buf and the socket. The
+				// contract allows at most ONE armed watch per parked connection —
+				// the close-path teardown (close_client) tracks exactly one fd.
+				if event_loop.last_watched < 0 {
+					// Suspended without arming a watch: nothing would ever resume
+					// this connection — flush what was appended, then close.
+					if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
+						close_conn(epoll_fd, fd, active_conns, mut st)
+					}
+					return false
+				}
+				cs.awaiting_fd = event_loop.last_watched
+				update_read_deadline(limits, mut st, mut cs) // parked ⇒ clears any armed deadline
+				if cs.write_buf.len > cs.write_off {
+					flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs)
+				}
+				return false // parked — not closed; on_watch_ready resumes it
+			}
+			.close {
+				// Flush what the handler appended (e.g. its close frame), then close.
 				if flush_batch(epoll_fd, fd, limits, active_conns, mut st, mut cs) {
 					close_conn(epoll_fd, fd, active_conns, mut st)
 				}
@@ -986,6 +1010,21 @@ fn on_watch_ready(h core.Handler, mut reactor Reactor, epoll_fd int, ext_fd int,
 					cs, state)
 				return
 			}
+			if cs.takeover != unsafe { nil } {
+				// A resumed TAKEN-OVER connection (a ConnHandler parked via
+				// watch_fd — the issue #136 follow-up): the continuation just
+				// appended protocol bytes; flush them, then hand the socket back
+				// to the takeover drain, which also consumes anything that
+				// arrived while parked.
+				if cs.write_buf.len > cs.write_off {
+					if !flush_batch(epoll_fd, client_fd, limits, active_conns, mut st, mut cs) {
+						return
+					}
+				}
+				serve_takeover_conn(mut reactor, epoll_fd, client_fd, limits, active_conns, mut st, mut
+					cs, state)
+				return
+			}
 			// Send this response and drain any requests that were pipelined behind it
 			// (and read anything that arrived while parked) — one batched flush.
 			serve_conn(h, mut reactor, epoll_fd, client_fd, limits, active_conns, mut st, mut cs,
@@ -1088,6 +1127,19 @@ fn drain_pipelined(h core.Handler, mut reactor Reactor, epoll_fd int, ext_fd int
 				if qt.cont != unsafe { nil } {
 					cs.takeover = qt.cont
 					cs.takeover_state = qt.state
+					if cs.write_buf.len > cs.write_off {
+						if !flush_batch(epoll_fd, client_fd, limits, active_conns, mut st, mut cs) {
+							continue
+						}
+					}
+					serve_takeover_conn(mut reactor, epoll_fd, client_fd, limits, active_conns, mut
+						st, mut cs, state)
+					continue
+				}
+				if cs.takeover != unsafe { nil } {
+					// Resumed takeover connection parked on this shared fd: flush
+					// the continuation's output and return the socket to the
+					// takeover drain (same routing as on_watch_ready).
 					if cs.write_buf.len > cs.write_off {
 						if !flush_batch(epoll_fd, client_fd, limits, active_conns, mut st, mut cs) {
 							continue


### PR DESCRIPTION
## What

The takeover seam's v1 (#136 / #138) declared `.suspend` unsupported for `ConnHandler`s — a taken-over connection that armed a watch was closed and the watch torn down. This makes `.suspend` **legal on the epoll backend**, so async work (timers, DB sockets, upstreams) can park a taken-over connection and resume it — which, combined with #139, means **async handlers now work over HTTP/2**, with streams as the parking unit.

### Why it's small

The engine's park/resume machinery was already connection-shaped in all but two places — everything routes through `cs.awaiting_fd`, which taken-over connections share with h1:

- `handle_readable`'s parked gate (bytes wait in the socket while parked) — already protocol-blind.
- `close_client`'s watch teardown on mid-park disconnect — already protocol-blind.
- deadline bookkeeping (`update_read_deadline`) — already keyed on `awaiting_fd`.

The actual changes:

- **`drain_takeover`**: `.suspend` with a live watch parks the connection (sets `awaiting_fd`, flushes pending output, stops the drain) instead of closing. `.suspend` *without* a watch still closes — nothing would ever resume it. A stray watch on `.done`/`.close` is still torn down (the fd-recycling hazard).
- **`on_watch_ready` / `drain_pipelined`**: a resumed connection that is taken over routes back to `serve_takeover_conn` (flush the continuation's output, then drain whatever arrived while parked) instead of the h1 request drain. The `.suspend` re-park (multi-hop chains, streaming) and `.close` arms work unchanged.
- **`core.ConnHandler` contract**: `.suspend` documented — the continuation contract is identical to an h1 park (`core.WakeFn` appending into the same write buffer), with **one armed watch per parked connection** (the close-path teardown tracks exactly one fd).
- **`http2.ServerConn.abort_stream`**: the application-level stream shed (RST_STREAM + state release) that composition layers need.

The h1 hot path is untouched; the h1 suspend path is untouched (the e2e proves it).

### The demo — one async handler, both protocols

`examples/http2_cleartext` gains `GET /slow`: parks on a one-shot 30 ms timerfd (the `async_timer` idiom), served by the **same handler** over both protocols:

- **Over h1**: the engine parks the request — pre-existing machinery.
- **Over http2**: the bridge hands the app handler a **capture event loop** — the watch the app arms is recorded (not armed), re-armed on the real loop with a bridge continuation (`StreamWait`), and the app's resumed h1 response is re-framed as HEADERS + DATA for exactly the stream that parked. Streams that don't park are served while the parked one waits. v1 limit: one parked stream per connection (the engine's one-watch contract); extra parkers get `RST_STREAM(REFUSED_STREAM)` so clients retry.

```
curl --http2-prior-knowledge http://localhost:3000/slow
```

Non-Linux builds degrade `/slow` to a sync 501 (timerfd is Linux-only; the OS-suffix file keeps the Windows lane compiling).

## Testing

- **In-process** (no sockets): park + resume through the bridge with a capture-register stand-in for the engine loop and a real timerfd — asserts the ready stream answers first, the parked stream produces nothing until resume, then exactly its HEADERS + DATA; a second parker in the same burst is refused with `RST_STREAM(REFUSED_STREAM)` while the first still completes.
- **vtest e2e** (real epoll worker): one http2 connection multiplexing `/slow` (stream 1) and `/` (stream 3) in a single write — asserts `/` answers **before** the timer releases `/slow` (the parked stream must not block the ready one); plus `/slow` over plain h1 keep-alive proving the pre-existing h1 park machinery is undisturbed.
- The full h2spec lane (146/146 from #139) reruns on this PR — the engine changes sit on the suspend paths only.

## Notes for review

- Same sandbox constraint as #139: `v fmt` can't run locally; formatting is by hand and I'll fix from the CI diff step if the gate disagrees.
- Deliberately deferred (rule 2/3): multiple concurrent parked streams per connection (needs per-connection watch lists in the engine), processing new client bytes while parked (head-of-line follows the h1 rule for now), `.suspend` over TLS takeovers, and `watch_fd_persistent` through the bridge (pooled DB fds over http2).

Refs #136 (the seam + its follow-up note), #139 (the http2 bridge this composes with).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MuVyfeCgZJzA3U6NjSPg5k

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuVyfeCgZJzA3U6NjSPg5k)_